### PR TITLE
fix: replace dangling marketplace symlink on install

### DIFF
--- a/src/cli/install.test.ts
+++ b/src/cli/install.test.ts
@@ -1,8 +1,24 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { addTmuxConfLine, addTmuxKeybindLines, removeTmuxConfLine, resolvePluginDir, tmuxConfPath } from './install.ts';
+import {
+  addTmuxConfLine,
+  addTmuxKeybindLines,
+  linkPluginDir,
+  removeTmuxConfLine,
+  resolvePluginDir,
+  tmuxConfPath,
+} from './install.ts';
 
 let workDir: string;
 let confFile: string;
@@ -132,6 +148,38 @@ describe('resolvePluginDir', () => {
     mkdirSync(join(plugin, 'hooks'), { recursive: true });
     writeFileSync(join(plugin, 'hooks', 'hooks.json'), '{}');
     expect(resolvePluginDir([bare, plugin])).toBe(plugin);
+  });
+});
+
+describe('linkPluginDir', () => {
+  test('creates a symlink to the plugin dir when none exists', () => {
+    const target = join(workDir, 'plugin-0.10.0');
+    const link = join(workDir, 'fleet');
+    mkdirSync(target, { recursive: true });
+    linkPluginDir(target, link);
+    expect(readlinkSync(link)).toBe(target);
+  });
+
+  test('replaces an existing valid symlink', () => {
+    const oldTarget = join(workDir, 'plugin-0.9.0');
+    const newTarget = join(workDir, 'plugin-0.10.0');
+    const link = join(workDir, 'fleet');
+    mkdirSync(oldTarget, { recursive: true });
+    mkdirSync(newTarget, { recursive: true });
+    symlinkSync(oldTarget, link);
+    linkPluginDir(newTarget, link);
+    expect(readlinkSync(link)).toBe(newTarget);
+  });
+
+  test('replaces a dangling symlink left by a removed target (brew upgrade)', () => {
+    const removedTarget = join(workDir, 'cellar-0.9.0'); // never created — simulates removed keg
+    const newTarget = join(workDir, 'cellar-0.10.0');
+    const link = join(workDir, 'fleet');
+    mkdirSync(newTarget, { recursive: true });
+    symlinkSync(removedTarget, link);
+    expect(existsSync(link)).toBe(false); // the trap: existsSync follows the link and can't see it
+    linkPluginDir(newTarget, link);
+    expect(readlinkSync(link)).toBe(newTarget);
   });
 });
 

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, readSync, symlinkSync, unlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, readSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { runStatusLineInject, runStatusLineRemove } from './statusline.ts';
@@ -126,11 +126,19 @@ function ensureMarketplace(fleetDir: string): string {
     ) + '\n',
   );
 
-  const link = join(mpDir, 'fleet');
-  if (existsSync(link)) unlinkSync(link);
-  symlinkSync(fleetDir, link);
+  linkPluginDir(fleetDir, join(mpDir, 'fleet'));
 
   return mpDir;
+}
+
+// Point `link` at `fleetDir`, replacing whatever is already there.
+// rmSync removes the symlink itself (it never follows it) and is a no-op when
+// nothing exists. existsSync would be wrong here: it *follows* the link, so a
+// symlink to a Cellar version removed by `brew upgrade` reports as absent, the
+// stale link survives, and symlinkSync then fails with EEXIST.
+export function linkPluginDir(fleetDir: string, link: string): void {
+  rmSync(link, { force: true });
+  symlinkSync(fleetDir, link);
 }
 
 export function runInstall(): number {


### PR DESCRIPTION
## Problem

`fleet install` crashed with `EEXIST` when the marketplace symlink was dangling:

```
EEXIST: file already exists, symlink '/opt/homebrew/Cellar/fleet/0.10.0' -> '/Users/.../.local/share/fleet-marketplace/fleet'
```

`ensureMarketplace` guarded the symlink swap with `existsSync(link)`, but **`existsSync` follows symlinks**. After `brew upgrade` removed the old Cellar keg (e.g. `0.8.0`), the marketplace link dangled — `existsSync` reported it absent, so `unlinkSync` was skipped and `symlinkSync` then hit the still-present link and threw `EEXIST`. This bites anyone re-running `fleet install` after a Homebrew upgrade.

## Fix

Extract an exported `linkPluginDir(fleetDir, link)` that uses `rmSync(link, { force: true })` — which removes the symlink itself *without following it* and no-ops when nothing is there — before creating the link.

## Testing

- Added a regression test covering the dangling-symlink case (asserts `existsSync` can't see the stale link, then that `linkPluginDir` replaces it).
- Verified the real exported function against a live dangling symlink.
- `bun test` (23 pass), `typecheck`, `lint`, `format` all clean.