### PR TITLE
feat: show tmux window in agent names

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -298,6 +298,7 @@ function refreshStates(statusDirs: string[]): AgentState[] {
       paneId: pane.paneId,
       paneNum: pane.paneNum,
       session: pane.sessionName,
+      window: pane.windowName,
       claudeName: extractClaudeName(pane.paneTitle),
       status,
       tool,

--- a/src/cli/status.test.ts
+++ b/src/cli/status.test.ts
@@ -6,6 +6,7 @@ const makeState = (overrides: Partial<AgentState>): AgentState => ({
   paneId: '%42',
   paneNum: 42,
   session: 'test',
+  window: 'main',
   claudeName: null,
   status: AgentStatus.IDLE,
   tool: null,

--- a/src/state/types.test.ts
+++ b/src/state/types.test.ts
@@ -5,6 +5,7 @@ import {
   compareStatus,
   extractClaudeName,
   displayName,
+  sessionLabel,
   type AgentState,
 } from './types.ts';
 
@@ -63,26 +64,41 @@ describe('extractClaudeName', () => {
   });
 });
 
-describe('displayName', () => {
-  const base: AgentState = {
-    paneId: '%1',
-    paneNum: 1,
-    session: 'dotfiles',
-    claudeName: null,
-    status: AgentStatus.IDLE,
-    tool: null,
-    project: null,
-    branch: null,
-    ports: [],
-    ts: 0,
-    agentType: 'claude',
-  };
+const base: AgentState = {
+  paneId: '%1',
+  paneNum: 1,
+  session: 'dotfiles',
+  window: 'editor',
+  claudeName: null,
+  status: AgentStatus.IDLE,
+  tool: null,
+  project: null,
+  branch: null,
+  ports: [],
+  ts: 0,
+  agentType: 'claude',
+};
 
+describe('sessionLabel', () => {
+  test('joins session and window tmux-style', () => {
+    expect(sessionLabel(base)).toBe('dotfiles:editor');
+  });
+
+  test('omits window when it matches the session name', () => {
+    expect(sessionLabel({ ...base, window: 'dotfiles' })).toBe('dotfiles');
+  });
+
+  test('omits window when empty', () => {
+    expect(sessionLabel({ ...base, window: '' })).toBe('dotfiles');
+  });
+});
+
+describe('displayName', () => {
   test('returns claudeName when set', () => {
     expect(displayName({ ...base, claudeName: 'Fix auth bug' })).toBe('Fix auth bug');
   });
 
-  test('falls back to session when no claudeName', () => {
-    expect(displayName(base)).toBe('dotfiles');
+  test('falls back to session:window when no claudeName', () => {
+    expect(displayName(base)).toBe('dotfiles:editor');
   });
 });

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -50,6 +50,7 @@ export interface AgentState {
   paneId: string;
   paneNum: number;
   session: string;
+  window: string;
   claudeName: string | null;
   status: AgentStatus;
   tool: string | null;
@@ -67,8 +68,15 @@ export function extractClaudeName(paneTitle: string): string | null {
   return name.length > 0 ? name : null;
 }
 
+// tmux target-style label (`session:window`). The window is dropped when it adds
+// no information — empty, or auto-named after the session itself.
+export function sessionLabel(state: AgentState): string {
+  if (state.window.length === 0 || state.window === state.session) return state.session;
+  return `${state.session}:${state.window}`;
+}
+
 export function displayName(state: AgentState): string {
-  return state.claudeName ?? state.session;
+  return state.claudeName ?? sessionLabel(state);
 }
 
 export interface HookStatus {

--- a/src/tui/app.test.ts
+++ b/src/tui/app.test.ts
@@ -6,6 +6,7 @@ const makeState = (session: string, status: AgentStatus, paneId?: string): Agent
   paneId: paneId ?? `%${Math.floor(Math.random() * 1000)}`,
   paneNum: Math.floor(Math.random() * 1000),
   session,
+  window: 'main',
   claudeName: null,
   status,
   tool: null,

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -75,6 +75,7 @@ export class TuiApp {
     return states.filter(
       (s) =>
         s.session.toLowerCase().includes(lower) ||
+        s.window.toLowerCase().includes(lower) ||
         (s.claudeName?.toLowerCase().includes(lower) ?? false) ||
         (s.project?.toLowerCase().includes(lower) ?? false),
     );

--- a/src/tui/dashboard.ts
+++ b/src/tui/dashboard.ts
@@ -1,6 +1,6 @@
 import { C } from '../terminal/colors.ts';
 import { truncateAnsi } from '../terminal/ansi.ts';
-import { AgentStatus, STATUS_DISPLAY, type AgentState } from '../state/types.ts';
+import { AgentStatus, STATUS_DISPLAY, sessionLabel, type AgentState } from '../state/types.ts';
 import { TuiMode, type TuiApp } from './app.ts';
 
 const BOX_H = '─';
@@ -70,7 +70,7 @@ function formatSessionRow(state: AgentState, cols: number, selected: boolean): s
   const sel = selected ? `${stColor}▌${C.reset}` : ' ';
 
   const nameColor = selected ? C.bold : '';
-  const name = state.session.padEnd(15);
+  const name = truncate(sessionLabel(state), 15).padEnd(15);
 
   let detail = '';
   if (state.claudeName) {

--- a/src/tui/kill.test.ts
+++ b/src/tui/kill.test.ts
@@ -6,6 +6,7 @@ const makeState = (overrides: Partial<AgentState>): AgentState => ({
   paneId: '%42',
   paneNum: 42,
   session: 'test',
+  window: 'main',
   claudeName: null,
   status: AgentStatus.IDLE,
   tool: null,

--- a/src/tui/kill.ts
+++ b/src/tui/kill.ts
@@ -1,5 +1,5 @@
 import { C } from '../terminal/colors.ts';
-import { AgentStatus, type AgentState } from '../state/types.ts';
+import { AgentStatus, sessionLabel, type AgentState } from '../state/types.ts';
 
 // Killing is destructive, so it gets the same state gating as send: refuse the
 // states where the agent is mid-thought or blocked on you. You can still reap
@@ -23,7 +23,7 @@ export function canKillSession(state: AgentState): { ok: boolean; reason: string
 export function renderKillConfirm(state: AgentState): string[] {
   const lines: string[] = [];
   const check = canKillSession(state);
-  const label = state.claudeName ? `${state.session} (${state.claudeName})` : state.session;
+  const label = state.claudeName ? `${sessionLabel(state)} (${state.claudeName})` : sessionLabel(state);
 
   lines.push(`${C.bold}Kill ${label}?${C.reset}`);
   lines.push('');

--- a/src/tui/preview.test.ts
+++ b/src/tui/preview.test.ts
@@ -9,6 +9,7 @@ const makeState = (status: AgentStatus): AgentState => ({
   paneId: '%1',
   paneNum: 1,
   session: 'test',
+  window: 'main',
   claudeName: null,
   status,
   tool: null,

--- a/src/tui/preview.ts
+++ b/src/tui/preview.ts
@@ -1,6 +1,6 @@
 import { C } from '../terminal/colors.ts';
 import { truncateAnsi } from '../terminal/ansi.ts';
-import { AgentStatus, STATUS_DISPLAY, type AgentState } from '../state/types.ts';
+import { AgentStatus, STATUS_DISPLAY, sessionLabel, type AgentState } from '../state/types.ts';
 import { capturePane } from '../tmux/sessions.ts';
 
 export function previewActions(state: AgentState): string {
@@ -34,7 +34,7 @@ export function renderPreview(
 
   const modeTag = passthrough ? ` ${C.cyan}● LIVE${C.reset}` : '';
   const claudeInfo = state.claudeName ? ` · ${state.claudeName}` : '';
-  const title = `${display.icon} ${state.session} · ${display.label.toUpperCase()}${claudeInfo}${modeTag}`;
+  const title = `${display.icon} ${sessionLabel(state)} · ${display.label.toUpperCase()}${claudeInfo}${modeTag}`;
   const toolInfo = state.tool ? ` · ${state.tool}` : '';
   const portInfo = state.ports.length > 0 ? ` · ⌁${state.ports.join(',')}` : '';
   lines.push(truncateAnsi(`${C.bold}${title}${C.reset}${C.gray}${toolInfo}${portInfo}${C.reset}`, width));

--- a/src/tui/render.test.ts
+++ b/src/tui/render.test.ts
@@ -28,6 +28,7 @@ const makeState = (): AgentState => ({
   paneId: '%1',
   paneNum: 1,
   session: 'agent-one',
+  window: 'main',
   claudeName: null,
   status: AgentStatus.BUSY,
   tool: null,


### PR DESCRIPTION
## Summary

Agents were labeled by tmux session name only, so multiple agents running in different windows of the same session all rendered the same name in the dashboard. This carries `window_name` — already collected by `listPanes()` but dropped when building `AgentState` — through the state model and renders tmux target-style `session:window` labels.

## Changes

- `AgentState` gains a `window` field, populated from `pane.windowName` in `refreshStates()`
- New `sessionLabel()` helper renders `session:window`, omitting the window when it's empty or identical to the session name (tmux auto-rename can make them redundant)
- `displayName()` falls back to `sessionLabel()` instead of bare session; `claudeName` (✳ pane title) still wins when set
- Dashboard name column, preview header, and kill confirmation all use the new label; the name column now truncates at its 15-char width instead of silently misaligning columns
- `/` filter also matches window names

## Test plan

- [x] 4 new tests for `sessionLabel` / `displayName` fallback (`src/state/types.test.ts`)
- [x] `bun test` — 180 pass
- [x] `bun run typecheck`, `lint`, `format:check` clean