### PR TITLE
feat: clear an agent's notification when you focus its pane

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ fleet statusline --inject
 
 Each entry is clickable (tmux 3.2+). **Left-click** an agent name to switch to that session; **right-click** to mark it read in place without switching. When any agent is ready, a `✕ clear` chip appears at the end of the row — click it to dismiss every ready agent at once. Only agents whose turn it is for you appear: PERMIT (tool approval), QUESTION (a question to answer), and DONE/ready (finished, waiting on your next move). Working and idle sessions stay out of the bar — they don't need you to act, so they'd just be noise. Watch those in the dashboard instead.
 
-(After upgrading Fleet, re-run `fleet statusline --inject` to pick up the right-click binding and clear chip.)
+(After upgrading Fleet, re-run `fleet statusline --inject` to pick up the right-click binding, clear chip, and focus-to-clear hook.)
 
 **Status-right icon (lightweight):** A single icon in your existing status bar:
 
@@ -219,6 +219,7 @@ Fleet doesn't trust any single signal. It fuses three layers for high-confidence
 
 - **Click it in the dashboard** — acknowledges in place, so you can clear several finished agents without leaving Fleet.
 - **Switch to it** (Enter, or left-click its statusline entry) — acknowledges, then takes you there.
+- **Focus its pane any other way** — reaching the pane through tmux itself (prefix keys, clicking the pane, `choose-tree`) clears it too, via a `pane-focus-in` hook, so you don't have to go through Fleet. Only a lingering `ready` chip clears this way; a pending `PERMIT`/`QUESTION` stays until you answer it on screen.
 - **Right-click its statusline entry** — acknowledges in place, without switching.
 - **Click the `✕ clear` chip** at the end of the statusline — acknowledges every ready agent at once.
 - **`fleet ack <pane>`** — from the CLI, for scripting or bulk-clearing.

--- a/src/cli/statusline.test.ts
+++ b/src/cli/statusline.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, test } from 'bun:test';
 import { buildInjectCommands, buildRemoveCommands } from './statusline.ts';
 
 describe('buildInjectCommands', () => {
-  test('returns enable status-2, status-format[1], and both mouse bind commands', () => {
+  test('returns status-2, status-format[1], both mouse binds, and the focus hook', () => {
     const cmds = buildInjectCommands();
-    expect(cmds).toHaveLength(4);
+    expect(cmds).toHaveLength(6);
     expect(cmds[0]).toEqual(['tmux', 'set', '-g', 'status', '2']);
     expect(cmds[1]).toEqual(['tmux', 'set', '-g', 'status-format[1]', '#[align=left]#(fleet status --statusline)']);
     expect(cmds[2]![0]).toBe('tmux');
@@ -12,6 +12,22 @@ describe('buildInjectCommands', () => {
     expect(cmds[2]).toContain('MouseDown1Status');
     expect(cmds[3]![1]).toBe('bind');
     expect(cmds[3]).toContain('MouseDown3Status');
+  });
+
+  test('registers a pane-focus-in hook that acks the focused pane', () => {
+    const cmds = buildInjectCommands();
+    // focus-events must be on for pane-focus-in to fire at all.
+    expect(cmds).toContainEqual(['tmux', 'set', '-g', 'focus-events', 'on']);
+    // The hook itself: reaching a pane by any route clears its ready chip.
+    const hook = cmds.find((c) => c[1] === 'set-hook');
+    expect(hook).toBeDefined();
+    // Indexed so it coexists with a user's own pane-focus-in hook at [0].
+    expect(hook).toContain('pane-focus-in[99]');
+    const action = hook!.find((a) => a.includes('fleet ack'));
+    expect(action).toBeDefined();
+    expect(action).toContain('#{pane_id}');
+    // Backgrounded so a pane switch never waits on fleet starting up.
+    expect(action).toContain('-b');
   });
 
   test('all commands invoke tmux', () => {
@@ -57,14 +73,24 @@ describe('buildInjectCommands', () => {
 });
 
 describe('buildRemoveCommands', () => {
-  test('unsets status-format[1], resets status, and unbinds both mouse buttons', () => {
+  test('unsets status-format[1], resets status, unbinds both mouse buttons, and removes the focus hook', () => {
     const cmds = buildRemoveCommands();
     expect(cmds).toEqual([
       ['tmux', 'set', '-g', '-u', 'status-format[1]'],
       ['tmux', 'set', '-g', 'status', 'on'],
       ['tmux', 'unbind', '-T', 'root', 'MouseDown1Status'],
       ['tmux', 'unbind', '-T', 'root', 'MouseDown3Status'],
+      ['tmux', 'set-hook', '-gu', 'pane-focus-in[99]'],
     ]);
+  });
+
+  test('removes only our indexed focus hook, leaving focus-events untouched', () => {
+    const cmds = buildRemoveCommands();
+    const unsetHook = cmds.find((c) => c[1] === 'set-hook');
+    expect(unsetHook).toEqual(['tmux', 'set-hook', '-gu', 'pane-focus-in[99]']);
+    // We never set focus-events back off — can't know the user's prior value,
+    // and leaving it on is harmless.
+    expect(cmds.some((c) => c.includes('focus-events'))).toBe(false);
   });
 
   test('all commands invoke tmux', () => {

--- a/src/cli/statusline.ts
+++ b/src/cli/statusline.ts
@@ -11,6 +11,16 @@
 // through fleet, which decides what to do based on the range value.
 const ROW1_RANGE_GUARD = '#{&&:#{==:#{mouse_status_line},1},#{!=:#{mouse_status_range},}}';
 
+// Clearing a notification by *reaching* the pane, not just by clicking its Fleet
+// chip. A pane-focus-in hook acks whatever pane just gained focus, so switching
+// to a ready agent by any route (prefix keys, clicking the pane, choose-tree)
+// retires its chip. `fleet ack` self-gates to DONE — focusing a working/permit/
+// question pane is a no-op (those clear themselves once the on-screen prompt is
+// answered). `[99]` namespaces our hook so it coexists with any user pane-focus-in
+// hook at `[0]`; `-b` backgrounds it so a pane switch never waits on fleet.
+const FOCUS_HOOK_INDEX = 'pane-focus-in[99]';
+const FOCUS_HOOK_ACTION = 'run-shell -b "fleet ack \\"#{pane_id}\\""';
+
 export function buildInjectCommands(): string[][] {
   return [
     ['tmux', 'set', '-g', 'status', '2'],
@@ -41,6 +51,9 @@ export function buildInjectCommands(): string[][] {
       ROW1_RANGE_GUARD,
       'run-shell "fleet ack \\"#{mouse_status_range}\\""',
     ],
+    // pane-focus-in requires focus-events; switching to a pane then acks it.
+    ['tmux', 'set', '-g', 'focus-events', 'on'],
+    ['tmux', 'set-hook', '-g', FOCUS_HOOK_INDEX, FOCUS_HOOK_ACTION],
   ];
 }
 
@@ -50,6 +63,9 @@ export function buildRemoveCommands(): string[][] {
     ['tmux', 'set', '-g', 'status', 'on'],
     ['tmux', 'unbind', '-T', 'root', 'MouseDown1Status'],
     ['tmux', 'unbind', '-T', 'root', 'MouseDown3Status'],
+    // Remove only our indexed hook; leave focus-events as we found it (we can't
+    // know the user's prior value, and leaving it on is harmless).
+    ['tmux', 'set-hook', '-gu', FOCUS_HOOK_INDEX],
   ];
 }
 


### PR DESCRIPTION
## What

Focusing an agent's pane by **any** route — prefix keys, clicking the pane, `choose-tree` — now clears its `ready` chip from the Fleet status line. Previously only clicking the Fleet status entry (or `fleet switch`/`ack`) cleared it, so reaching a finished agent any other way left a stale chip until the next `status-interval` tick.

## How

- `buildInjectCommands()` enables `focus-events` and registers a `pane-focus-in[99]` hook: `run-shell -b "fleet ack #{pane_id}"`.
  - Index `[99]` namespaces the hook so it coexists with a user's own `pane-focus-in[0]`.
  - `-b` backgrounds it so a pane switch never waits on fleet starting up.
- `buildRemoveCommands()` removes only our indexed hook and leaves `focus-events` as-is (we can't know the prior value, and leaving it on is harmless).
- Reuses the existing `fleet ack` path, which self-gates to `DONE` — focusing a `working`/`permit`/`question` pane is a no-op.

## Test plan

- `bun test` → **222 pass** (new tests assert the inject/remove hook commands).
- `bun run lint`, `bun run typecheck` → clean.
- Verified live on tmux 3.6b: the exact hook action (`fleet ack %<pane>`) flips a planted `DONE` status to `idle`; the indexed hook sets/unsets cleanly without touching a user hook at `[0]`.

## Follow-up (not in this PR)

This clears finished (`DONE`) agents. A separate class remains: a non-Claude agent (e.g. Pi) that writes a `waiting`/`permit` status and never clears it can still strand a chip, because the scraper can't read a non-Claude UI to retire a non-decaying `PERMIT`. A follow-up could broaden focus to force-clear any chip (the scraper re-asserts genuine Claude prompts).
