### PR TITLE
fix: ship plugin hooks in homebrew package and fail loudly on hookless install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
         run: bun build --compile --minify --target=${{ matrix.target }} index.ts --outfile fleet
 
       - name: Package tarball
-        run: tar czf ${{ matrix.artifact }}.tar.gz fleet
+        run: tar czf ${{ matrix.artifact }}.tar.gz fleet hooks .claude-plugin
 
       - uses: actions/upload-artifact@v4
         with:
@@ -76,6 +76,12 @@ jobs:
     needs: [release-please, build]
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout fleet repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-please.outputs.tag_name }}
+          path: fleet
+
       - name: Checkout tap repo
         uses: actions/checkout@v4
         with:
@@ -92,6 +98,10 @@ jobs:
           VERSION: ${{ needs.release-please.outputs.tag_name }}
         run: |
           VER="${VERSION#v}"
+          # The in-repo formula is canonical; copy it so the tap can never
+          # diverge from it (e.g. missing prefix.install lines), then patch
+          # version + shas below.
+          cp fleet/Formula/fleet.rb tap/Formula/fleet.rb
           SHA_ARM64=$(shasum -a 256 fleet-darwin-arm64.tar.gz | cut -d' ' -f1)
           SHA_X86_64=$(shasum -a 256 fleet-darwin-x86_64.tar.gz | cut -d' ' -f1)
           SHA_LINUX=$(shasum -a 256 fleet-linux-x86_64.tar.gz | cut -d' ' -f1)

--- a/Formula/fleet.rb
+++ b/Formula/fleet.rb
@@ -21,6 +21,8 @@ class Fleet < Formula
 
   def install
     bin.install "fleet"
+    prefix.install "hooks"
+    prefix.install ".claude-plugin"
   end
 
   test do

--- a/README.md
+++ b/README.md
@@ -62,19 +62,19 @@ Each row leads with the tmux session name. When Claude Code has auto-named a ses
 
 ### Keybindings
 
-| Key                        | Action                              |
-| -------------------------- | ----------------------------------- |
-| `j` / `k` or `Up` / `Down` | Navigate sessions                   |
-| `Enter`                    | Switch to selected session          |
-| `n`                        | Jump to next waiting agent (cycles) |
-| `p`                        | Toggle preview pane                 |
-| `s`                        | Send prompt to selected session     |
-| `i`                        | Enter passthrough (preview mode)    |
-| `y`                        | Approve permission prompt (preview) |
-| `/`                        | Filter sessions by name or project  |
+| Key                        | Action                                 |
+| -------------------------- | -------------------------------------- |
+| `j` / `k` or `Up` / `Down` | Navigate sessions                      |
+| `Enter`                    | Switch to selected session             |
+| `n`                        | Jump to next waiting agent (cycles)    |
+| `p`                        | Toggle preview pane                    |
+| `s`                        | Send prompt to selected session        |
+| `i`                        | Enter passthrough (preview mode)       |
+| `y`                        | Approve permission prompt (preview)    |
+| `/`                        | Filter sessions by name or project     |
 | `x`                        | Kill selected session (confirms first) |
-| `?`                        | Help overlay                        |
-| `q` or `Esc`               | Quit (or clear filter)              |
+| `?`                        | Help overlay                           |
+| `q` or `Esc`               | Quit (or clear filter)                 |
 
 You can also **click** a session row to select it; clicking a `ready` agent acknowledges it in place (see [Acknowledge](#agent-states)).
 
@@ -82,15 +82,15 @@ You can also **click** a session row to select it; clicking a `ready` agent ackn
 
 Fleet tracks seven states, sorted by urgency. The icon and color tell you what's happening at a glance:
 
-| Icon | State       | Meaning                                            |
-| ---- | ----------- | -------------------------------------------------- |
-| `⚠`  | **waiting** | Tool approval needed (`[y/n]` prompt)              |
-| `?`  | **asking**  | Agent asked you a question (`AskUserQuestion`)     |
-| `◉`  | **working** | Thinking or running tools                          |
+| Icon | State       | Meaning                                                         |
+| ---- | ----------- | --------------------------------------------------------------- |
+| `⚠`  | **waiting** | Tool approval needed (`[y/n]` prompt)                           |
+| `?`  | **asking**  | Agent asked you a question (`AskUserQuestion`)                  |
+| `◉`  | **working** | Thinking or running tools                                       |
 | `●`  | **ready**   | Turn ended — your move (finished, or asked in prose); green dot |
-| `●`  | **idle**    | Up but no recent activity (blue dot)               |
-| `■`  | **shell**   | No agent running (hidden by default)               |
-| `○`  | **down**    | No live process (hidden by default)                |
+| `●`  | **idle**    | Up but no recent activity (blue dot)                            |
+| `■`  | **shell**   | No agent running (hidden by default)                            |
+| `○`  | **down**    | No live process (hidden by default)                             |
 
 **asking vs. ready:** A turn that ends — whether the agent finished the task or asked you something in prose — looks identical at the hook layer (both are a plain `Stop`). Fleet can't tell them apart, so both land in **ready** ("your move"). The dedicated **asking** state is only reachable through structured signals the agent emits: the `AskUserQuestion` tool and MCP elicitation dialogs. Either way both sort into the attention tier, so nothing that needs you gets buried.
 
@@ -138,20 +138,20 @@ This is the power feature: approve prompts, answer questions, type commands, and
 
 Fleet also works as a non-interactive CLI for scripting and tmux integration.
 
-| Command                                   | Description                                                                      |
-| ----------------------------------------- | -------------------------------------------------------------------------------- |
-| `fleet status [--tmux] <session>`         | Query agent state. `--tmux` outputs a tmux format string for status bars.        |
-| `fleet status --statusline`               | Render a full multi-agent status line for tmux's second row.                     |
-| `fleet next`                              | Switch to the next waiting agent pane (cycles through PERMIT > QUESTION > DONE). |
+| Command                                   | Description                                                                        |
+| ----------------------------------------- | ---------------------------------------------------------------------------------- |
+| `fleet status [--tmux] <session>`         | Query agent state. `--tmux` outputs a tmux format string for status bars.          |
+| `fleet status --statusline`               | Render a full multi-agent status line for tmux's second row.                       |
+| `fleet next`                              | Switch to the next waiting agent pane (cycles through PERMIT > QUESTION > DONE).   |
 | `fleet switch <pane-id>`                  | Acknowledge a ready agent and switch to it (used by the statusline click binding). |
-| `fleet ack <pane-id>`                     | Acknowledge a ready agent in place (clear it from the attention tier, no switch). |
-| `fleet send <session> <prompt>`           | Send a prompt to a session. Refuses unsafe states unless `--force`.              |
-| `fleet doctor`                            | Check tmux version, plugin installation, status directories, hook health.        |
-| `fleet reconcile [--dry-run] [--verbose]` | Remove orphan status files for dead panes, fix stale working states.             |
-| `fleet install`                           | Register Fleet as a Claude Code plugin + add second tmux status row.             |
-| `fleet uninstall`                         | Remove plugin registration + tmux status row.                                    |
-| `fleet statusline --inject`               | Manually add the second tmux status row.                                         |
-| `fleet statusline --remove`               | Manually remove the second tmux status row.                                      |
+| `fleet ack <pane-id>`                     | Acknowledge a ready agent in place (clear it from the attention tier, no switch).  |
+| `fleet send <session> <prompt>`           | Send a prompt to a session. Refuses unsafe states unless `--force`.                |
+| `fleet doctor`                            | Check tmux version, plugin installation, status directories, hook health.          |
+| `fleet reconcile [--dry-run] [--verbose]` | Remove orphan status files for dead panes, fix stale working states.               |
+| `fleet install`                           | Register Fleet as a Claude Code plugin + add second tmux status row.               |
+| `fleet uninstall`                         | Remove plugin registration + tmux status row.                                      |
+| `fleet statusline --inject`               | Manually add the second tmux status row.                                           |
+| `fleet statusline --remove`               | Manually remove the second tmux status row.                                        |
 
 ### Tmux Status Bar Integration
 

--- a/docs/superpowers/specs/2026-06-08-statusline-clear-notifications-design.md
+++ b/docs/superpowers/specs/2026-06-08-statusline-clear-notifications-design.md
@@ -11,7 +11,7 @@ interaction is a left-click, bound to `fleet switch <paneId>`, which both
 acknowledges a ready agent (flips `DONE` → `idle`) **and** switches the tmux
 client to that pane.
 
-There is no way to clear a ready notification *without* jumping to its pane, and
+There is no way to clear a ready notification _without_ jumping to its pane, and
 no way to clear all of them at once. `fleet ack <pane-id>` already acknowledges
 in place without switching, but nothing in tmux is bound to it.
 
@@ -87,12 +87,12 @@ Reuses the DONE-only gating in `acknowledgedStatus` (called inside
 
 ## Behavior summary
 
-| Interaction                  | Result                                  |
-| ---------------------------- | --------------------------------------- |
-| Left-click a ready entry     | Switch to pane + acknowledge (unchanged)|
-| Right-click a ready entry    | Acknowledge in place (no switch)        |
-| Click `✕ clear`              | Acknowledge all ready agents            |
-| PERMIT / QUESTION entries    | Never dismissible                       |
+| Interaction               | Result                                   |
+| ------------------------- | ---------------------------------------- |
+| Left-click a ready entry  | Switch to pane + acknowledge (unchanged) |
+| Right-click a ready entry | Acknowledge in place (no switch)         |
+| Click `✕ clear`           | Acknowledge all ready agents             |
+| PERMIT / QUESTION entries | Never dismissible                        |
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-06-08-statusline-clear-notifications-design.md
+++ b/docs/superpowers/specs/2026-06-08-statusline-clear-notifications-design.md
@@ -1,0 +1,111 @@
+# Clear / mark-as-read notifications in the tmux status line
+
+Date: 2026-06-08
+
+## Problem
+
+The fleet status line (tmux row 2) lists agents whose turn it is for you to act
+on: `PERMIT` (blocked on a permission prompt), `QUESTION` (asking), and `DONE`
+(ready / finished, waiting on your next move). Today the only status-line
+interaction is a left-click, bound to `fleet switch <paneId>`, which both
+acknowledges a ready agent (flips `DONE` → `idle`) **and** switches the tmux
+client to that pane.
+
+There is no way to clear a ready notification *without* jumping to its pane, and
+no way to clear all of them at once. `fleet ack <pane-id>` already acknowledges
+in place without switching, but nothing in tmux is bound to it.
+
+## Scope
+
+- Only **ready (`DONE`)** agents are dismissible. `PERMIT` and `QUESTION`
+  represent an agent that is genuinely blocked/waiting; dismissing them would
+  hide a live pending action, and they would re-assert on the next refresh
+  anyway. `acknowledgedStatus()` already gates on ready-only — we reuse that.
+- Two new interactions, both routed through existing CLI commands:
+  - **Per-item dismiss** — right-click a ready entry to acknowledge it without
+    switching.
+  - **Clear-all** — click a dedicated `✕ clear` chip to acknowledge every ready
+    agent at once.
+
+## Design
+
+### Sentinel constant
+
+`src/state/types.ts`:
+
+```ts
+export const ACK_ALL_RANGE = '__ack_all__';
+```
+
+Shared by the renderer (range name) and the CLI router (target detection).
+
+### Renderer — `src/cli/status.ts` `formatStatusLine`
+
+When the filtered (`PERMIT`/`QUESTION`/`DONE`) set contains at least one `DONE`,
+append a trailing chip after the existing entries, joined with the same `│`
+divider:
+
+```
+#[range=user|__ack_all__]#[fg=#6c7086]✕ clear#[norange]
+```
+
+No chip is rendered when nothing is ready.
+
+### Acknowledge-all helper — `index.ts`
+
+```ts
+function acknowledgeAllReady(statusDirs: string[]): void {
+  for (const hook of readAllStatusDirs(statusDirs)) {
+    acknowledgePane(hook.pane, statusDirs);
+  }
+}
+```
+
+Reuses the DONE-only gating in `acknowledgedStatus` (called inside
+`acknowledgePane`), so `PERMIT`/`QUESTION` are left untouched for free.
+
+### CLI routing — `index.ts`
+
+- **`switch`**: if `target === ACK_ALL_RANGE` → `acknowledgeAllReady` +
+  `refresh-client -S`, then return (no switch). Otherwise the current
+  ack-then-switch behavior.
+- **`ack`**: if `target === ACK_ALL_RANGE` → `acknowledgeAllReady` + redraw.
+  Otherwise `acknowledgePane(target)` + `refresh-client -S` (right-click single
+  dismiss).
+- A small best-effort helper runs `tmux refresh-client -S` so the bar redraws
+  immediately instead of waiting for the next status-interval (~15s). The switch
+  path already redraws by switching the client.
+
+### tmux bindings — `src/cli/statusline.ts`
+
+- Loosen the existing `MouseDown1Status` guard from `#{m:%*,#{mouse_status_range}}`
+  to a non-empty check `#{!=:#{mouse_status_range},}`, so the clear chip's
+  sentinel range also routes through `fleet switch`.
+- Add a `MouseDown3Status` (right-click) binding with the same guard →
+  `fleet ack "#{mouse_status_range}"`.
+- `buildRemoveCommands` also unbinds `MouseDown3Status`.
+
+## Behavior summary
+
+| Interaction                  | Result                                  |
+| ---------------------------- | --------------------------------------- |
+| Left-click a ready entry     | Switch to pane + acknowledge (unchanged)|
+| Right-click a ready entry    | Acknowledge in place (no switch)        |
+| Click `✕ clear`              | Acknowledge all ready agents            |
+| PERMIT / QUESTION entries    | Never dismissible                       |
+
+## Testing
+
+- `status.test.ts`: `✕ clear` chip present iff a `DONE` exists; correct sentinel
+  range string; absent when only `PERMIT`/`QUESTION` (or nothing) present.
+- `statusline.test.ts`: inject includes both `MouseDown1Status` and
+  `MouseDown3Status` with the loosened guard; remove unbinds both.
+- Acknowledge: ack-all flips only ready states, leaves `PERMIT`/`QUESTION`
+  unchanged.
+
+## Out of scope
+
+- Dismissing `PERMIT`/`QUESTION` notifications.
+- Any change to the dashboard TUI click/keyboard behavior.
+- Persisting a separate "read" flag — acknowledgement reuses the existing
+  `DONE` → `idle` flip; no new state field.

--- a/src/cli/doctor.test.ts
+++ b/src/cli/doctor.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { installedPluginHasHooks } from './doctor.ts';
+
+let pluginsRoot: string;
+
+function writeInstalledPlugins(plugins: Record<string, Array<{ installPath: string }>>): void {
+  writeFileSync(join(pluginsRoot, 'installed_plugins.json'), JSON.stringify({ version: 2, plugins }));
+}
+
+function makePluginDir(name: string, withHooks: boolean): string {
+  const dir = join(pluginsRoot, 'cache', name);
+  mkdirSync(withHooks ? join(dir, 'hooks') : dir, { recursive: true });
+  if (withHooks) writeFileSync(join(dir, 'hooks', 'hooks.json'), '{}');
+  return dir;
+}
+
+beforeEach(() => {
+  pluginsRoot = mkdtempSync(join(tmpdir(), 'fleet-doctor-test-'));
+});
+
+afterEach(() => {
+  rmSync(pluginsRoot, { recursive: true, force: true });
+});
+
+describe('installedPluginHasHooks', () => {
+  test('returns false when installed_plugins.json is missing', () => {
+    expect(installedPluginHasHooks(pluginsRoot)).toBe(false);
+  });
+
+  test('returns false when installed_plugins.json is malformed', () => {
+    writeFileSync(join(pluginsRoot, 'installed_plugins.json'), 'not json');
+    expect(installedPluginHasHooks(pluginsRoot)).toBe(false);
+  });
+
+  test('returns false when no plugin matches the prefix', () => {
+    writeInstalledPlugins({
+      'other@marketplace': [{ installPath: makePluginDir('other', true) }],
+    });
+    expect(installedPluginHasHooks(pluginsRoot)).toBe(false);
+  });
+
+  test('returns false when the installed plugin has no hooks/hooks.json', () => {
+    writeInstalledPlugins({
+      'fleet@fleet-local': [{ installPath: makePluginDir('fleet-bare', false) }],
+    });
+    expect(installedPluginHasHooks(pluginsRoot)).toBe(false);
+  });
+
+  test('returns true when the installed plugin ships hooks/hooks.json', () => {
+    writeInstalledPlugins({
+      'fleet@fleet-local': [{ installPath: makePluginDir('fleet-hooked', true) }],
+    });
+    expect(installedPluginHasHooks(pluginsRoot)).toBe(true);
+  });
+
+  test('returns true when any entry for the plugin has hooks', () => {
+    writeInstalledPlugins({
+      'fleet@fleet-local': [
+        { installPath: makePluginDir('fleet-old', false) },
+        { installPath: makePluginDir('fleet-new', true) },
+      ],
+    });
+    expect(installedPluginHasHooks(pluginsRoot)).toBe(true);
+  });
+
+  test('respects a custom prefix', () => {
+    writeInstalledPlugins({
+      'custom@mp': [{ installPath: makePluginDir('custom', true) }],
+    });
+    expect(installedPluginHasHooks(pluginsRoot, 'custom@')).toBe(true);
+    expect(installedPluginHasHooks(pluginsRoot, 'fleet@')).toBe(false);
+  });
+});

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { tmux } from '../tmux/ipc.ts';
@@ -8,6 +8,32 @@ interface Check {
   name: string;
   ok: boolean;
   detail: string;
+}
+
+interface InstalledPluginEntry {
+  installPath?: string;
+}
+
+export function installedPluginHasHooks(pluginsRoot: string, prefix = 'fleet@'): boolean {
+  const manifest = join(pluginsRoot, 'installed_plugins.json');
+  if (!existsSync(manifest)) return false;
+
+  let plugins: Record<string, InstalledPluginEntry[]>;
+  try {
+    plugins = JSON.parse(readFileSync(manifest, 'utf8')).plugins ?? {};
+  } catch {
+    return false;
+  }
+
+  for (const [key, entries] of Object.entries(plugins)) {
+    if (!key.startsWith(prefix)) continue;
+    for (const entry of entries) {
+      if (entry.installPath && existsSync(join(entry.installPath, 'hooks', 'hooks.json'))) {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 export function runDoctor(): number {
@@ -52,6 +78,15 @@ export function runDoctor(): number {
     name: 'fleet plugin',
     ok: fleetInstalled,
     detail: fleetInstalled ? 'installed' : 'not installed (run: fleet install)',
+  });
+
+  const hasHooks = installedPluginHasHooks(pluginDir);
+  checks.push({
+    name: 'fleet hooks',
+    ok: hasHooks,
+    detail: hasHooks
+      ? 'registered'
+      : 'installed plugin has no hooks/hooks.json — dashboard will stay empty (reinstall: fleet install)',
   });
 
   let allOk = true;

--- a/src/cli/install.test.ts
+++ b/src/cli/install.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { addTmuxConfLine, removeTmuxConfLine, tmuxConfPath } from './install.ts';
+import { addTmuxConfLine, removeTmuxConfLine, resolvePluginDir, tmuxConfPath } from './install.ts';
 
 let workDir: string;
 let confFile: string;
@@ -104,6 +104,34 @@ describe('removeTmuxConfLine', () => {
     expect(result).not.toContain('# fleet-managed');
     expect(result).toContain('set -g mouse on');
     expect(result).toContain('set -g foo bar');
+  });
+});
+
+describe('resolvePluginDir', () => {
+  test('returns null when no candidate has hooks/hooks.json', () => {
+    const bare = join(workDir, 'bare');
+    mkdirSync(bare, { recursive: true });
+    expect(resolvePluginDir([bare])).toBe(null);
+  });
+
+  test('returns null for an empty candidate list', () => {
+    expect(resolvePluginDir([])).toBe(null);
+  });
+
+  test('returns the candidate containing hooks/hooks.json', () => {
+    const plugin = join(workDir, 'plugin');
+    mkdirSync(join(plugin, 'hooks'), { recursive: true });
+    writeFileSync(join(plugin, 'hooks', 'hooks.json'), '{}');
+    expect(resolvePluginDir([plugin])).toBe(plugin);
+  });
+
+  test('skips candidates without hooks and returns the first that has them', () => {
+    const bare = join(workDir, 'bare-keg');
+    const plugin = join(workDir, 'dev-checkout');
+    mkdirSync(bare, { recursive: true });
+    mkdirSync(join(plugin, 'hooks'), { recursive: true });
+    writeFileSync(join(plugin, 'hooks', 'hooks.json'), '{}');
+    expect(resolvePluginDir([bare, plugin])).toBe(plugin);
   });
 });
 

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -6,13 +6,17 @@ import { runStatusLineInject, runStatusLineRemove } from './statusline.ts';
 const FLEET_MANAGED_MARKER = '# fleet-managed';
 const FLEET_TMUX_LINE = `run-shell "fleet statusline --inject" ${FLEET_MANAGED_MARKER}`;
 
-function fleetPluginDir(): string {
-  const binDir = dirname(process.execPath);
-  const fromBin = resolve(binDir, '..');
-  if (existsSync(join(fromBin, 'hooks', 'hooks.json'))) return fromBin;
+export function resolvePluginDir(candidates: string[]): string | null {
+  for (const dir of candidates) {
+    if (existsSync(join(dir, 'hooks', 'hooks.json'))) return dir;
+  }
+  return null;
+}
+
+function fleetPluginDir(): string | null {
+  const fromBin = resolve(dirname(process.execPath), '..');
   const fromDev = resolve(import.meta.dir, '../..');
-  if (existsSync(join(fromDev, 'hooks', 'hooks.json'))) return fromDev;
-  return fromBin;
+  return resolvePluginDir([fromBin, fromDev]);
 }
 
 function marketplaceDir(): string {
@@ -87,6 +91,14 @@ function ensureMarketplace(fleetDir: string): string {
 
 export function runInstall(): number {
   const fleetDir = fleetPluginDir();
+  if (fleetDir === null) {
+    process.stderr.write(
+      'fleet install failed: could not find a plugin directory containing hooks/hooks.json.\n' +
+        'Without hooks, Claude Code writes no status files and the dashboard stays empty.\n' +
+        'If fleet was installed via Homebrew, the package may be missing the hooks/ directory — try upgrading.\n',
+    );
+    return 1;
+  }
   const mpDir = ensureMarketplace(fleetDir);
 
   const addMp = Bun.spawnSync({

--- a/src/state/acknowledge.ts
+++ b/src/state/acknowledge.ts
@@ -7,10 +7,7 @@ const READY_HOOK_STATES = new Set(['done', 'completed']);
 // Given the current parsed status-file object, return the updated object that
 // marks the agent acknowledged (idle), or null if it isn't in a ready state —
 // we only clear finished turns, never a working/waiting/asking agent.
-export function acknowledgedStatus(
-  current: Record<string, unknown>,
-  now: number,
-): Record<string, unknown> | null {
+export function acknowledgedStatus(current: Record<string, unknown>, now: number): Record<string, unknown> | null {
   if (!READY_HOOK_STATES.has(String(current.state))) return null;
   return { ...current, state: 'idle', ts: now };
 }

--- a/src/state/events.test.ts
+++ b/src/state/events.test.ts
@@ -87,9 +87,7 @@ describe('deriveStatusFromEvents', () => {
   });
 
   test('an Acknowledged event clears a ready turn to IDLE', () => {
-    const events = parseEventLog(
-      '{"event":"Stop","ts":1,"stop_reason":"end_turn"}\n{"event":"Acknowledged","ts":2}',
-    );
+    const events = parseEventLog('{"event":"Stop","ts":1,"stop_reason":"end_turn"}\n{"event":"Acknowledged","ts":2}');
     expect(deriveStatusFromEvents(events)).toBe(AgentStatus.IDLE);
   });
 

--- a/src/state/events.ts
+++ b/src/state/events.ts
@@ -71,7 +71,10 @@ export function readLastEvents(path: string, maxLines: number): EventEntry[] {
       const readBytes = Math.min(size, TAIL_BYTES);
       const buf = Buffer.alloc(readBytes);
       readSync(fd, buf, 0, readBytes, size - readBytes);
-      const lines = buf.toString('utf-8').split('\n').filter((l) => l.length > 0);
+      const lines = buf
+        .toString('utf-8')
+        .split('\n')
+        .filter((l) => l.length > 0);
       // If we didn't reach the start of the file, the first line may be partial.
       const usable = size > readBytes ? lines.slice(1) : lines;
       return parseEventLog(usable.slice(-maxLines).join('\n'));

--- a/src/tui/kill.ts
+++ b/src/tui/kill.ts
@@ -34,6 +34,8 @@ export function renderKillConfirm(state: AgentState): string[] {
     return lines;
   }
 
-  lines.push(`${C.gray}This closes the tmux pane. ${C.reset}${C.yellowBold}y${C.reset}${C.gray} to confirm, Esc to cancel${C.reset}`);
+  lines.push(
+    `${C.gray}This closes the tmux pane. ${C.reset}${C.yellowBold}y${C.reset}${C.gray} to confirm, Esc to cancel${C.reset}`,
+  );
   return lines;
 }


### PR DESCRIPTION
## Problem

`fleet install` after a Homebrew install produced an empty dashboard. The release tarball (and therefore the Homebrew keg) shipped only the bare `fleet` binary — no `hooks/` or `.claude-plugin/`. `fleet install` then silently registered the hookless keg as the plugin, Claude Code loaded zero hooks, no status files were written, and every pane filtered out as `SHELL`.

## Fix

- **Packaging**: release tarball and `Formula/fleet.rb` now include `hooks/` and `.claude-plugin/`
- **Fail loudly**: `fleet install` exits 1 with an explanatory error when no candidate directory contains `hooks/hooks.json`, instead of silently installing a hookless plugin (extracted testable `resolvePluginDir(candidates)`)
- **Diagnosable**: `fleet doctor` gains a `fleet hooks` check — reads the recorded `installPath` from `installed_plugins.json` and verifies `hooks/hooks.json` exists there ("installed" alone was a false positive)
- **No regression path**: the `update-formula` release job now copies the canonical in-repo `Formula/fleet.rb` into the tap (nicknisi/homebrew-formulae) before patching version/shas, so the tap's `def install` block can never drift again

Second commit is unrelated formatting drift (CI enforces `format:check`).

## Testing

- 11 new tests (`resolvePluginDir`, `installedPluginHasHooks`), written test-first
- 167 tests pass, typecheck/lint/format clean