### PR TITLE
feat: make fleet sidebar span the full window height

### DIFF
--- a/src/cli/install.test.ts
+++ b/src/cli/install.test.ts
@@ -226,7 +226,7 @@ describe('addTmuxKeybindLines', () => {
     const added = addTmuxKeybindLines(path, () => true);
     expect(added).toHaveLength(2);
     const conf = readFileSync(path, 'utf8');
-    expect(conf).toContain('bind-key f split-window');
+    expect(conf).toContain('bind-key f split-window -hbf');
     expect(conf).toContain('bind-key F display-popup');
     expect(conf.match(/# fleet-managed/g)?.length).toBe(2);
   });

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -5,7 +5,7 @@ import { runStatusLineInject, runStatusLineRemove } from './statusline.ts';
 
 const FLEET_MANAGED_MARKER = '# fleet-managed';
 const FLEET_TMUX_LINE = `run-shell "fleet statusline --inject" ${FLEET_MANAGED_MARKER}`;
-const FLEET_KEYBIND_SIDEBAR = `bind-key f split-window -hb -l 34 fleet ${FLEET_MANAGED_MARKER}`;
+const FLEET_KEYBIND_SIDEBAR = `bind-key f split-window -hbf -l 34 fleet ${FLEET_MANAGED_MARKER}`;
 const FLEET_KEYBIND_POPUP = `bind-key F display-popup -E -w 80% -h 60% fleet ${FLEET_MANAGED_MARKER}`;
 
 export function resolvePluginDir(candidates: string[]): string | null {


### PR DESCRIPTION
## What

The `prefix+f` sidebar binding used `split-window -hb`, which splits only the **current pane**. If the window already had stacked panes, the fleet sidebar spanned just the focused pane's height instead of the full left column.

Add tmux's `-f` flag (`-hbf`) — "full width/height of the **window** instead of the pane" — so the sidebar always claims the full-height left column.

```diff
-bind-key f split-window -hb -l 34 fleet
+bind-key f split-window -hbf -l 34 fleet
```

## Verification

Live tmux check on a window with pre-existing stacked panes:

```
=== BEFORE (stacked panes) ===
1: 0,0 200x12
2: 0,13 200x11
=== AFTER -hbf (full-height left sidebar) ===
1: left=0 top=0 34x24     <- full 24-row height, hard left
2: left=35 top=0 165x12
3: left=35 top=13 165x11
```

Test assertion tightened to lock in the `-hbf` flag. Full suite (281 tests), typecheck, lint all pass.

## Notes

- Only governs how the binding *creates* the pane — it won't reflow if panes are later added beside it.
- Existing users who already ran `fleet install` keep the old binding (the installer skips lines already present); they'd re-run install after uninstalling the managed line, or edit their tmux.conf.