### PR TITLE
fix: make tmux status line legible on light terminal themes

### DIFF
--- a/src/cli/status.test.ts
+++ b/src/cli/status.test.ts
@@ -126,8 +126,8 @@ describe('formatStatusLine', () => {
       makeState({ status: AgentStatus.PERMIT, session: 'mysession', window: 'task-window', ts: now - 10 }),
     ];
     const result = formatStatusLine(states);
-    // Icon for PERMIT is ⚠ with color #f9e2af
-    expect(result).toContain('#[fg=#f9e2af]');
+    // Icon for PERMIT is ⚠ in the terminal's yellow (theme-aware named color)
+    expect(result).toContain('#[fg=yellow]');
     expect(result).toContain('⚠');
     expect(result).toContain('#[bold]task-window#[nobold]');
     expect(result).toContain('10s');
@@ -173,7 +173,7 @@ describe('formatStatusLine', () => {
       makeState({ status: AgentStatus.QUESTION, session: 'b', paneId: '%2' }),
     ];
     const result = formatStatusLine(states);
-    expect(result).toContain(' #[fg=#45475a]│ ');
+    expect(result).toContain(' #[fg=brightblack]│ ');
   });
 
   test('uses the window name even when claudeName is set', () => {

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -36,10 +36,10 @@ export function formatStatusLine(states: AgentState[]): string {
   // A "clear all" chip dismisses every ready agent at once. Only ready (DONE)
   // agents are dismissible, so the chip only appears when one is present.
   if (filtered.some((s) => s.status === AgentStatus.DONE)) {
-    entries.push(`#[range=user|${ACK_ALL_RANGE}]#[fg=#6c7086]✕ clear#[norange]`);
+    entries.push(`#[range=user|${ACK_ALL_RANGE}]#[fg=brightblack]✕ clear#[norange]`);
   }
 
-  return entries.join(' #[fg=#45475a]│ ');
+  return entries.join(' #[fg=brightblack]│ ');
 }
 
 export function formatPlainStatus(states: AgentState[], session: string): string {

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -36,14 +36,19 @@ export function compareStatus(a: AgentStatus, b: AgentStatus): number {
   return PRIORITY[a] - PRIORITY[b];
 }
 
+// `color` is a tmux color name (not a hex value): it is consumed only by the
+// tmux status line via `#[fg=...]`, where named colors resolve against the
+// terminal's own palette so they stay readable on light and dark themes alike.
+// The in-app TUI ignores this field and colors state via getStateColor()/the C
+// palette instead.
 export const STATUS_DISPLAY: Record<AgentStatus, { icon: string; label: string; color: string }> = {
-  [AgentStatus.PERMIT]: { icon: '⚠', label: 'waiting', color: '#f9e2af' },
-  [AgentStatus.QUESTION]: { icon: '?', label: 'asking', color: '#cba6f7' },
-  [AgentStatus.DONE]: { icon: '●', label: 'ready', color: '#a6e3a1' },
-  [AgentStatus.BUSY]: { icon: '◉', label: 'working', color: '#fab387' },
-  [AgentStatus.IDLE]: { icon: '●', label: 'idle', color: '#89b4fa' },
-  [AgentStatus.SHELL]: { icon: '■', label: 'shell', color: '#6c7086' },
-  [AgentStatus.DOWN]: { icon: '○', label: 'down', color: '#45475a' },
+  [AgentStatus.PERMIT]: { icon: '⚠', label: 'waiting', color: 'yellow' },
+  [AgentStatus.QUESTION]: { icon: '?', label: 'asking', color: 'magenta' },
+  [AgentStatus.DONE]: { icon: '●', label: 'ready', color: 'green' },
+  [AgentStatus.BUSY]: { icon: '◉', label: 'working', color: 'brightred' },
+  [AgentStatus.IDLE]: { icon: '●', label: 'idle', color: 'blue' },
+  [AgentStatus.SHELL]: { icon: '■', label: 'shell', color: 'brightblack' },
+  [AgentStatus.DOWN]: { icon: '○', label: 'down', color: 'brightblack' },
 };
 
 export interface AgentState {


### PR DESCRIPTION
## Problem

On a light terminal theme the Fleet tmux status line is hard to read: the status colors were emitted as Catppuccin **Mocha** pastels via truecolor `#[fg=#hex]`, which are tuned for dark backgrounds and wash out against a light status bar.

![before](attachment-not-applicable)

tmux can't probe the terminal/status-bar background, so any fixed truecolor value only reads well on one polarity.

## Fix

Switch the status-line colors to tmux **named** colors — `yellow`, `magenta`, `green`, `brightblack` — which resolve against the terminal's own ANSI palette and therefore follow its light/dark variant automatically. This is the same theme-aware mechanism the rest of `colors.ts` already relies on for non-state colors.

- `src/state/types.ts` — `STATUS_DISPLAY.color` values: hex → tmux named colors, with a comment clarifying the field is tmux-only and theme-aware.
- `src/cli/status.ts` — hardcoded separator (`#45475a`) and "clear" chip (`#6c7086`) → `brightblack`.
- `src/cli/status.test.ts` — assertions updated to the named colors.

### Why this is safe / narrow

`STATUS_DISPLAY.color` is consumed **only** by the tmux status output. The in-app TUI colors state through `getStateColor()`/the `C` palette and only borrows `.icon`/`.label` from `STATUS_DISPLAY`, so this changes nothing in the dashboard/preview renderers.

## Verification

- `bun test` — 220 pass
- `bun run typecheck`, `bun run lint`, `bun run format` — clean
- Manually verified the rebuilt binary in a live tmux status line on a light theme: noticeably more legible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)