### PR TITLE
feat: agent-awareness polish — explain, detection manifests, Codex, wait, window rollup, labels/rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,27 @@ To remove everything cleanly:
 fleet uninstall
 ```
 
+### Codex
+
+Fleet also tracks [Codex](https://github.com/openai/codex) sessions. Codex has no plugin marketplace, so `fleet install codex` wires fleet into Codex's own config instead:
+
+```bash
+fleet install codex
+```
+
+This:
+
+1. Creates the Codex status dir (`~/.cache/codex-status`)
+2. Adds fleet `PreToolUse` + `Stop` hooks to `~/.codex/hooks.json` (your own Codex hooks are preserved)
+3. Ensures `[features] hooks = true` in `~/.codex/config.toml`
+4. Registers `codex` in `~/.config/fleet/agents.json`
+
+Re-run it after a `brew upgrade` to re-point fleet's hook path. Codex panes then appear on the dashboard labeled `codex`, alongside `claude`. To reverse it (leaving your own Codex hooks intact):
+
+```bash
+fleet uninstall codex
+```
+
 ## Usage
 
 ### TUI Dashboard
@@ -179,7 +200,9 @@ Fleet also works as a non-interactive CLI for scripting and tmux integration.
 | `fleet doctor`                            | Check tmux version, plugin installation, status directories, hook health.          |
 | `fleet reconcile [--dry-run] [--verbose]` | Remove orphan status files for dead panes, fix stale working states.               |
 | `fleet install`                           | Register Fleet as a Claude Code plugin + add second tmux status row.               |
+| `fleet install codex`                     | Wire fleet into Codex's `hooks.json` + `config.toml` (preserves your own hooks).   |
 | `fleet uninstall`                         | Remove plugin registration + tmux status row.                                      |
+| `fleet uninstall codex`                   | Remove fleet's Codex hooks + config (leaves your own Codex hooks intact).          |
 | `fleet statusline --inject`               | Manually add the second tmux status row.                                           |
 | `fleet statusline --remove`               | Manually remove the second tmux status row.                                        |
 
@@ -287,7 +310,7 @@ Fleet reads agent directories from (in priority order):
 
 1. `~/.config/fleet/agents.json` (new format)
 2. `~/.config/agent-status/agents.conf` (legacy format)
-3. Hardcoded fallback: `~/.cache/claude-status` + `~/.cache/pi-status`
+3. Hardcoded fallback: `~/.cache/claude-status` + `~/.cache/codex-status` + `~/.cache/pi-status`
 
 ### New format (`agents.json`)
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,26 @@ Re-run it after a `brew upgrade` to re-point fleet's hook path. Codex panes then
 fleet uninstall codex
 ```
 
+### pi
+
+Fleet also tracks [pi](https://www.npmjs.com/package/@mariozechner/pi-coding-agent) sessions. pi has no shell hooks — it loads TypeScript extensions auto-discovered from `~/.pi/agent/extensions/` — so `fleet install pi` drops fleet's extension there:
+
+```bash
+fleet install pi
+```
+
+This:
+
+1. Creates the pi status dir (`~/.cache/pi-status`)
+2. Symlinks the `fleet-pi` extension into `~/.pi/agent/extensions/` (your own pi extensions are untouched)
+3. Registers `pi` in `~/.config/fleet/agents.json`
+
+The extension publishes fleet status from pi's `agent_start` / `tool_execution_start` / `agent_end` lifecycle events, so pi panes appear on the dashboard labeled `pi` (working / idle / done). pi auto-runs its tools, so there is no permission-prompt (PERMIT/QUESTION) state to surface — working/done is the full picture. Re-run after a `brew upgrade` to re-point the extension; in an already-running pi session, `/reload` picks it up. To reverse it (leaving your own pi extensions intact):
+
+```bash
+fleet uninstall pi
+```
+
 ## Usage
 
 ### TUI Dashboard
@@ -201,8 +221,10 @@ Fleet also works as a non-interactive CLI for scripting and tmux integration.
 | `fleet reconcile [--dry-run] [--verbose]` | Remove orphan status files for dead panes, fix stale working states.               |
 | `fleet install`                           | Register Fleet as a Claude Code plugin + add second tmux status row.               |
 | `fleet install codex`                     | Wire fleet into Codex's `hooks.json` + `config.toml` (preserves your own hooks).   |
+| `fleet install pi`                        | Wire fleet into pi via an auto-discovered extension (preserves your own).          |
 | `fleet uninstall`                         | Remove plugin registration + tmux status row.                                      |
 | `fleet uninstall codex`                   | Remove fleet's Codex hooks + config (leaves your own Codex hooks intact).          |
+| `fleet uninstall pi`                      | Remove fleet's pi extension + registration.                                        |
 | `fleet statusline --inject`               | Manually add the second tmux status row.                                           |
 | `fleet statusline --remove`               | Manually remove the second tmux status row.                                        |
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Below 48 columns — like that narrow sidebar — Fleet automatically reflows th
 | `y`                        | Approve permission prompt (preview)    |
 | `/`                        | Filter sessions by name or project     |
 | `x`                        | Kill selected session (confirms first) |
+| `R`                        | Rename selected session                |
 | `?`                        | Help overlay                           |
 | `q` or `Esc`               | Quit (or clear filter)                 |
 

--- a/README.md
+++ b/README.md
@@ -294,8 +294,8 @@ Fleet reads agent directories from (in priority order):
 ```json
 {
   "agents": [
-    { "name": "claude", "statusDir": "~/.cache/fleet/claude" },
-    { "name": "codex", "statusDir": "~/.cache/fleet/codex" }
+    { "name": "claude", "statusDir": "~/.cache/claude-status" },
+    { "name": "codex", "statusDir": "~/.cache/codex-status" }
   ]
 }
 ```

--- a/hooks/codex/codex-hook.sh
+++ b/hooks/codex/codex-hook.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Fleet Codex hook — one parameterized script for both events Codex fires:
+#   codex-hook.sh PreToolUse   (a tool is about to run -> working)
+#   codex-hook.sh Stop         (turn ended -> working if more work, else done)
+# Codex has no $CLAUDE_PLUGIN_ROOT, so `fleet install codex` writes this script's
+# absolute path into ~/.codex/hooks.json. It reuses hooks/lib.sh by pointing
+# FLEET_STATUS_DIR at Codex's own status dir BEFORE sourcing (lib.sh honors the
+# override); the [ -z "$TMUX" ] guard and TMUX_PANE capture in lib.sh are
+# agent-agnostic — Codex runs inside the tmux pane exactly like Claude.
+INPUT=$(cat)
+EVENT="${1:-}"
+# Default to Codex's status dir, but honor a caller-set FLEET_STATUS_DIR (same
+# ${VAR:-default} pattern lib.sh uses) so the hook is testable against a temp dir.
+export FLEET_STATUS_DIR="${FLEET_STATUS_DIR:-${HOME}/.cache/codex-status}"
+. "$(dirname "$0")/../lib.sh" # ../ -> hooks/lib.sh; sets FLEET_STATUS_FILE etc.
+
+case "$EVENT" in
+  PreToolUse)
+    TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || echo "")
+    fleet_write_status "working" "$TOOL"
+    fleet_append_event "PreToolUse" "tool" "\"$TOOL\""
+    ;;
+  Stop)
+    STOP_REASON=$(printf '%s' "$INPUT" | jq -r '.stop_reason // "end_turn"' 2>/dev/null)
+    BG_TASKS=$(printf '%s' "$INPUT" | jq -r '.background_tasks // false' 2>/dev/null)
+    TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || echo "")
+    fleet_append_event "Stop" "stop_reason" "\"$STOP_REASON\"" "background_tasks" "$BG_TASKS"
+    if [ "$STOP_REASON" = "tool_use" ] || [ "$BG_TASKS" = "true" ]; then
+      fleet_write_status "working" "$TOOL"
+    else
+      # Debounced done: a new turn within 3s rewrites .status with a fresh ts, so
+      # the ts-equality check cancels this stale done (same guard as stop.sh).
+      (
+        sleep 3
+        if [ -f "$FLEET_STATUS_FILE" ]; then
+          CURRENT_TS=$(jq -r '.ts // 0' "$FLEET_STATUS_FILE" 2>/dev/null)
+          if [ "$CURRENT_TS" = "$FLEET_TS" ]; then
+            fleet_write_status "done" "$TOOL"
+            fleet_notify "done" "$FLEET_SESSION" "$FLEET_PANE_ID" "$TOOL" >/dev/null 2>&1
+          fi
+        fi
+      ) &
+    fi
+    ;;
+esac
+exit 0

--- a/hooks/label.sh
+++ b/hooks/label.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Pure: reads a PreToolUse JSON payload on stdin, prints an enriched activity
+# label on stdout. No tmux, no filesystem — sourceable for unit checks.
+fleet_tool_label() {
+  jq -r '
+    .tool_name as $t | (.tool_input // {}) as $in
+    | if $t == "Bash" then
+        "Bash: " + (($in.command // "") | gsub("\\s+"; " ") | .[0:48])
+      elif ($t == "Edit" or $t == "Write" or $t == "Read" or $t == "NotebookEdit") then
+        $t + ": " + (($in.file_path // $in.notebook_path // "") | split("/") | (last // ""))
+      else
+        ($t // "")
+      end
+  ' 2>/dev/null
+}

--- a/hooks/lib.sh
+++ b/hooks/lib.sh
@@ -18,11 +18,29 @@ FLEET_TMUX_PID=$(tmux display-message -p '#{pid}' 2>/dev/null)
 FLEET_STATUS_FILE="${FLEET_STATUS_DIR}/${FLEET_PANE_NUM}.status"
 FLEET_EVENTS_FILE="${FLEET_STATUS_DIR}/${FLEET_PANE_NUM}.events.jsonl"
 
+# Collapse to a single line and cap width. Belt to jq's suspenders; also the
+# sole guard on the jq-less path.
+fleet_sanitize_label() {
+  printf '%s' "$1" | tr '\n\r\t' '   ' | LC_ALL=C tr -d '\000-\037' | cut -c1-60
+}
+
 fleet_write_status() {
-  local state="$1" tool="${2:-}"
-  printf '{"state":"%s","pane":"%s","session":"%s","tool":"%s","ts":%s,"tmux_pid":%s}\n' \
-    "$state" "$FLEET_PANE_ID" "$FLEET_SESSION" "$tool" "$FLEET_TS" "${FLEET_TMUX_PID:-0}" \
-    > "$FLEET_STATUS_FILE"
+  local state="$1" tool
+  tool=$(fleet_sanitize_label "${2:-}")
+  if command -v jq >/dev/null 2>&1; then
+    jq -cn \
+      --arg state "$state" --arg pane "$FLEET_PANE_ID" --arg session "$FLEET_SESSION" \
+      --arg tool "$tool" --argjson ts "$FLEET_TS" --argjson pid "${FLEET_TMUX_PID:-0}" \
+      '{state:$state, pane:$pane, session:$session, tool:$tool, ts:$ts, tmux_pid:$pid}' \
+      > "$FLEET_STATUS_FILE"
+  else
+    # jq absent: label already stripped of control chars; also drop " and \.
+    local safe=${tool//\"/}
+    safe=${safe//\\/}
+    printf '{"state":"%s","pane":"%s","session":"%s","tool":"%s","ts":%s,"tmux_pid":%s}\n' \
+      "$state" "$FLEET_PANE_ID" "$FLEET_SESSION" "$safe" "$FLEET_TS" "${FLEET_TMUX_PID:-0}" \
+      > "$FLEET_STATUS_FILE"
+  fi
 }
 
 fleet_append_event() {

--- a/hooks/lib.sh
+++ b/hooks/lib.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # Fleet hook shared library
 
-FLEET_STATUS_DIR="${HOME}/.cache/claude-status"
+# Parameterized so a per-agent hook (e.g. Phase 3 Codex) can point at its own
+# dir; unset resolves to the canonical claude default that config.ts reads.
+FLEET_STATUS_DIR="${FLEET_STATUS_DIR:-${HOME}/.cache/claude-status}"
 mkdir -p "$FLEET_STATUS_DIR"
 
 [ -z "$TMUX" ] && exit 0

--- a/hooks/pi/fleet-pi.test.ts
+++ b/hooks/pi/fleet-pi.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import piDefault, { buildPiStatusLine, fleetPiLabel } from './fleet-pi.ts';
+import { parseStatusFile } from '../../src/state/hooks.ts';
+
+describe('fleetPiLabel', () => {
+  test('bash: collapses whitespace and truncates to 48 chars', () => {
+    expect(fleetPiLabel('bash', { command: 'npm    test   -- --watch --coverage --reporter verbose extra' })).toBe(
+      'Bash: npm test -- --watch --coverage --reporter verbos',
+    );
+  });
+
+  test('bash: empty/absent command falls back to bare "Bash"', () => {
+    expect(fleetPiLabel('bash', { command: '' })).toBe('Bash');
+    expect(fleetPiLabel('bash', {})).toBe('Bash');
+  });
+
+  test('edit/write/read: basename only, capitalized tool', () => {
+    expect(fleetPiLabel('edit', { path: '/Users/x/src/auth.ts' })).toBe('Edit: auth.ts');
+    expect(fleetPiLabel('write', { path: '/tmp/foo/bar.md' })).toBe('Write: bar.md');
+    expect(fleetPiLabel('read', { path: 'README.md' })).toBe('Read: README.md');
+  });
+
+  test('unknown tool: capitalized name, no colon', () => {
+    expect(fleetPiLabel('grep', { pattern: 'x' })).toBe('Grep');
+    expect(fleetPiLabel('list', {})).toBe('List');
+  });
+
+  test('missing/non-object args never throws', () => {
+    expect(fleetPiLabel('bash', undefined)).toBe('Bash');
+    expect(fleetPiLabel('edit', null)).toBe('Edit');
+    expect(fleetPiLabel('', {})).toBe('');
+  });
+});
+
+describe('buildPiStatusLine', () => {
+  test('round-trips through fleet parseStatusFile with the exact schema', () => {
+    const line = buildPiStatusLine('working', '%3', 'projects', 'Bash: npm test', 1783136479, 17136);
+    const parsed = parseStatusFile(line);
+    expect(parsed).toEqual({
+      state: 'working',
+      pane: '%3',
+      session: 'projects',
+      tool: 'Bash: npm test',
+      ts: 1783136479,
+      tmux_pid: 17136,
+    });
+  });
+
+  test('escapes quotes/newlines in the label so the file stays valid JSON', () => {
+    const line = buildPiStatusLine('working', '%1', 's', 'Bash: echo "hi"\nrm -rf', 1, 2);
+    expect(() => JSON.parse(line)).not.toThrow();
+    expect(parseStatusFile(line)?.tool).toBe('Bash: echo "hi"\nrm -rf');
+  });
+});
+
+describe('extension event wiring', () => {
+  let statusDir: string;
+  let saved: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    statusDir = mkdtempSync(join(tmpdir(), 'fleet-pi-test-'));
+    saved = {
+      TMUX: process.env.TMUX,
+      TMUX_PANE: process.env.TMUX_PANE,
+      FLEET_PI_STATUS_DIR: process.env.FLEET_PI_STATUS_DIR,
+    };
+    process.env.FLEET_PI_STATUS_DIR = statusDir;
+  });
+
+  afterEach(() => {
+    rmSync(statusDir, { recursive: true, force: true });
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  // Capture the handlers the extension registers so the test can fire them.
+  function loadWithTmux(pane: string): Record<string, (e?: unknown) => void> {
+    process.env.TMUX = '/tmp/fake-tmux,1,0';
+    process.env.TMUX_PANE = pane;
+    const handlers: Record<string, (e?: unknown) => void> = {};
+    const mockPi = {
+      on(event: string, handler: (e?: unknown) => void): void {
+        handlers[event] = handler;
+      },
+    };
+    piDefault(mockPi as unknown as Parameters<typeof piDefault>[0]);
+    return handlers;
+  }
+
+  const readStatus = (paneNum: string): ReturnType<typeof parseStatusFile> =>
+    parseStatusFile(readFileSync(join(statusDir, `${paneNum}.status`), 'utf8'));
+
+  test('agent_start writes working; tool_execution_start enriches the label; agent_end writes done', () => {
+    const h = loadWithTmux('%42');
+
+    h.agent_start?.();
+    expect(readStatus('42')?.state).toBe('working');
+    expect(readStatus('42')?.pane).toBe('%42');
+
+    h.tool_execution_start?.({ toolName: 'bash', args: { command: 'bun test' } });
+    let s = readStatus('42');
+    expect(s?.state).toBe('working');
+    expect(s?.tool).toBe('Bash: bun test');
+
+    h.agent_end?.();
+    s = readStatus('42');
+    expect(s?.state).toBe('done');
+  });
+
+  test('session_shutdown removes the status file', () => {
+    const h = loadWithTmux('%7');
+    h.agent_start?.();
+    expect(existsSync(join(statusDir, '7.status'))).toBe(true);
+    h.session_shutdown?.();
+    expect(existsSync(join(statusDir, '7.status'))).toBe(false);
+  });
+
+  test('outside tmux: registers no handlers and writes nothing', () => {
+    delete process.env.TMUX;
+    process.env.TMUX_PANE = '%1';
+    const handlers: Record<string, (e?: unknown) => void> = {};
+    const mockPi = {
+      on(event: string, handler: (e?: unknown) => void): void {
+        handlers[event] = handler;
+      },
+    };
+    piDefault(mockPi as unknown as Parameters<typeof piDefault>[0]);
+    expect(Object.keys(handlers)).toHaveLength(0);
+    // status dir stays empty
+    writeFileSync(join(statusDir, 'sentinel'), 'x'); // prove the dir is otherwise empty of .status
+    expect(existsSync(join(statusDir, '1.status'))).toBe(false);
+  });
+});

--- a/hooks/pi/fleet-pi.ts
+++ b/hooks/pi/fleet-pi.ts
@@ -1,0 +1,140 @@
+/**
+ * fleet-pi — a pi extension that publishes fleet agent-status from pi's
+ * lifecycle events, so a pi session shows up on the fleet dashboard (working /
+ * idle / done) alongside claude and codex.
+ *
+ * pi has no shell-hook config like Claude Code or Codex; it loads TypeScript
+ * extensions auto-discovered from ~/.pi/agent/extensions/*.ts. `fleet install pi`
+ * symlinks this file there. It subscribes to pi's lifecycle events and writes the
+ * same status-file schema fleet's shell hooks write (see hooks/lib.sh):
+ *
+ *   agent_start          -> { state: "working" }
+ *   tool_execution_start -> { state: "working", tool: "Bash: …" | "Edit: …" }
+ *   agent_end            -> { state: "done" }        (fleet ages done -> idle)
+ *   session_shutdown     -> remove the status file   (pi exited; no stale state)
+ *
+ * pi auto-runs its tools (no interactive permission prompt), so there is no
+ * PERMIT/QUESTION state to source — working/done is complete coverage. State
+ * goes to $FLEET_PI_STATUS_DIR or ~/.cache/pi-status (must match config.ts's
+ * PI_STATUS_DIR). It is a no-op outside tmux, since fleet keys every agent on a
+ * tmux pane. Every write is wrapped so a status-file error can never break pi.
+ *
+ * Zero fleet dependency: this file is loaded by pi, not bundled into fleet's
+ * binary, and imports nothing from fleet. The pi API surface it uses is declared
+ * locally (see PiExtensionAPI) rather than imported from
+ * @mariozechner/pi-coding-agent, so fleet stays zero-dependency and typechecks
+ * without pulling pi's types. pi invokes the default export with its real
+ * ExtensionAPI, which structurally satisfies the local type.
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+// --- minimal structural view of the pi ExtensionAPI slice this uses -----------
+// pi's real handler signature is (event, ctx) => void | Promise<void>; narrower
+// handlers (fewer params, void return) are assignable, so these compile against
+// pi's real `on` at load time. See pi's docs/extensions.md for the full surface.
+interface PiToolExecutionStartEvent {
+  toolName: string;
+  args: unknown;
+}
+interface PiExtensionAPI {
+  on(event: 'session_start' | 'agent_start' | 'agent_end' | 'session_shutdown', handler: () => void): void;
+  on(event: 'tool_execution_start', handler: (event: PiToolExecutionStartEvent) => void): void;
+}
+
+// --- pure helpers (exported for unit tests) -----------------------------------
+
+// Enrich a pi tool call into a fleet activity label, matching the Claude/Codex
+// convention: "Bash: <cmd>", "Edit: <file>". pi's built-in tool names are
+// lowercase (bash, edit, write, read, …) with `command` (bash) or `path`
+// (edit/write/read) inputs; anything else falls back to the capitalized name.
+export function fleetPiLabel(toolName: string, args: unknown): string {
+  const a = (args ?? {}) as Record<string, unknown>;
+  const str = (v: unknown): string => (typeof v === 'string' ? v : '');
+  const cap = toolName ? toolName.charAt(0).toUpperCase() + toolName.slice(1) : '';
+  if (toolName === 'bash') {
+    const cmd = str(a.command).replace(/\s+/g, ' ').trim().slice(0, 48);
+    return cmd ? `Bash: ${cmd}` : 'Bash';
+  }
+  if (toolName === 'edit' || toolName === 'write' || toolName === 'read') {
+    const base = str(a.path).split('/').pop() ?? '';
+    return base ? `${cap}: ${base}` : cap;
+  }
+  return cap;
+}
+
+// Serialize a fleet status record. JSON.stringify escapes quotes/newlines in the
+// label so a status file can never be corrupted by tool input. Field names and
+// shape mirror parseStatusFile in src/state/hooks.ts exactly.
+export function buildPiStatusLine(
+  state: string,
+  pane: string,
+  session: string,
+  tool: string,
+  ts: number,
+  tmuxPid: number,
+): string {
+  return JSON.stringify({ state, pane, session, tool, ts, tmux_pid: tmuxPid }) + '\n';
+}
+
+// --- extension entry point ----------------------------------------------------
+export default function (pi: PiExtensionAPI): void {
+  const paneId = process.env.TMUX_PANE ?? '';
+  // fleet keys every agent on a tmux pane; outside tmux there is nothing to
+  // publish, so register no handlers (a clean no-op).
+  if (!process.env.TMUX || !paneId) return;
+
+  // Honor a caller-set override (tests), else the canonical dir config.ts reads.
+  const statusDir = process.env.FLEET_PI_STATUS_DIR || join(homedir(), '.cache', 'pi-status');
+  const paneNum = paneId.replace(/^%/, '');
+  const statusFile = join(statusDir, `${paneNum}.status`);
+
+  const tmuxQuery = (fmt: string): string => {
+    try {
+      return execFileSync('tmux', ['display-message', '-p', '-t', paneId, fmt], { encoding: 'utf8' }).trim();
+    } catch {
+      return '';
+    }
+  };
+  let session = tmuxQuery('#{session_name}');
+  let tmuxPid = Number(tmuxQuery('#{pid}')) || 0;
+
+  const write = (state: string, tool: string): void => {
+    try {
+      mkdirSync(statusDir, { recursive: true });
+      writeFileSync(
+        statusFile,
+        buildPiStatusLine(state, paneId, session, tool, Math.floor(Date.now() / 1000), tmuxPid),
+      );
+    } catch {
+      // Never break the user's pi session over a status write.
+    }
+  };
+
+  let currentTool = '';
+
+  pi.on('session_start', () => {
+    // tmux env is fully populated by now; backfill anything missing at load.
+    if (!session) session = tmuxQuery('#{session_name}');
+    if (!tmuxPid) tmuxPid = Number(tmuxQuery('#{pid}')) || 0;
+  });
+  pi.on('agent_start', () => write('working', currentTool));
+  pi.on('tool_execution_start', (event) => {
+    currentTool = fleetPiLabel(event.toolName, event.args);
+    write('working', currentTool);
+  });
+  pi.on('agent_end', () => {
+    currentTool = '';
+    write('done', '');
+  });
+  pi.on('session_shutdown', () => {
+    // pi is exiting — drop the status file so the pane doesn't linger as done.
+    try {
+      rmSync(statusFile, { force: true });
+    } catch {
+      // ignore
+    }
+  });
+}

--- a/hooks/pre-tool-use.sh
+++ b/hooks/pre-tool-use.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 INPUT=$(cat)
 . "$(dirname "$0")/lib.sh"
+. "$(dirname "$0")/label.sh"
 
-TOOL=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || echo "")
+RAW_TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || echo "")
+LABEL=$(printf '%s' "$INPUT" | fleet_tool_label)
+[ -z "$LABEL" ] && LABEL="$RAW_TOOL"          # fall back to the bare tool name
 
-fleet_write_status "working" "$TOOL"
-fleet_append_event "PreToolUse" "tool" "\"$TOOL\""
+fleet_write_status "working" "$LABEL"          # enriched → .status label
+fleet_append_event "PreToolUse" "tool" "$(printf '%s' "$RAW_TOOL" | jq -Rs .)"  # RAW → event (slurp: empty → "")
 
 exit 0

--- a/index.ts
+++ b/index.ts
@@ -32,6 +32,7 @@ import { runSend } from './src/cli/send.ts';
 import { runInstall, runUninstall } from './src/cli/install.ts';
 import { runDoctor } from './src/cli/doctor.ts';
 import { runReconcile } from './src/cli/reconcile.ts';
+import { runExplain } from './src/cli/explain.ts';
 import { runStatusLineInject, runStatusLineRemove } from './src/cli/statusline.ts';
 import { readFileSync, writeFileSync, appendFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
@@ -64,6 +65,7 @@ function printHelp(): number {
       `    ${C.idle}fleet status${C.reset} --statusline        ${C.gray}Render multi-agent tmux status line${C.reset}`,
       `    ${C.idle}fleet next${C.reset}                       ${C.gray}Jump to next waiting agent${C.reset}`,
       `    ${C.idle}fleet send${C.reset} <session> <prompt>    ${C.gray}Send prompt to session${C.reset}`,
+      `    ${C.idle}fleet explain${C.reset} <session>          ${C.gray}Trace how a session's state was decided${C.reset}`,
       `    ${C.idle}fleet reconcile${C.reset} [--dry-run]      ${C.gray}Sweep orphan status files${C.reset}`,
       '',
       `  ${C.bold}Plugin${C.reset}`,
@@ -281,7 +283,7 @@ function refreshStates(statusDirs: string[]): AgentState[] {
         scrapeStatus: scrapeCache.get(pane.paneId) ?? null,
         currentStatus: AgentStatus.IDLE,
         currentTs: 0,
-      });
+      }).status;
     } else {
       status = AgentStatus.SHELL;
     }
@@ -386,6 +388,16 @@ function handleCli(args: string[]): number | null {
       const states = fullRefreshStates(statusDirs);
       const force = args.includes('--force');
       return runSend(session, prompt, states, force);
+    }
+    case 'explain': {
+      const session = args[1];
+      if (!session) {
+        process.stderr.write('Usage: fleet explain <session> [--show-snapshot]\n');
+        return 1;
+      }
+      const showSnapshot = args.includes('--show-snapshot');
+      const states = fullRefreshStates(statusDirs);
+      return runExplain(session, states, statusDirs, showSnapshot);
     }
     case 'install':
       return runInstall();

--- a/index.ts
+++ b/index.ts
@@ -33,6 +33,7 @@ import { runNext } from './src/cli/next.ts';
 import { runSend } from './src/cli/send.ts';
 import { runInstall, runUninstall } from './src/cli/install.ts';
 import { runInstallCodex, runUninstallCodex } from './src/cli/install-codex.ts';
+import { runInstallPi, runUninstallPi } from './src/cli/install-pi.ts';
 import { runDoctor } from './src/cli/doctor.ts';
 import { runReconcile } from './src/cli/reconcile.ts';
 import { runExplain } from './src/cli/explain.ts';
@@ -76,8 +77,10 @@ function printHelp(): number {
       `  ${C.bold}Plugin${C.reset}`,
       `    ${C.idle}fleet install${C.reset}                    ${C.gray}Register as Claude Code plugin${C.reset}`,
       `    ${C.idle}fleet install codex${C.reset}              ${C.gray}Wire fleet into Codex's hooks + config${C.reset}`,
+      `    ${C.idle}fleet install pi${C.reset}                 ${C.gray}Wire fleet into pi via an extension${C.reset}`,
       `    ${C.idle}fleet uninstall${C.reset}                  ${C.gray}Remove plugin registration${C.reset}`,
       `    ${C.idle}fleet uninstall codex${C.reset}            ${C.gray}Remove fleet's Codex hooks + config${C.reset}`,
+      `    ${C.idle}fleet uninstall pi${C.reset}               ${C.gray}Remove fleet's pi extension${C.reset}`,
       `    ${C.idle}fleet doctor${C.reset}                     ${C.gray}Health check${C.reset}`,
       '',
       `  ${C.bold}Tmux${C.reset}`,
@@ -437,9 +440,13 @@ async function handleCli(args: string[]): Promise<number | null> {
       return runExplain(session, states, statusDirs, showSnapshot);
     }
     case 'install':
-      return args[1] === 'codex' ? runInstallCodex() : runInstall();
+      if (args[1] === 'codex') return runInstallCodex();
+      if (args[1] === 'pi') return runInstallPi();
+      return runInstall();
     case 'uninstall':
-      return args[1] === 'codex' ? runUninstallCodex() : runUninstall();
+      if (args[1] === 'codex') return runUninstallCodex();
+      if (args[1] === 'pi') return runUninstallPi();
+      return runUninstall();
     case 'doctor':
       return runDoctor();
     case 'reconcile': {

--- a/index.ts
+++ b/index.ts
@@ -24,6 +24,7 @@ import { scrapePane } from './src/state/scraper.ts';
 import { loadRenames, saveRename } from './src/state/rename.ts';
 import { AgentStatus, ACK_ALL_RANGE, extractClaudeName, type AgentState } from './src/state/types.ts';
 import { AgentRegistry } from './src/agents/registry.ts';
+import type { AgentDir } from './src/agents/config.ts';
 import { listPanesResult, switchClient, killPane, gitBranch } from './src/tmux/sessions.ts';
 import { detectPorts } from './src/tmux/ports.ts';
 import { sendKeys, sendRawKey } from './src/tmux/send.ts';
@@ -31,6 +32,7 @@ import { runStatus } from './src/cli/status.ts';
 import { runNext } from './src/cli/next.ts';
 import { runSend } from './src/cli/send.ts';
 import { runInstall, runUninstall } from './src/cli/install.ts';
+import { runInstallCodex, runUninstallCodex } from './src/cli/install-codex.ts';
 import { runDoctor } from './src/cli/doctor.ts';
 import { runReconcile } from './src/cli/reconcile.ts';
 import { runExplain } from './src/cli/explain.ts';
@@ -73,7 +75,9 @@ function printHelp(): number {
       '',
       `  ${C.bold}Plugin${C.reset}`,
       `    ${C.idle}fleet install${C.reset}                    ${C.gray}Register as Claude Code plugin${C.reset}`,
+      `    ${C.idle}fleet install codex${C.reset}              ${C.gray}Wire fleet into Codex's hooks + config${C.reset}`,
       `    ${C.idle}fleet uninstall${C.reset}                  ${C.gray}Remove plugin registration${C.reset}`,
+      `    ${C.idle}fleet uninstall codex${C.reset}            ${C.gray}Remove fleet's Codex hooks + config${C.reset}`,
       `    ${C.idle}fleet doctor${C.reset}                     ${C.gray}Health check${C.reset}`,
       '',
       `  ${C.bold}Tmux${C.reset}`,
@@ -88,7 +92,7 @@ function printHelp(): number {
 }
 
 function verifyPaneState(state: AgentState, statusDirs: string[]): void {
-  const scraped = scrapePane(state.paneId);
+  const scraped = scrapePane(state.paneId, state.agentType || 'claude');
   if (scraped === null) return;
   if (scraped === state.status) return;
 
@@ -186,8 +190,9 @@ function acknowledgePane(paneId: string, statusDirs: string[]): void {
 // Acknowledge every ready agent across all tracked panes in one sweep — backs
 // the status-line "clear all" chip. Reuses acknowledgePane's ready-only gating,
 // so working/waiting/asking agents are left untouched.
-function acknowledgeAllReady(statusDirs: string[]): void {
-  for (const hook of readAllStatusDirs(statusDirs)) {
+function acknowledgeAllReady(dirs: AgentDir[]): void {
+  const statusDirs = dirs.map((d) => d.statusDir);
+  for (const hook of readAllStatusDirs(dirs)) {
     acknowledgePane(hook.pane, statusDirs);
   }
 }
@@ -224,7 +229,7 @@ function reloadRenameCache(): void {
   renameCache = loadRenames();
 }
 
-function refreshSlowCaches(panes: { paneId: string; currentPath: string }[]): void {
+function refreshSlowCaches(panes: { paneId: string; currentPath: string }[], dirs: AgentDir[]): void {
   const paths = new Set<string>();
   for (const p of panes) paths.add(p.currentPath);
   branchCache.clear();
@@ -242,11 +247,21 @@ function refreshSlowCaches(panes: { paneId: string; currentPath: string }[]): vo
   } catch {}
   portCache = newPorts;
 
+  // Which agent owns each pane, so the scraper picks that agent's detection
+  // manifest. Scraping runs before refreshStates derives agentType, so learn it
+  // up front from the status files. Freshness-wins on a pane-id collision across
+  // dirs — same rule as refreshStates' hookByPane.
+  const paneAgent = new Map<string, { agent: string; ts: number }>();
+  for (const h of readAllStatusDirs(dirs)) {
+    const prev = paneAgent.get(h.pane);
+    if (!prev || h.ts > prev.ts) paneAgent.set(h.pane, { agent: h.agent, ts: h.ts });
+  }
+
   // Layer 3: pane scraping (~50ms per pane) — slow cycle only
   const seen = new Set<string>();
   for (const p of panes) {
     seen.add(p.paneId);
-    scrapeCache.set(p.paneId, scrapePane(p.paneId));
+    scrapeCache.set(p.paneId, scrapePane(p.paneId, paneAgent.get(p.paneId)?.agent ?? 'claude'));
   }
   for (const paneId of scrapeCache.keys()) {
     if (!seen.has(paneId)) scrapeCache.delete(paneId);
@@ -254,14 +269,19 @@ function refreshSlowCaches(panes: { paneId: string; currentPath: string }[]): vo
 }
 
 // Fast refresh: ONE tmux call + status file reads + last-line JSONL reads. No git, no lsof.
-function refreshStates(statusDirs: string[]): AgentState[] {
-  const hookStatuses = readAllStatusDirs(statusDirs);
+function refreshStates(dirs: AgentDir[]): AgentState[] {
+  const hookStatuses = readAllStatusDirs(dirs);
   const { ok: tmuxOk, panes } = listPanesResult();
   lastTmuxOk = tmuxOk;
 
+  // tmux pane ids (%N) are server-global, so the same pane number can have a
+  // .status in two agents' dirs while only one agent truly occupies it. Keep the
+  // freshest record per pane; its `agent`/`statusDir` then drive agentType and
+  // the events read below.
   const hookByPane = new Map<string, (typeof hookStatuses)[number]>();
   for (const h of hookStatuses) {
-    hookByPane.set(h.pane, h);
+    const prev = hookByPane.get(h.pane);
+    if (!prev || h.ts > prev.ts) hookByPane.set(h.pane, h);
   }
 
   const states: AgentState[] = [];
@@ -272,20 +292,18 @@ function refreshStates(statusDirs: string[]): AgentState[] {
     let status: AgentStatus;
     let tool: string | null = null;
     let ts = Math.floor(Date.now() / 1000);
+    let agentType = ''; // shell pane: honestly no agent (cards.ts filters it out)
 
     if (hook) {
-      let eventStatus: AgentStatus | null = null;
-      for (const dir of statusDirs) {
-        const eventsFile = join(dir, `${pane.paneNum}.events.jsonl`);
-        const recent = readLastEvents(eventsFile, 12);
-        if (recent.length > 0) {
-          eventStatus = deriveStatusFromEvents(recent);
-          break;
-        }
-      }
+      // Read events from the WINNING hook's own dir (not a first-match scan
+      // across all dirs, which could read the wrong agent's stream on collision).
+      const eventsFile = join(hook.statusDir, `${pane.paneNum}.events.jsonl`);
+      const recent = readLastEvents(eventsFile, 12);
+      const eventStatus = recent.length > 0 ? deriveStatusFromEvents(recent) : null;
 
       tool = hook.tool || null;
       ts = hook.ts;
+      agentType = hook.agent;
 
       status = fuseState({
         hookState: hook.state,
@@ -313,7 +331,7 @@ function refreshStates(statusDirs: string[]): AgentState[] {
       branch: branchCache.get(pane.currentPath) ?? null,
       ports: portCache.get(pane.paneId) ?? [],
       ts,
-      agentType: 'claude',
+      agentType,
     });
   }
 
@@ -321,10 +339,10 @@ function refreshStates(statusDirs: string[]): AgentState[] {
 }
 
 // Full refresh: runs slow caches then fast refresh
-function fullRefreshStates(statusDirs: string[]): AgentState[] {
+function fullRefreshStates(dirs: AgentDir[]): AgentState[] {
   const panes = listPanesResult().panes;
-  refreshSlowCaches(panes);
-  return refreshStates(statusDirs);
+  refreshSlowCaches(panes, dirs);
+  return refreshStates(dirs);
 }
 
 async function handleCli(args: string[]): Promise<number | null> {
@@ -335,12 +353,13 @@ async function handleCli(args: string[]): Promise<number | null> {
   if (!command) return null;
 
   const registry = new AgentRegistry();
-  const statusDirs = registry.statusDirs();
+  const dirs = registry.all(); // AgentDir[] for the read path (name rides with the data)
+  const statusDirs = registry.statusDirs(); // string[] for the file-locating write helpers
   reloadRenameCache();
 
   switch (command) {
     case 'status': {
-      const states = fullRefreshStates(statusDirs);
+      const states = fullRefreshStates(dirs);
       const output = runStatus(args.slice(1), states);
       if (output.length > 0) process.stdout.write(output + '\n');
       // Emit runs even when output is empty: an all-calm bar still needs every
@@ -350,7 +369,7 @@ async function handleCli(args: string[]): Promise<number | null> {
       return 0;
     }
     case 'next': {
-      const states = fullRefreshStates(statusDirs);
+      const states = fullRefreshStates(dirs);
       return runNext(states);
     }
     case 'ack': {
@@ -363,7 +382,7 @@ async function handleCli(args: string[]): Promise<number | null> {
         return 1;
       }
       if (target === ACK_ALL_RANGE) {
-        acknowledgeAllReady(statusDirs);
+        acknowledgeAllReady(dirs);
       } else {
         acknowledgePane(target, statusDirs);
       }
@@ -381,7 +400,7 @@ async function handleCli(args: string[]): Promise<number | null> {
         return 1;
       }
       if (target === ACK_ALL_RANGE) {
-        acknowledgeAllReady(statusDirs);
+        acknowledgeAllReady(dirs);
         refreshTmuxStatus();
         return 0;
       }
@@ -403,7 +422,7 @@ async function handleCli(args: string[]): Promise<number | null> {
         process.stderr.write('Usage: fleet send <session> <prompt>\n');
         return 1;
       }
-      const states = fullRefreshStates(statusDirs);
+      const states = fullRefreshStates(dirs);
       const force = args.includes('--force');
       return runSend(session, prompt, states, force);
     }
@@ -414,13 +433,13 @@ async function handleCli(args: string[]): Promise<number | null> {
         return 1;
       }
       const showSnapshot = args.includes('--show-snapshot');
-      const states = fullRefreshStates(statusDirs);
+      const states = fullRefreshStates(dirs);
       return runExplain(session, states, statusDirs, showSnapshot);
     }
     case 'install':
-      return runInstall();
+      return args[1] === 'codex' ? runInstallCodex() : runInstall();
     case 'uninstall':
-      return runUninstall();
+      return args[1] === 'codex' ? runUninstallCodex() : runUninstall();
     case 'doctor':
       return runDoctor();
     case 'reconcile': {
@@ -445,7 +464,7 @@ async function handleCli(args: string[]): Promise<number | null> {
         session: args[1],
         stateArg: stateIdx >= 0 ? args[stateIdx + 1] : undefined,
         timeoutArg: timeoutIdx >= 0 ? args[timeoutIdx + 1] : undefined,
-        getStates: () => fullRefreshStates(statusDirs),
+        getStates: () => fullRefreshStates(dirs),
         sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
         now: () => Date.now(),
       });
@@ -524,7 +543,7 @@ function handleSendInput(app: TuiApp, key: ReturnType<typeof parseKeyEvent>, _fi
   }
 }
 
-function handleRenameInput(app: TuiApp, key: ReturnType<typeof parseKeyEvent>, statusDirs: string[]): void {
+function handleRenameInput(app: TuiApp, key: ReturnType<typeof parseKeyEvent>, dirs: AgentDir[]): void {
   switch (key.type) {
     case 'escape':
       app.exitRename();
@@ -540,7 +559,7 @@ function handleRenameInput(app: TuiApp, key: ReturnType<typeof parseKeyEvent>, s
       if (selected) {
         saveRename(selected.session, app.renameBuffer); // empty buffer clears
         reloadRenameCache();
-        app.updateStates(refreshStates(statusDirs)); // re-resolve customName
+        app.updateStates(refreshStates(dirs)); // re-resolve customName
       }
       app.exitRename();
       break;
@@ -548,7 +567,7 @@ function handleRenameInput(app: TuiApp, key: ReturnType<typeof parseKeyEvent>, s
   }
 }
 
-function handleKillConfirmInput(app: TuiApp, key: ReturnType<typeof parseKeyEvent>, statusDirs: string[]): void {
+function handleKillConfirmInput(app: TuiApp, key: ReturnType<typeof parseKeyEvent>, dirs: AgentDir[]): void {
   if (key.type === 'char' && (key.char === 'y' || key.char === 'x')) {
     const selected = app.selectedState();
     if (selected && canKillSession(selected).ok) {
@@ -557,7 +576,7 @@ function handleKillConfirmInput(app: TuiApp, key: ReturnType<typeof parseKeyEven
       } catch {
         // Pane may already be gone — refresh will drop it either way
       }
-      app.updateStates(fullRefreshStates(statusDirs));
+      app.updateStates(fullRefreshStates(dirs));
     }
   }
   // Any other key (or a rejected confirm) just returns to the prior mode.
@@ -586,7 +605,8 @@ function handlePassthroughInput(app: TuiApp, buf: Buffer): void {
 
 async function launchTui(): Promise<number> {
   const registry = new AgentRegistry();
-  const statusDirs = registry.statusDirs();
+  const dirs = registry.all(); // read path (agent name rides with each status)
+  const statusDirs = registry.statusDirs(); // watcher + file-locating write helpers
   const app = new TuiApp();
 
   const args = process.argv.slice(2);
@@ -616,7 +636,7 @@ async function launchTui(): Promise<number> {
   };
 
   const doRefresh = () => {
-    const states = refreshStates(statusDirs);
+    const states = refreshStates(dirs);
     app.updateStates(states);
     app.tmuxDown = !lastTmuxOk;
     app.hooksMissing = !statusDirs.some((d) => existsSync(d));
@@ -624,7 +644,7 @@ async function launchTui(): Promise<number> {
   };
 
   const doFullRefresh = () => {
-    const states = fullRefreshStates(statusDirs);
+    const states = fullRefreshStates(dirs);
     app.updateStates(states);
     app.tmuxDown = !lastTmuxOk;
     app.hooksMissing = !statusDirs.some((d) => existsSync(d));
@@ -733,7 +753,7 @@ async function launchTui(): Promise<number> {
             if (idx >= 0) app.selectedIndex = idx;
             if (sel.status === AgentStatus.DONE) {
               acknowledgePane(sel.paneId, statusDirs);
-              app.updateStates(refreshStates(statusDirs));
+              app.updateStates(refreshStates(dirs));
             }
             needsRender = true;
           }
@@ -768,7 +788,7 @@ async function launchTui(): Promise<number> {
       }
 
       if (app.mode === TuiMode.CONFIRM_KILL) {
-        handleKillConfirmInput(app, key, statusDirs);
+        handleKillConfirmInput(app, key, dirs);
         needsRender = true;
         return;
       }
@@ -780,7 +800,7 @@ async function launchTui(): Promise<number> {
       }
 
       if (app.mode === TuiMode.RENAME) {
-        handleRenameInput(app, key, statusDirs);
+        handleRenameInput(app, key, dirs);
         needsRender = true;
         return;
       }
@@ -836,7 +856,7 @@ async function launchTui(): Promise<number> {
                 }
               }
               {
-                const states = fullRefreshStates(statusDirs);
+                const states = fullRefreshStates(dirs);
                 runNext(states);
                 finish(0);
                 return;

--- a/index.ts
+++ b/index.ts
@@ -34,6 +34,7 @@ import { runDoctor } from './src/cli/doctor.ts';
 import { runReconcile } from './src/cli/reconcile.ts';
 import { runExplain } from './src/cli/explain.ts';
 import { runStatusLineInject, runStatusLineRemove } from './src/cli/statusline.ts';
+import { runWait } from './src/cli/wait.ts';
 import { readFileSync, writeFileSync, appendFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -65,6 +66,7 @@ function printHelp(): number {
       `    ${C.idle}fleet status${C.reset} --statusline        ${C.gray}Render multi-agent tmux status line${C.reset}`,
       `    ${C.idle}fleet next${C.reset}                       ${C.gray}Jump to next waiting agent${C.reset}`,
       `    ${C.idle}fleet send${C.reset} <session> <prompt>    ${C.gray}Send prompt to session${C.reset}`,
+      `    ${C.idle}fleet wait${C.reset} <session> --state <s> ${C.gray}Block until agent reaches state${C.reset}`,
       `    ${C.idle}fleet explain${C.reset} <session>          ${C.gray}Trace how a session's state was decided${C.reset}`,
       `    ${C.idle}fleet reconcile${C.reset} [--dry-run]      ${C.gray}Sweep orphan status files${C.reset}`,
       '',
@@ -314,7 +316,7 @@ function fullRefreshStates(statusDirs: string[]): AgentState[] {
   return refreshStates(statusDirs);
 }
 
-function handleCli(args: string[]): number | null {
+async function handleCli(args: string[]): Promise<number | null> {
   if (args.includes('--version') || args.includes('-v')) return printVersion();
   if (args.includes('--help') || args.includes('-h')) return printHelp();
 
@@ -419,6 +421,18 @@ function handleCli(args: string[]): number | null {
       }
       process.stderr.write('Usage: fleet statusline --inject | --remove\n');
       return 1;
+    }
+    case 'wait': {
+      const stateIdx = args.indexOf('--state');
+      const timeoutIdx = args.indexOf('--timeout');
+      return await runWait({
+        session: args[1],
+        stateArg: stateIdx >= 0 ? args[stateIdx + 1] : undefined,
+        timeoutArg: timeoutIdx >= 0 ? args[timeoutIdx + 1] : undefined,
+        getStates: () => fullRefreshStates(statusDirs),
+        sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+        now: () => Date.now(),
+      });
     }
     default:
       process.stderr.write(`Unknown command: ${command}\n`);
@@ -874,7 +888,7 @@ async function launchTui(): Promise<number> {
 
 async function main(): Promise<number> {
   const args = process.argv.slice(2);
-  const cliResult = handleCli(args);
+  const cliResult = await handleCli(args);
   if (cliResult !== null) return cliResult;
   return launchTui();
 }

--- a/index.ts
+++ b/index.ts
@@ -21,6 +21,7 @@ import { readAllStatusDirs, watchStatusDirs } from './src/state/hooks.ts';
 import { readLastEvents, deriveStatusFromEvents } from './src/state/events.ts';
 import { acknowledgePlan } from './src/state/acknowledge.ts';
 import { scrapePane } from './src/state/scraper.ts';
+import { loadRenames, saveRename } from './src/state/rename.ts';
 import { AgentStatus, ACK_ALL_RANGE, extractClaudeName, type AgentState } from './src/state/types.ts';
 import { AgentRegistry } from './src/agents/registry.ts';
 import { listPanesResult, switchClient, killPane, gitBranch } from './src/tmux/sessions.ts';
@@ -125,10 +126,10 @@ function verifyPaneState(state: AgentState, statusDirs: string[]): void {
           return;
         }
         const updated = JSON.stringify({
+          ...existing, // preserve tool (enriched label) + any custom field
           state: newHookState,
           pane: state.paneId,
           session: state.session,
-          tool: '',
           ts: now,
           tmux_pid: tmuxPid,
         });
@@ -215,6 +216,14 @@ let portCache = new Map<string, number[]>();
 const scrapeCache = new Map<string, AgentStatus | null>();
 let lastTmuxOk = true;
 
+// User renames (session name → custom label), loaded once per entry point and
+// re-read after each rename. A display overlay only — grouping/selection still
+// key off the real session name.
+let renameCache = new Map<string, string>();
+function reloadRenameCache(): void {
+  renameCache = loadRenames();
+}
+
 function refreshSlowCaches(panes: { paneId: string; currentPath: string }[]): void {
   const paths = new Set<string>();
   for (const p of panes) paths.add(p.currentPath);
@@ -297,6 +306,7 @@ function refreshStates(statusDirs: string[]): AgentState[] {
       window: pane.windowName,
       windowId: pane.windowId,
       claudeName: extractClaudeName(pane.paneTitle),
+      customName: renameCache.get(pane.sessionName) ?? null,
       status,
       tool,
       project: shortenPath(pane.currentPath),
@@ -326,6 +336,7 @@ async function handleCli(args: string[]): Promise<number | null> {
 
   const registry = new AgentRegistry();
   const statusDirs = registry.statusDirs();
+  reloadRenameCache();
 
   switch (command) {
     case 'status': {
@@ -513,6 +524,30 @@ function handleSendInput(app: TuiApp, key: ReturnType<typeof parseKeyEvent>, _fi
   }
 }
 
+function handleRenameInput(app: TuiApp, key: ReturnType<typeof parseKeyEvent>, statusDirs: string[]): void {
+  switch (key.type) {
+    case 'escape':
+      app.exitRename();
+      break;
+    case 'backspace':
+      app.renameBuffer = app.renameBuffer.slice(0, -1);
+      break;
+    case 'char':
+      app.renameBuffer += key.char;
+      break;
+    case 'enter': {
+      const selected = app.selectedState();
+      if (selected) {
+        saveRename(selected.session, app.renameBuffer); // empty buffer clears
+        reloadRenameCache();
+        app.updateStates(refreshStates(statusDirs)); // re-resolve customName
+      }
+      app.exitRename();
+      break;
+    }
+  }
+}
+
 function handleKillConfirmInput(app: TuiApp, key: ReturnType<typeof parseKeyEvent>, statusDirs: string[]): void {
   if (key.type === 'char' && (key.char === 'y' || key.char === 'x')) {
     const selected = app.selectedState();
@@ -596,6 +631,7 @@ async function launchTui(): Promise<number> {
     needsRender = true;
   };
 
+  reloadRenameCache();
   doFullRefresh();
 
   // Debounce watcher-triggered refreshes — hooks fire rapidly
@@ -743,6 +779,12 @@ async function launchTui(): Promise<number> {
         return;
       }
 
+      if (app.mode === TuiMode.RENAME) {
+        handleRenameInput(app, key, statusDirs);
+        needsRender = true;
+        return;
+      }
+
       // Filter mode
       if (app.isFiltering()) {
         handleFilterInput(app, key, finish, statusDirs);
@@ -817,6 +859,11 @@ async function launchTui(): Promise<number> {
               if (app.selectedState()) app.enterKillConfirm();
               break;
             }
+            case 'R': {
+              const sel = app.selectedState();
+              if (sel) app.enterRename(sel.customName ?? '');
+              break;
+            }
             case '?':
               app.mode = TuiMode.HELP;
               break;
@@ -867,7 +914,7 @@ async function launchTui(): Promise<number> {
       tick();
     });
 
-    const isTyping = () => app.mode === TuiMode.SEND || app.isFiltering();
+    const isTyping = () => app.mode === TuiMode.SEND || app.mode === TuiMode.RENAME || app.isFiltering();
 
     // Fast timer: keep running in passthrough (preview needs live updates), skip during typing
     refreshTimer = setInterval(() => {

--- a/index.ts
+++ b/index.ts
@@ -33,7 +33,7 @@ import { runInstall, runUninstall } from './src/cli/install.ts';
 import { runDoctor } from './src/cli/doctor.ts';
 import { runReconcile } from './src/cli/reconcile.ts';
 import { runExplain } from './src/cli/explain.ts';
-import { runStatusLineInject, runStatusLineRemove } from './src/cli/statusline.ts';
+import { runStatusLineInject, runStatusLineRemove, emitWindowColors, rollupEnabled } from './src/cli/statusline.ts';
 import { runWait } from './src/cli/wait.ts';
 import { readFileSync, writeFileSync, appendFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
@@ -295,6 +295,7 @@ function refreshStates(statusDirs: string[]): AgentState[] {
       paneNum: pane.paneNum,
       session: pane.sessionName,
       window: pane.windowName,
+      windowId: pane.windowId,
       claudeName: extractClaudeName(pane.paneTitle),
       status,
       tool,
@@ -331,6 +332,10 @@ async function handleCli(args: string[]): Promise<number | null> {
       const states = fullRefreshStates(statusDirs);
       const output = runStatus(args.slice(1), states);
       if (output.length > 0) process.stdout.write(output + '\n');
+      // Emit runs even when output is empty: an all-calm bar still needs every
+      // window UNSET to clear stale tints. Gated on --statusline (the single
+      // per-redraw fleet call) and the opt-in @fleet_rollup option.
+      if (args.includes('--statusline') && rollupEnabled()) emitWindowColors(states);
       return 0;
     }
     case 'next': {

--- a/src/agents/config.test.ts
+++ b/src/agents/config.test.ts
@@ -1,5 +1,7 @@
-import { describe, expect, test } from 'bun:test';
-import { loadAgentDirs } from './config.ts';
+import { afterEach, describe, expect, test } from 'bun:test';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { CLAUDE_STATUS_DIR, loadAgentDirs } from './config.ts';
 
 describe('loadAgentDirs', () => {
   test('returns array of agent dirs', () => {
@@ -15,5 +17,29 @@ describe('loadAgentDirs', () => {
       expect(typeof dir.name).toBe('string');
       expect(typeof dir.statusDir).toBe('string');
     }
+  });
+});
+
+// Dir-drift guard: the read side (this constant, used by loadAgentDirs) must
+// name the exact dir the write side (hooks/lib.sh's FLEET_STATUS_DIR default)
+// creates. If they drift, adopting the documented config silently breaks Claude.
+describe('CLAUDE_STATUS_DIR drift guard', () => {
+  const originalXdg = process.env.XDG_CONFIG_HOME;
+  afterEach(() => {
+    if (originalXdg === undefined) delete process.env.XDG_CONFIG_HOME;
+    else process.env.XDG_CONFIG_HOME = originalXdg;
+  });
+
+  test('equals the ~/.cache/claude-status dir the hook writes', () => {
+    expect(CLAUDE_STATUS_DIR).toBe(join(homedir(), '.cache', 'claude-status'));
+    expect(CLAUDE_STATUS_DIR.endsWith('/.cache/claude-status')).toBe(true);
+  });
+
+  test('the claude fallback, when present, uses the canonical constant', () => {
+    // Point config discovery at a dir with no agents.json/agents.conf so
+    // loadAgentDirs is forced down the hardcoded fallback branch.
+    process.env.XDG_CONFIG_HOME = join(homedir(), '.cache', 'claude-status', '__fleet_no_config_here__');
+    const claude = loadAgentDirs().find((d) => d.name === 'claude');
+    if (claude) expect(claude.statusDir).toBe(CLAUDE_STATUS_DIR);
   });
 });

--- a/src/agents/config.ts
+++ b/src/agents/config.ts
@@ -21,6 +21,11 @@ export const CLAUDE_STATUS_DIR = join(HOME, '.cache', 'claude-status');
 // FLEET_STATUS_DIR must resolve to this same dir or detection silently breaks.
 export const CODEX_STATUS_DIR = join(HOME, '.cache', 'codex-status');
 
+// pi's canonical status dir. Same naming + same drift contract as the others:
+// install-pi.ts (mkdir + agents.json entry) and the fleet-pi extension's
+// FLEET_PI_STATUS_DIR default must resolve here or pi detection silently breaks.
+export const PI_STATUS_DIR = join(HOME, '.cache', 'pi-status');
+
 export function loadAgentDirs(): AgentDir[] {
   const configDir = process.env.XDG_CONFIG_HOME ?? join(HOME, '.config');
 
@@ -61,8 +66,7 @@ export function loadAgentDirs(): AgentDir[] {
   const fallback: AgentDir[] = [];
   if (existsSync(CLAUDE_STATUS_DIR)) fallback.push({ name: 'claude', statusDir: CLAUDE_STATUS_DIR });
   if (existsSync(CODEX_STATUS_DIR)) fallback.push({ name: 'codex', statusDir: CODEX_STATUS_DIR });
-  const piDir = join(HOME, '.cache', 'pi-status');
-  if (existsSync(piDir)) fallback.push({ name: 'pi', statusDir: piDir });
+  if (existsSync(PI_STATUS_DIR)) fallback.push({ name: 'pi', statusDir: PI_STATUS_DIR });
 
   return fallback;
 }

--- a/src/agents/config.ts
+++ b/src/agents/config.ts
@@ -9,6 +9,11 @@ export interface AgentDir {
 
 const HOME = homedir();
 
+// Claude's canonical status dir. Named once here (the read side) so it is
+// testable and can be asserted equal to what hooks/lib.sh writes (the write
+// side). These two must never drift: a mismatch silently breaks detection.
+export const CLAUDE_STATUS_DIR = join(HOME, '.cache', 'claude-status');
+
 export function loadAgentDirs(): AgentDir[] {
   const configDir = process.env.XDG_CONFIG_HOME ?? join(HOME, '.config');
 
@@ -47,8 +52,7 @@ export function loadAgentDirs(): AgentDir[] {
   }
 
   const fallback: AgentDir[] = [];
-  const claudeDir = join(HOME, '.cache', 'claude-status');
-  if (existsSync(claudeDir)) fallback.push({ name: 'claude', statusDir: claudeDir });
+  if (existsSync(CLAUDE_STATUS_DIR)) fallback.push({ name: 'claude', statusDir: CLAUDE_STATUS_DIR });
   const piDir = join(HOME, '.cache', 'pi-status');
   if (existsSync(piDir)) fallback.push({ name: 'pi', statusDir: piDir });
 

--- a/src/agents/config.ts
+++ b/src/agents/config.ts
@@ -14,6 +14,13 @@ const HOME = homedir();
 // side). These two must never drift: a mismatch silently breaks detection.
 export const CLAUDE_STATUS_DIR = join(HOME, '.cache', 'claude-status');
 
+// Codex's canonical status dir (Phase 3). Mirrors CLAUDE_STATUS_DIR's naming
+// (~/.cache/<agent>-status) because Phase 2 kept claude at ~/.cache/claude-status
+// rather than moving everything under ~/.cache/fleet/. This is the single source
+// of truth: install-codex.ts (mkdir + agents.json entry) and the Codex hook's
+// FLEET_STATUS_DIR must resolve to this same dir or detection silently breaks.
+export const CODEX_STATUS_DIR = join(HOME, '.cache', 'codex-status');
+
 export function loadAgentDirs(): AgentDir[] {
   const configDir = process.env.XDG_CONFIG_HOME ?? join(HOME, '.config');
 
@@ -53,6 +60,7 @@ export function loadAgentDirs(): AgentDir[] {
 
   const fallback: AgentDir[] = [];
   if (existsSync(CLAUDE_STATUS_DIR)) fallback.push({ name: 'claude', statusDir: CLAUDE_STATUS_DIR });
+  if (existsSync(CODEX_STATUS_DIR)) fallback.push({ name: 'codex', statusDir: CODEX_STATUS_DIR });
   const piDir = join(HOME, '.cache', 'pi-status');
   if (existsSync(piDir)) fallback.push({ name: 'pi', statusDir: piDir });
 

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -15,10 +15,6 @@ export class AgentRegistry {
     return this.dirs.map((d) => d.statusDir);
   }
 
-  nameForDir(dir: string): string | null {
-    return this.dirs.find((d) => d.statusDir === dir)?.name ?? null;
-  }
-
   reload(): void {
     this.dirs = loadAgentDirs();
   }

--- a/src/cli/explain.test.ts
+++ b/src/cli/explain.test.ts
@@ -37,6 +37,7 @@ const makeState = (o: Partial<AgentState> = {}): AgentState => ({
   window: 'main',
   windowId: '@1',
   claudeName: null,
+  customName: null,
   status: AgentStatus.IDLE,
   tool: null,
   project: '~/dev',

--- a/src/cli/explain.test.ts
+++ b/src/cli/explain.test.ts
@@ -35,6 +35,7 @@ const makeState = (o: Partial<AgentState> = {}): AgentState => ({
   paneNum: 99,
   session: 'other',
   window: 'main',
+  windowId: '@1',
   claudeName: null,
   status: AgentStatus.IDLE,
   tool: null,

--- a/src/cli/explain.test.ts
+++ b/src/cli/explain.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from 'bun:test';
+import { renderExplain, runExplain, type ExplainBlock } from './explain.ts';
+import { AgentStatus, type AgentState, type StateDecision } from '../state/types.ts';
+
+const now = Math.floor(Date.now() / 1000);
+
+const makeDecision = (o: Partial<StateDecision> = {}): StateDecision => ({
+  final: AgentStatus.DONE,
+  candidates: { hook: AgentStatus.DONE, event: AgentStatus.DONE, scrape: AgentStatus.IDLE },
+  hookTs: now - 12,
+  eventTs: now - 12,
+  now,
+  winner: 'event',
+  reason: 'derived from the latest JSONL event',
+  workingTimeoutFired: false,
+  freshnessEvaluated: false,
+  scrapeRuleId: 'idle.prompt',
+  ...o,
+});
+
+const makeBlock = (o: Partial<ExplainBlock> = {}): ExplainBlock => ({
+  session: 'api',
+  paneId: '%42',
+  agentType: 'claude',
+  statusFile: '~/.cache/claude-status/42.status',
+  finalStatus: AgentStatus.DONE,
+  decision: makeDecision(),
+  snapshot: null,
+  scrapeAvailable: true,
+  ...o,
+});
+
+const makeState = (o: Partial<AgentState> = {}): AgentState => ({
+  paneId: '%99',
+  paneNum: 99,
+  session: 'other',
+  window: 'main',
+  claudeName: null,
+  status: AgentStatus.IDLE,
+  tool: null,
+  project: '~/dev',
+  branch: 'main',
+  ports: [],
+  ts: now,
+  agentType: 'claude',
+  ...o,
+});
+
+describe('renderExplain', () => {
+  test('renders the final label and all three candidate rows', () => {
+    const out = renderExplain(makeBlock(), false);
+    expect(out).toContain("session 'api'");
+    expect(out).toContain('%42');
+    expect(out).toContain('ready'); // STATUS_DISPLAY[DONE].label
+    expect(out).toContain('(DONE)');
+    expect(out).toContain('hook');
+    expect(out).toContain('event');
+    expect(out).toContain('scrape');
+  });
+
+  test('surfaces the winner, reason, and scrape rule id', () => {
+    const out = renderExplain(makeBlock(), false);
+    expect(out).toContain('winner');
+    expect(out).toContain('derived from the latest JSONL event');
+    expect(out).toContain('rule: idle.prompt');
+  });
+
+  test('annotates that DONE never comes from the scraper', () => {
+    const out = renderExplain(makeBlock(), false);
+    expect(out).toContain('DONE never comes from scrape');
+  });
+
+  test('reports the dead freshness branch as not evaluated (success criterion)', () => {
+    const out = renderExplain(makeBlock({ decision: makeDecision({ freshnessEvaluated: false }) }), false);
+    expect(out).toContain('not evaluated');
+    expect(out).toContain('live refresh is stateless');
+  });
+
+  test('reports freshness evaluated when the branch actually fired', () => {
+    const out = renderExplain(makeBlock({ decision: makeDecision({ freshnessEvaluated: true }) }), false);
+    expect(out).toContain('kept in-memory state');
+    expect(out).not.toContain('not evaluated');
+  });
+
+  test('renders the working-timeout line (not fired)', () => {
+    const out = renderExplain(makeBlock(), false);
+    expect(out).toContain('working-timeout');
+    expect(out).toContain('not fired');
+  });
+
+  test('renders the working-timeout line (fired)', () => {
+    const out = renderExplain(makeBlock({ decision: makeDecision({ workingTimeoutFired: true }) }), false);
+    expect(out).toContain('working-timeout');
+    expect(out).toContain('stale BUSY');
+    expect(out).not.toContain('not fired');
+  });
+
+  test('event candidate renders none when there is no event', () => {
+    const out = renderExplain(
+      makeBlock({
+        decision: makeDecision({
+          candidates: { hook: AgentStatus.DONE, event: null, scrape: AgentStatus.IDLE },
+          eventTs: null,
+        }),
+      }),
+      false,
+    );
+    // The event row shows "none" rather than a fabricated status.
+    const eventLine = out.split('\n').find((l) => l.trimStart().startsWith('event'))!;
+    expect(eventLine).toContain('none');
+  });
+
+  test('shell block renders shell and no decision', () => {
+    const out = renderExplain(makeBlock({ finalStatus: AgentStatus.SHELL, decision: null, statusFile: null }), false);
+    expect(out).toContain('shell');
+    expect(out).toContain('no agent hook');
+    expect(out).not.toContain('candidates');
+    expect(out).not.toContain('winner');
+  });
+
+  test('--show-snapshot frames the scraped buffer', () => {
+    const out = renderExplain(makeBlock({ snapshot: ['● Done!', '', '❯'] }), true);
+    expect(out).toContain('┌');
+    expect(out).toContain('│ ❯');
+    expect(out).toContain('└');
+    expect(out).not.toContain('run with --show-snapshot');
+  });
+
+  test('--show-snapshot reports scrape unavailable when capture failed', () => {
+    const out = renderExplain(makeBlock({ snapshot: null, scrapeAvailable: false }), true);
+    expect(out).toContain('scrape unavailable');
+    expect(out).not.toContain('┌');
+  });
+});
+
+describe('runExplain', () => {
+  test('unknown session returns 1', () => {
+    // No matching pane → returns before any tmux/fs access.
+    expect(runExplain('nope', [], [], false)).toBe(1);
+  });
+
+  test('session filter misses a differently-named session and returns 1', () => {
+    expect(runExplain('nope', [makeState({ session: 'other' })], [], false)).toBe(1);
+  });
+});

--- a/src/cli/explain.ts
+++ b/src/cli/explain.ts
@@ -1,0 +1,218 @@
+import {
+  AgentStatus,
+  STATUS_DISPLAY,
+  type AgentState,
+  type HookStatus,
+  type EventEntry,
+  type StateDecision,
+} from '../state/types.ts';
+import { fuseState } from '../state/engine.ts';
+import { scrapePaneDetailed, type ScrapeDetail } from '../state/scraper.ts';
+import { parseStatusFile } from '../state/hooks.ts';
+import { readLastEvents, deriveStatusFromEvents } from '../state/events.ts';
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+export interface ExplainBlock {
+  session: string;
+  paneId: string;
+  agentType: string;
+  statusFile: string | null; // resolved hook file, or null if hookless
+  finalStatus: AgentStatus;
+  decision: StateDecision | null; // null for a hookless/shell pane
+  snapshot: string[] | null; // set only with --show-snapshot; null if capture failed
+  scrapeAvailable: boolean;
+}
+
+const FRAME_WIDTH = 58;
+
+// Age of a delta in seconds. Pure (takes a delta, not a ts) so renderExplain
+// stays deterministic under test — it reads decision.now, never Date.now().
+function fmtAge(deltaSecs: number): string {
+  const d = Math.max(0, deltaSecs);
+  if (d < 5) return 'now';
+  if (d < 60) return `${d}s`;
+  if (d < 3600) return `${Math.floor(d / 60)}m`;
+  if (d < 86400) return `${Math.floor(d / 3600)}h`;
+  return `${Math.floor(d / 86400)}d`;
+}
+
+function candidateRow(label: string, status: string, age: string, detail: string): string {
+  return `    ${label.padEnd(10)}${status.padEnd(9)}${age.padEnd(8)}${detail}`.trimEnd();
+}
+
+function renderSnapshot(block: ExplainBlock): string[] {
+  const header = `  snapshot — bottom lines the scraper evaluated (pane ${block.paneId})`;
+  if (!block.scrapeAvailable || block.snapshot === null) {
+    return [header, '  scrape unavailable (capture-pane failed)'];
+  }
+  const border = '─'.repeat(FRAME_WIDTH);
+  const lines = [header, `  ┌${border}`];
+  for (const line of block.snapshot) lines.push(`  │ ${line}`);
+  lines.push(`  └${border}`);
+  return lines;
+}
+
+export function renderExplain(block: ExplainBlock, showSnapshot: boolean): string {
+  const display = STATUS_DISPLAY[block.finalStatus];
+  const lines: string[] = [
+    `fleet explain — session '${block.session}'  (pane ${block.paneId}, ${block.agentType})`,
+    '',
+    `  final   ${display.icon} ${display.label} (${block.finalStatus})`,
+    '',
+  ];
+
+  // A hookless pane is a plain shell — refreshStates never fuses it, so there is
+  // no decision to trace.
+  if (block.decision === null) {
+    lines.push('  shell (no agent hook) — nothing to fuse');
+    if (showSnapshot) {
+      lines.push('');
+      lines.push(...renderSnapshot(block));
+    }
+    return lines.join('\n');
+  }
+
+  const d = block.decision;
+  const enumOrNone = (s: AgentStatus | null): string => s ?? 'none';
+
+  // Candidate table — the mapped enum for each layer so all three are comparable.
+  lines.push('  ' + 'candidates'.padEnd(12) + 'status'.padEnd(9) + 'age'.padEnd(8) + 'detail');
+
+  const hookAge = fmtAge(d.now - d.hookTs);
+  lines.push(candidateRow('hook', enumOrNone(d.candidates.hook), hookAge, block.statusFile ?? ''));
+
+  const eventAge = d.eventTs !== null ? fmtAge(d.now - d.eventTs) : '—';
+  lines.push(candidateRow('event', enumOrNone(d.candidates.event), eventAge, ''));
+
+  // The scraper is re-read live at explain time, so its age is always "now". It
+  // structurally cannot emit DONE (a finished and a long-idle turn both show a
+  // bare prompt) — annotate so the trace can't be misread.
+  let scrapeStatus: string;
+  let scrapeDetail: string;
+  if (!block.scrapeAvailable) {
+    scrapeStatus = 'unavailable';
+    scrapeDetail = '';
+  } else if (d.candidates.scrape === null) {
+    scrapeStatus = 'none';
+    scrapeDetail = 'no rule matched  (DONE never comes from scrape)';
+  } else {
+    scrapeStatus = d.candidates.scrape;
+    scrapeDetail = `rule: ${d.scrapeRuleId ?? '—'}  (DONE never comes from scrape)`;
+  }
+  lines.push(candidateRow('scrape', scrapeStatus, block.scrapeAvailable ? 'now' : '—', scrapeDetail));
+
+  lines.push('');
+  lines.push('  decision');
+  lines.push(`    winner            ${d.winner}`);
+  lines.push(`    reason            ${d.reason}`);
+  lines.push(`    working-timeout   ${d.workingTimeoutFired ? 'fired (stale BUSY → idle)' : 'not fired'}`);
+  lines.push(
+    `    freshness         ${d.freshnessEvaluated ? 'evaluated — kept in-memory state' : 'not evaluated (live refresh is stateless)'}`,
+  );
+
+  if (showSnapshot) {
+    lines.push('');
+    lines.push(...renderSnapshot(block));
+  } else {
+    lines.push('');
+    lines.push('  run with --show-snapshot to print the scraped buffer');
+  }
+
+  return lines.join('\n');
+}
+
+// Scan statusDirs for the pane's .status file exactly as acknowledgePane does,
+// returning the parsed hook plus its resolved path (for the trace's source column).
+function findHook(paneId: string, statusDirs: string[]): { status: HookStatus; file: string } | null {
+  const paneNum = paneId.replace('%', '');
+  for (const dir of statusDirs) {
+    const file = join(dir, `${paneNum}.status`);
+    if (!existsSync(file)) continue;
+    try {
+      const status = parseStatusFile(readFileSync(file, 'utf-8'));
+      if (status && status.pane === paneId) return { status, file };
+    } catch {
+      // Unreadable — try the next dir
+    }
+  }
+  return null;
+}
+
+// Last 12 events for the pane, mirroring refreshStates' scan of statusDirs.
+function readRecentEvents(paneId: string, statusDirs: string[]): EventEntry[] {
+  const paneNum = paneId.replace('%', '');
+  for (const dir of statusDirs) {
+    const recent = readLastEvents(join(dir, `${paneNum}.events.jsonl`), 12);
+    if (recent.length > 0) return recent;
+  }
+  return [];
+}
+
+function toBlock(
+  state: AgentState,
+  hookFile: string,
+  finalStatus: AgentStatus,
+  decision: StateDecision,
+  detail: ScrapeDetail | null,
+  showSnapshot: boolean,
+): ExplainBlock {
+  return {
+    session: state.session,
+    paneId: state.paneId,
+    agentType: state.agentType,
+    statusFile: hookFile,
+    finalStatus,
+    decision,
+    snapshot: showSnapshot ? (detail?.snapshot ?? null) : null,
+    scrapeAvailable: detail !== null,
+  };
+}
+
+function shellBlock(state: AgentState, detail: ScrapeDetail | null, showSnapshot: boolean): ExplainBlock {
+  return {
+    session: state.session,
+    paneId: state.paneId,
+    agentType: state.agentType,
+    statusFile: null,
+    finalStatus: state.status,
+    decision: null,
+    snapshot: showSnapshot ? (detail?.snapshot ?? null) : null,
+    scrapeAvailable: detail !== null,
+  };
+}
+
+export function runExplain(session: string, states: AgentState[], statusDirs: string[], showSnapshot: boolean): number {
+  const targets = states.filter((s) => s.session === session);
+  if (targets.length === 0) {
+    process.stderr.write(`No agents found in session '${session}'\n`);
+    return 1;
+  }
+
+  const out: string[] = [];
+  for (const state of targets) {
+    // Re-scrape live so the ruleId and snapshot reflect the screen right now,
+    // not the cache the dashboard warmed on its last slow tick.
+    const detail = scrapePaneDetailed(state.paneId);
+    const hook = findHook(state.paneId, statusDirs);
+    if (!hook) {
+      out.push(renderExplain(shellBlock(state, detail, showSnapshot), showSnapshot));
+      continue;
+    }
+    const events = readRecentEvents(state.paneId, statusDirs);
+    const eventStatus = events.length > 0 ? deriveStatusFromEvents(events) : null;
+    const { status, decision } = fuseState({
+      hookState: hook.status.state,
+      hookTs: hook.status.ts,
+      eventStatus,
+      eventTs: events.at(-1)?.ts ?? null,
+      scrapeStatus: detail?.result.status ?? null,
+      scrapeRuleId: detail?.result.ruleId ?? null,
+      currentStatus: AgentStatus.IDLE, // mirror the live wiring exactly (index.ts:282-283)
+      currentTs: 0,
+    });
+    out.push(renderExplain(toBlock(state, hook.file, status, decision, detail, showSnapshot), showSnapshot));
+  }
+  process.stdout.write(out.join('\n\n') + '\n');
+  return 0;
+}

--- a/src/cli/install-codex.test.ts
+++ b/src/cli/install-codex.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  addCodexHooks,
+  ensureCodexFeatures,
+  removeAgentEntry,
+  removeCodexFeatures,
+  removeCodexHooks,
+  upsertAgentEntry,
+} from './install-codex.ts';
+
+// A representative absolute hook-script path (what install writes into hooks.json).
+const SCRIPT = '/Users/you/.local/share/fleet/plugin/hooks/codex/codex-hook.sh';
+
+interface HookCmd {
+  type?: string;
+  command?: string;
+  timeout?: number;
+}
+interface HookEntry {
+  hooks?: HookCmd[];
+}
+interface HooksDoc {
+  hooks?: Record<string, HookEntry[]>;
+}
+interface AgentsDoc {
+  agents: { name: string; statusDir: string }[];
+}
+
+let workDir: string;
+const readJson = <T>(p: string): T => JSON.parse(readFileSync(p, 'utf8')) as T;
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'fleet-codex-test-'));
+});
+afterEach(() => {
+  rmSync(workDir, { recursive: true, force: true });
+});
+
+describe('addCodexHooks / removeCodexHooks', () => {
+  test('creates PreToolUse+Stop fleet entries on a missing file', () => {
+    const p = join(workDir, 'hooks.json');
+    addCodexHooks(p, SCRIPT);
+    const doc = readJson<HooksDoc>(p);
+    expect(doc.hooks!.PreToolUse).toHaveLength(1);
+    expect(doc.hooks!.Stop).toHaveLength(1);
+    expect(doc.hooks!.PreToolUse![0]!.hooks![0]!.command).toBe(`bash ${SCRIPT} PreToolUse`);
+    expect(doc.hooks!.Stop![0]!.hooks![0]!.command).toBe(`bash ${SCRIPT} Stop`);
+    expect(doc.hooks!.PreToolUse![0]!.hooks![0]!.timeout).toBe(5000);
+  });
+
+  test('running twice does not duplicate fleet entries', () => {
+    const p = join(workDir, 'hooks.json');
+    addCodexHooks(p, SCRIPT);
+    const after1 = readFileSync(p, 'utf8');
+    addCodexHooks(p, SCRIPT);
+    expect(readFileSync(p, 'utf8')).toBe(after1);
+    const doc = readJson<HooksDoc>(p);
+    expect(doc.hooks!.PreToolUse).toHaveLength(1);
+    expect(doc.hooks!.Stop).toHaveLength(1);
+  });
+
+  test('preserves a pre-existing user entry, appends fleet, and removes only fleet on uninstall', () => {
+    const p = join(workDir, 'hooks.json');
+    writeFileSync(
+      p,
+      JSON.stringify(
+        {
+          hooks: {
+            PreToolUse: [{ hooks: [{ type: 'command', command: 'claude-status-hook PreToolUse', timeout: 5000 }] }],
+            Stop: [{ hooks: [{ type: 'command', command: 'claude-status-hook Stop', timeout: 5000 }] }],
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    addCodexHooks(p, SCRIPT);
+    let doc = readJson<HooksDoc>(p);
+    expect(doc.hooks!.PreToolUse).toHaveLength(2);
+    expect(doc.hooks!.PreToolUse![0]!.hooks![0]!.command).toBe('claude-status-hook PreToolUse'); // user preserved, first
+    expect(doc.hooks!.PreToolUse![1]!.hooks![0]!.command).toContain('codex-hook.sh');
+
+    removeCodexHooks(p);
+    doc = readJson<HooksDoc>(p);
+    expect(doc.hooks!.PreToolUse).toHaveLength(1);
+    expect(doc.hooks!.PreToolUse![0]!.hooks![0]!.command).toBe('claude-status-hook PreToolUse');
+    expect(doc.hooks!.Stop).toHaveLength(1);
+    expect(doc.hooks!.Stop![0]!.hooks![0]!.command).toBe('claude-status-hook Stop');
+  });
+
+  test('removeCodexHooks deletes an event key when only fleet entries were present', () => {
+    const p = join(workDir, 'hooks.json');
+    addCodexHooks(p, SCRIPT);
+    removeCodexHooks(p);
+    const doc = readJson<HooksDoc>(p);
+    expect(doc.hooks!.PreToolUse).toBeUndefined();
+    expect(doc.hooks!.Stop).toBeUndefined();
+  });
+
+  test('throws on malformed hooks.json and leaves the file untouched (never clobber)', () => {
+    const p = join(workDir, 'hooks.json');
+    const junk = '{ not valid json ]';
+    writeFileSync(p, junk);
+    expect(() => addCodexHooks(p, SCRIPT)).toThrow();
+    expect(readFileSync(p, 'utf8')).toBe(junk);
+  });
+
+  test('removeCodexHooks throws on malformed hooks.json (runUninstallCodex catches this)', () => {
+    const p = join(workDir, 'hooks.json');
+    const junk = '{ not valid json ]';
+    writeFileSync(p, junk);
+    expect(() => removeCodexHooks(p)).toThrow();
+    expect(readFileSync(p, 'utf8')).toBe(junk); // untouched
+  });
+
+  test('removeCodexHooks is a no-op on a missing file', () => {
+    expect(() => removeCodexHooks(join(workDir, 'nope.json'))).not.toThrow();
+  });
+});
+
+describe('ensureCodexFeatures', () => {
+  test('missing config creates [features] hooks = true', () => {
+    const p = join(workDir, 'config.toml');
+    ensureCodexFeatures(p);
+    const t = readFileSync(p, 'utf8');
+    expect(t).toContain('[features]');
+    expect(t).toMatch(/hooks\s*=\s*true/);
+  });
+
+  test('inserts hooks = true under an existing [features] without duplicating the header', () => {
+    const p = join(workDir, 'config.toml');
+    writeFileSync(p, '[features]\nother = 1\n\n[model]\nname = "x"\n');
+    ensureCodexFeatures(p);
+    const t = readFileSync(p, 'utf8');
+    expect((t.match(/\[features\]/g) ?? []).length).toBe(1);
+    expect(t).toMatch(/hooks\s*=\s*true/);
+    expect(t).toContain('other = 1');
+    expect(t).toContain('[model]');
+  });
+
+  test('flips hooks = false to true', () => {
+    const p = join(workDir, 'config.toml');
+    writeFileSync(p, '[features]\nhooks = false\n');
+    ensureCodexFeatures(p);
+    const t = readFileSync(p, 'utf8');
+    expect(t).toMatch(/hooks\s*=\s*true/);
+    expect(t).not.toMatch(/hooks\s*=\s*false/);
+  });
+
+  test('already-true is a byte-identical no-op', () => {
+    const p = join(workDir, 'config.toml');
+    const before = '[features]\nhooks = true\n';
+    writeFileSync(p, before);
+    ensureCodexFeatures(p);
+    expect(readFileSync(p, 'utf8')).toBe(before);
+  });
+});
+
+describe('removeCodexFeatures', () => {
+  test('leaves hooks = true when other hook entries remain, strips it when none do', () => {
+    const cfg = join(workDir, 'config.toml');
+    const hooks = join(workDir, 'hooks.json');
+    writeFileSync(cfg, '[features]\nhooks = true\n');
+
+    // A user hook remains -> leave the flag on.
+    writeFileSync(
+      hooks,
+      JSON.stringify({ hooks: { PreToolUse: [{ hooks: [{ command: 'claude-status-hook PreToolUse' }] }] } }),
+    );
+    removeCodexFeatures(cfg, hooks);
+    expect(readFileSync(cfg, 'utf8')).toMatch(/hooks\s*=\s*true/);
+
+    // No hooks remain -> strip the flag (header stays).
+    writeFileSync(hooks, JSON.stringify({ hooks: {} }));
+    removeCodexFeatures(cfg, hooks);
+    const t = readFileSync(cfg, 'utf8');
+    expect(t).not.toMatch(/hooks\s*=\s*true/);
+    expect(t).toContain('[features]');
+  });
+});
+
+describe('upsertAgentEntry / removeAgentEntry', () => {
+  test('adds codex without dropping claude and is a byte-identical no-op on re-run', () => {
+    const p = join(workDir, 'agents.json');
+    writeFileSync(p, JSON.stringify({ agents: [{ name: 'claude', statusDir: '~/.cache/claude-status' }] }, null, 2));
+
+    upsertAgentEntry(p, { name: 'codex', statusDir: '~/.cache/codex-status' });
+    const doc = readJson<AgentsDoc>(p);
+    expect(doc.agents.map((a) => a.name).sort()).toEqual(['claude', 'codex']);
+
+    const after1 = readFileSync(p, 'utf8');
+    upsertAgentEntry(p, { name: 'codex', statusDir: '~/.cache/codex-status' });
+    expect(readFileSync(p, 'utf8')).toBe(after1);
+  });
+
+  test('synthesizes from the seed when agents.json is missing (does not drop claude)', () => {
+    const p = join(workDir, 'agents.json');
+    upsertAgentEntry(p, { name: 'codex', statusDir: '~/.cache/codex-status' }, [
+      { name: 'claude', statusDir: '/home/u/.cache/claude-status' },
+    ]);
+    const doc = readJson<AgentsDoc>(p);
+    expect(doc.agents.map((a) => a.name).sort()).toEqual(['claude', 'codex']);
+  });
+
+  test('removeAgentEntry drops codex and keeps the rest', () => {
+    const p = join(workDir, 'agents.json');
+    writeFileSync(
+      p,
+      JSON.stringify({
+        agents: [
+          { name: 'claude', statusDir: '~/.cache/claude-status' },
+          { name: 'codex', statusDir: '~/.cache/codex-status' },
+        ],
+      }),
+    );
+    removeAgentEntry(p, 'codex');
+    const doc = readJson<AgentsDoc>(p);
+    expect(doc.agents.map((a) => a.name)).toEqual(['claude']);
+  });
+});

--- a/src/cli/install-codex.ts
+++ b/src/cli/install-codex.ts
@@ -30,14 +30,16 @@ const CODEX_HOOK_SCRIPT = join(STABLE_LINK, 'hooks', 'codex', 'codex-hook.sh');
 // expands the leading ~ back to CODEX_STATUS_DIR when it reads this.
 const CODEX_STATUS_DIR_CONFIG = '~/.cache/codex-status';
 
-function agentsJsonPath(): string {
+// Exported so install-pi.ts registers pi in the same agents.json the read path
+// resolves — these helpers are agent-agnostic, they just live here.
+export function agentsJsonPath(): string {
   // Mirror loadAgentDirs' resolution exactly so install writes where the read
   // path looks.
   const configDir = process.env.XDG_CONFIG_HOME ?? join(homedir(), '.config');
   return join(configDir, 'fleet', 'agents.json');
 }
 
-function withTilde(p: string): string {
+export function withTilde(p: string): string {
   const home = homedir();
   return p.startsWith(home) ? '~' + p.slice(home.length) : p;
 }

--- a/src/cli/install-codex.ts
+++ b/src/cli/install-codex.ts
@@ -1,0 +1,274 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fleetPluginDir, linkPluginDir } from './install.ts';
+import { CODEX_STATUS_DIR, loadAgentDirs, type AgentDir } from '../agents/config.ts';
+
+// Codex is configured entirely by editing its own files — no marketplace, no
+// `claude plugin` CLI, no $CLAUDE_PLUGIN_ROOT. `fleet install codex` is a
+// distinct path from the Claude installer; everything here is idempotent and
+// surgically reversible so the user's own Codex hooks/config survive uninstall.
+
+// Codex fires exactly these two events (verified in ~/.codex/hooks.json).
+const CODEX_EVENTS = ['PreToolUse', 'Stop'] as const;
+
+// The observed timeout Codex uses for its own hook entries (ms).
+const CODEX_HOOK_TIMEOUT_MS = 5000;
+
+// Substring that identifies a fleet-owned hook entry inside hooks.json, so
+// install adds only if absent and uninstall removes exactly ours.
+const FLEET_HOOK_MARKER = 'codex-hook.sh';
+
+// --- canonical paths (single source of truth) ---------------------------------
+// CODEX_STATUS_DIR (absolute) is owned by config.ts (the read side) so the two
+// never drift. The stable symlink gives Codex an upgrade-safe path to reference.
+const CODEX_HOOKS_JSON = join(homedir(), '.codex', 'hooks.json');
+const CODEX_CONFIG_TOML = join(homedir(), '.codex', 'config.toml');
+const STABLE_LINK = join(homedir(), '.local', 'share', 'fleet', 'plugin');
+const CODEX_HOOK_SCRIPT = join(STABLE_LINK, 'hooks', 'codex', 'codex-hook.sh');
+// Stored ~-form in agents.json (portable, README-documented); loadAgentDirs
+// expands the leading ~ back to CODEX_STATUS_DIR when it reads this.
+const CODEX_STATUS_DIR_CONFIG = '~/.cache/codex-status';
+
+function agentsJsonPath(): string {
+  // Mirror loadAgentDirs' resolution exactly so install writes where the read
+  // path looks.
+  const configDir = process.env.XDG_CONFIG_HOME ?? join(homedir(), '.config');
+  return join(configDir, 'fleet', 'agents.json');
+}
+
+function withTilde(p: string): string {
+  const home = homedir();
+  return p.startsWith(home) ? '~' + p.slice(home.length) : p;
+}
+
+// --- hooks.json editor ---------------------------------------------------------
+// Codex's hooks.json shape: { hooks: { <Event>: [ { hooks: [ { type, command,
+// timeout } ] } ] } }. No `matcher`; timeout is in ms.
+interface CodexHookCommand {
+  type?: string;
+  command?: string;
+  timeout?: number;
+}
+interface CodexHookEntry {
+  hooks?: CodexHookCommand[];
+}
+interface CodexHooksDoc {
+  hooks?: Record<string, CodexHookEntry[]>;
+}
+
+function codexEntry(script: string, event: string): CodexHookEntry {
+  return { hooks: [{ type: 'command', command: `bash ${script} ${event}`, timeout: CODEX_HOOK_TIMEOUT_MS }] };
+}
+
+function isFleetEntry(entry: CodexHookEntry): boolean {
+  return (entry.hooks ?? []).some((h) => typeof h.command === 'string' && h.command.includes(FLEET_HOOK_MARKER));
+}
+
+// Add fleet's PreToolUse+Stop entries, preserving any the user already has.
+// Throws on malformed JSON (the caller aborts without writing — never clobber).
+export function addCodexHooks(path: string, script: string): void {
+  const doc: CodexHooksDoc = existsSync(path) ? (JSON.parse(readFileSync(path, 'utf8')) as CodexHooksDoc) : { hooks: {} };
+  const hooks = (doc.hooks ??= {});
+  for (const ev of CODEX_EVENTS) {
+    const arr = (hooks[ev] ??= []);
+    if (!arr.some(isFleetEntry)) arr.push(codexEntry(script, ev));
+  }
+  writeFileSync(path, JSON.stringify(doc, null, 2) + '\n');
+}
+
+// Remove exactly fleet's entries; leave the user's own hooks intact.
+export function removeCodexHooks(path: string): void {
+  if (!existsSync(path)) return;
+  const doc = JSON.parse(readFileSync(path, 'utf8')) as CodexHooksDoc;
+  if (!doc.hooks) return;
+  for (const ev of CODEX_EVENTS) {
+    const arr = doc.hooks[ev];
+    if (!Array.isArray(arr)) continue;
+    const kept = arr.filter((e) => !isFleetEntry(e));
+    if (kept.length === 0) delete doc.hooks[ev];
+    else doc.hooks[ev] = kept;
+  }
+  writeFileSync(path, JSON.stringify(doc, null, 2) + '\n');
+}
+
+// True if hooks.json still has ANY hook entry (used to decide whether disabling
+// [features] hooks would break the user's own Codex hooks). Malformed => assume
+// yes, so we never strip the flag out from under a user we can't read.
+function hasAnyHookEntries(hooksJsonPath: string): boolean {
+  if (!existsSync(hooksJsonPath)) return false;
+  let doc: CodexHooksDoc;
+  try {
+    doc = JSON.parse(readFileSync(hooksJsonPath, 'utf8')) as CodexHooksDoc;
+  } catch {
+    return true;
+  }
+  const hooks = doc.hooks ?? {};
+  for (const ev of Object.keys(hooks)) {
+    const arr = hooks[ev];
+    if (Array.isArray(arr) && arr.length > 0) return true;
+  }
+  return false;
+}
+
+// --- config.toml editor (line-based; zero deps, no TOML parser) ----------------
+// Ensure `[features] hooks = true`. Never duplicates the [features] header;
+// flips an existing `hooks = false` to true; already-true is a byte-identical no-op.
+export function ensureCodexFeatures(path: string): void {
+  const text = existsSync(path) ? readFileSync(path, 'utf8') : '';
+  const lines = text.split('\n');
+  const featIdx = lines.findIndex((l) => l.trim() === '[features]');
+  if (featIdx === -1) {
+    const sep = text.length === 0 || text.endsWith('\n') ? '' : '\n';
+    writeFileSync(path, text + sep + '\n[features]\nhooks = true\n');
+    return;
+  }
+  for (let i = featIdx + 1; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (line.trimStart().startsWith('[')) break; // next section — key absent
+    if (/^\s*hooks\s*=/.test(line)) {
+      if (/^\s*hooks\s*=\s*true\s*$/.test(line)) return; // already on -> no-op
+      lines[i] = 'hooks = true'; // flip false -> true
+      writeFileSync(path, lines.join('\n'));
+      return;
+    }
+  }
+  lines.splice(featIdx + 1, 0, 'hooks = true'); // header present, key absent
+  writeFileSync(path, lines.join('\n'));
+}
+
+// Strip `hooks = true` ONLY when fleet was the sole reason it was on (no hook
+// entries remain in hooksJsonPath). Otherwise leave it — the user's own Codex
+// hooks still need it.
+export function removeCodexFeatures(configPath: string, hooksJsonPath: string): void {
+  if (!existsSync(configPath)) return;
+  if (hasAnyHookEntries(hooksJsonPath)) return;
+  const lines = readFileSync(configPath, 'utf8').split('\n');
+  const featIdx = lines.findIndex((l) => l.trim() === '[features]');
+  if (featIdx === -1) return;
+  for (let i = featIdx + 1; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (line.trimStart().startsWith('[')) break;
+    if (/^\s*hooks\s*=\s*true\s*$/.test(line)) {
+      lines.splice(i, 1);
+      writeFileSync(configPath, lines.join('\n'));
+      return;
+    }
+  }
+}
+
+// --- agents.json merge (non-destructive) --------------------------------------
+interface AgentsDoc {
+  agents?: AgentDir[];
+}
+
+// Add `entry` if absent, preserving every existing agent. When agents.json does
+// not exist, `seed` (the currently resolved dirs) supplies the baseline so the
+// naive write doesn't drop claude — loadAgentDirs would otherwise early-return an
+// array that excludes it.
+export function upsertAgentEntry(path: string, entry: AgentDir, seed: AgentDir[] = []): void {
+  let agents: AgentDir[] = [...seed];
+  if (existsSync(path)) {
+    try {
+      const doc = JSON.parse(readFileSync(path, 'utf8')) as AgentsDoc;
+      if (Array.isArray(doc.agents)) agents = doc.agents;
+    } catch {
+      // Malformed — keep the seed rather than clobbering with just the new entry.
+    }
+  }
+  if (!agents.some((a) => a.name === entry.name)) agents.push(entry);
+  writeFileSync(path, JSON.stringify({ agents }, null, 2) + '\n');
+}
+
+// Drop an agent by name, keeping the rest. Missing file or absent name is a no-op.
+export function removeAgentEntry(path: string, name: string): void {
+  if (!existsSync(path)) return;
+  let agents: AgentDir[];
+  try {
+    const doc = JSON.parse(readFileSync(path, 'utf8')) as AgentsDoc;
+    agents = Array.isArray(doc.agents) ? doc.agents : [];
+  } catch {
+    return; // malformed — leave it untouched
+  }
+  const kept = agents.filter((a) => a.name !== name);
+  if (kept.length === agents.length) return; // not present
+  writeFileSync(path, JSON.stringify({ agents: kept }, null, 2) + '\n');
+}
+
+// --- top-level commands --------------------------------------------------------
+export function runInstallCodex(): number {
+  const fleetDir = fleetPluginDir();
+  if (fleetDir === null) {
+    process.stderr.write(
+      'fleet install codex failed: could not find a plugin directory containing hooks/hooks.json.\n' +
+        'Without the Codex hook script there is nothing to point ~/.codex/hooks.json at.\n' +
+        'If fleet was installed via Homebrew, the package may be missing the hooks/ directory — try upgrading.\n',
+    );
+    return 1;
+  }
+
+  // Snapshot the agents that exist BEFORE this install (so the mkdir below doesn't
+  // pull a half-formed codex into the fallback) — this seeds a fresh agents.json
+  // without dropping them. Guarantee a claude entry even when ~/.cache/claude-status
+  // doesn't exist yet: agents.json PREEMPTS the fallback once written, so a
+  // Codex-first user who later runs Claude would otherwise find it hidden.
+  const seed = loadAgentDirs();
+  if (!seed.some((a) => a.name === 'claude')) {
+    seed.unshift({ name: 'claude', statusDir: '~/.cache/claude-status' });
+  }
+
+  // Stable, upgrade-safe path for Codex to reference (no $CLAUDE_PLUGIN_ROOT, and
+  // a Homebrew keg path changes on upgrade). Re-pointed on every install.
+  mkdirSync(dirname(STABLE_LINK), { recursive: true });
+  linkPluginDir(fleetDir, STABLE_LINK);
+  process.stdout.write(`Linked ${withTilde(STABLE_LINK)} -> ${fleetDir}\n`);
+
+  mkdirSync(CODEX_STATUS_DIR, { recursive: true });
+  process.stdout.write(`Created ${withTilde(CODEX_STATUS_DIR)}\n`);
+
+  mkdirSync(dirname(CODEX_HOOKS_JSON), { recursive: true });
+  try {
+    addCodexHooks(CODEX_HOOKS_JSON, CODEX_HOOK_SCRIPT);
+  } catch {
+    process.stderr.write(
+      `fleet install codex failed: refusing to edit malformed ${withTilde(CODEX_HOOKS_JSON)}.\n` +
+        'Fix or remove the file, then re-run — your Codex config was not modified.\n',
+    );
+    return 1;
+  }
+  process.stdout.write(`Added fleet PreToolUse/Stop hooks to ${withTilde(CODEX_HOOKS_JSON)}\n`);
+
+  ensureCodexFeatures(CODEX_CONFIG_TOML);
+  process.stdout.write(`Enabled [features] hooks in ${withTilde(CODEX_CONFIG_TOML)}\n`);
+
+  const agentsPath = agentsJsonPath();
+  mkdirSync(dirname(agentsPath), { recursive: true });
+  upsertAgentEntry(agentsPath, { name: 'codex', statusDir: CODEX_STATUS_DIR_CONFIG }, seed);
+  process.stdout.write(`Registered codex in ${withTilde(agentsPath)}\n`);
+
+  process.stdout.write('\nfleet is now wired into Codex. Start codex in a tmux pane to see it on the dashboard.\n');
+  return 0;
+}
+
+export function runUninstallCodex(): number {
+  try {
+    removeCodexHooks(CODEX_HOOKS_JSON);
+  } catch {
+    process.stderr.write(
+      `fleet uninstall codex failed: refusing to edit malformed ${withTilde(CODEX_HOOKS_JSON)}.\n` +
+        'Fix or remove the file, then re-run — your Codex config was not modified.\n',
+    );
+    return 1;
+  }
+  process.stdout.write(`Removed fleet's Codex hooks from ${withTilde(CODEX_HOOKS_JSON)}\n`);
+
+  removeCodexFeatures(CODEX_CONFIG_TOML, CODEX_HOOKS_JSON);
+
+  const agentsPath = agentsJsonPath();
+  removeAgentEntry(agentsPath, 'codex');
+  process.stdout.write(`Unregistered codex from ${withTilde(agentsPath)}\n`);
+
+  // Leave the status dir and the stable symlink in place: harmless, and the
+  // symlink is shared with any future `fleet install codex`.
+  return 0;
+}

--- a/src/cli/install-codex.ts
+++ b/src/cli/install-codex.ts
@@ -68,7 +68,9 @@ function isFleetEntry(entry: CodexHookEntry): boolean {
 // Add fleet's PreToolUse+Stop entries, preserving any the user already has.
 // Throws on malformed JSON (the caller aborts without writing — never clobber).
 export function addCodexHooks(path: string, script: string): void {
-  const doc: CodexHooksDoc = existsSync(path) ? (JSON.parse(readFileSync(path, 'utf8')) as CodexHooksDoc) : { hooks: {} };
+  const doc: CodexHooksDoc = existsSync(path)
+    ? (JSON.parse(readFileSync(path, 'utf8')) as CodexHooksDoc)
+    : { hooks: {} };
   const hooks = (doc.hooks ??= {});
   for (const ev of CODEX_EVENTS) {
     const arr = (hooks[ev] ??= []);

--- a/src/cli/install-pi.ts
+++ b/src/cli/install-pi.ts
@@ -1,0 +1,88 @@
+import { existsSync, lstatSync, mkdirSync, rmSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fleetPluginDir, linkPluginDir } from './install.ts';
+import { agentsJsonPath, removeAgentEntry, upsertAgentEntry, withTilde } from './install-codex.ts';
+import { loadAgentDirs, PI_STATUS_DIR } from '../agents/config.ts';
+
+// pi (npm: @mariozechner/pi-coding-agent) has no shell-hook config; it loads
+// TypeScript extensions auto-discovered from ~/.pi/agent/extensions/*.ts (see
+// pi's docs/extensions.md). `fleet install pi` symlinks fleet's extension there
+// — a symlink into the plugin dir so a fleet upgrade is picked up without a
+// re-copy; re-running install after a Homebrew upgrade re-points it (linkPluginDir
+// replaces even a dangling link). Everything is idempotent and reversible; the
+// user's own pi extensions and config are never touched.
+
+const PI_EXTENSIONS_DIR = join(homedir(), '.pi', 'agent', 'extensions');
+const PI_EXTENSION_LINK = join(PI_EXTENSIONS_DIR, 'fleet-pi.ts');
+// ~-form stored in agents.json (portable, README-documented); loadAgentDirs
+// expands the leading ~ back to PI_STATUS_DIR when it reads this.
+const PI_STATUS_DIR_CONFIG = '~/.cache/pi-status';
+
+// lstat (does not follow the link) so a dangling symlink still reports present.
+function linkPresent(path: string): boolean {
+  try {
+    lstatSync(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function runInstallPi(): number {
+  const fleetDir = fleetPluginDir();
+  if (fleetDir === null) {
+    process.stderr.write(
+      'fleet install pi failed: could not find a plugin directory containing hooks/hooks.json.\n' +
+        'Without it there is no fleet-pi extension to link into pi.\n' +
+        'If fleet was installed via Homebrew, the package may be missing the hooks/ directory — try upgrading.\n',
+    );
+    return 1;
+  }
+  const extensionSrc = join(fleetDir, 'hooks', 'pi', 'fleet-pi.ts');
+  if (!existsSync(extensionSrc)) {
+    process.stderr.write(`fleet install pi failed: fleet-pi extension not found at ${extensionSrc}\n`);
+    return 1;
+  }
+
+  // Snapshot agents present BEFORE the mkdir below so a fresh agents.json is
+  // seeded without dropping claude/codex; guarantee a claude entry even when its
+  // status dir doesn't exist yet (agents.json preempts the fallback once written,
+  // same reasoning as install-codex).
+  const seed = loadAgentDirs();
+  if (!seed.some((a) => a.name === 'claude')) {
+    seed.unshift({ name: 'claude', statusDir: '~/.cache/claude-status' });
+  }
+
+  mkdirSync(PI_EXTENSIONS_DIR, { recursive: true });
+  linkPluginDir(extensionSrc, PI_EXTENSION_LINK); // rm + symlink; replaces a stale/dangling link
+  process.stdout.write(`Linked ${withTilde(PI_EXTENSION_LINK)} -> ${extensionSrc}\n`);
+
+  mkdirSync(PI_STATUS_DIR, { recursive: true });
+  process.stdout.write(`Created ${withTilde(PI_STATUS_DIR)}\n`);
+
+  const agentsPath = agentsJsonPath();
+  mkdirSync(dirname(agentsPath), { recursive: true });
+  upsertAgentEntry(agentsPath, { name: 'pi', statusDir: PI_STATUS_DIR_CONFIG }, seed);
+  process.stdout.write(`Registered pi in ${withTilde(agentsPath)}\n`);
+
+  process.stdout.write('\nfleet is now wired into pi. Start pi in a tmux pane to see it on the dashboard.\n');
+  process.stdout.write('(In an already-running pi session, run /reload to pick up the extension.)\n');
+  return 0;
+}
+
+export function runUninstallPi(): number {
+  // Remove only fleet's extension symlink; the user's own pi extensions stay.
+  if (linkPresent(PI_EXTENSION_LINK)) {
+    rmSync(PI_EXTENSION_LINK, { force: true });
+    process.stdout.write(`Removed ${withTilde(PI_EXTENSION_LINK)}\n`);
+  }
+
+  const agentsPath = agentsJsonPath();
+  removeAgentEntry(agentsPath, 'pi');
+  process.stdout.write(`Unregistered pi from ${withTilde(agentsPath)}\n`);
+
+  // Leave ~/.cache/pi-status in place: harmless, and it may still hold live state
+  // for a pi session that is currently running.
+  return 0;
+}

--- a/src/cli/install.test.ts
+++ b/src/cli/install.test.ts
@@ -280,7 +280,9 @@ describe('addTmuxRollupLines', () => {
     expect(added).toHaveLength(3);
     const conf = readFileSync(path, 'utf8');
     expect(conf).toContain('set -g @fleet_rollup 1 # fleet-managed');
-    expect(conf).toContain('set -g window-status-format "#{?#{@fleet_state},#[fg=#{@fleet_state}],}#I:#W#F" # fleet-managed');
+    expect(conf).toContain(
+      'set -g window-status-format "#{?#{@fleet_state},#[fg=#{@fleet_state}],}#I:#W#F" # fleet-managed',
+    );
     expect(conf).toContain(
       'set -g window-status-current-format "#{?#{@fleet_state},#[fg=#{@fleet_state}],}#[bold]#I:#W#F#[nobold]" # fleet-managed',
     );

--- a/src/cli/install.test.ts
+++ b/src/cli/install.test.ts
@@ -14,6 +14,7 @@ import { join } from 'node:path';
 import {
   addTmuxConfLine,
   addTmuxKeybindLines,
+  addTmuxRollupLines,
   linkPluginDir,
   removeTmuxConfLine,
   resolvePluginDir,
@@ -120,6 +121,20 @@ describe('removeTmuxConfLine', () => {
     expect(result).not.toContain('# fleet-managed');
     expect(result).toContain('set -g mouse on');
     expect(result).toContain('set -g foo bar');
+  });
+
+  test('strips the three window-rollup lines added by addTmuxRollupLines', () => {
+    writeFileSync(confFile, 'set -g mouse on\n');
+    addTmuxRollupLines(confFile, () => true);
+    expect(readFileSync(confFile, 'utf8')).toContain('@fleet_rollup');
+
+    expect(removeTmuxConfLine(confFile)).toBe(true);
+    const result = readFileSync(confFile, 'utf8');
+    expect(result).not.toContain('# fleet-managed');
+    expect(result).not.toContain('@fleet_rollup');
+    expect(result).not.toContain('window-status-format');
+    expect(result).not.toContain('window-status-current-format');
+    expect(result).toContain('set -g mouse on');
   });
 });
 
@@ -248,5 +263,49 @@ describe('addTmuxKeybindLines', () => {
 
   test('missing conf file adds nothing', () => {
     expect(addTmuxKeybindLines('/nonexistent/tmux.conf', () => true)).toHaveLength(0);
+  });
+});
+
+describe('addTmuxRollupLines', () => {
+  const confWith = (content: string): string => {
+    const dir = mkdtempSync(join(tmpdir(), 'fleet-rollup-test-'));
+    const path = join(dir, 'tmux.conf');
+    writeFileSync(path, content);
+    return path;
+  };
+
+  test('accepting appends the gate option and both window-status format lines', () => {
+    const path = confWith('set -g mouse on\n');
+    const added = addTmuxRollupLines(path, () => true);
+    expect(added).toHaveLength(3);
+    const conf = readFileSync(path, 'utf8');
+    expect(conf).toContain('set -g @fleet_rollup 1 # fleet-managed');
+    expect(conf).toContain('set -g window-status-format "#{?#{@fleet_state},#[fg=#{@fleet_state}],}#I:#W#F" # fleet-managed');
+    expect(conf).toContain(
+      'set -g window-status-current-format "#{?#{@fleet_state},#[fg=#{@fleet_state}],}#[bold]#I:#W#F#[nobold]" # fleet-managed',
+    );
+    expect(conf.match(/# fleet-managed/g)?.length).toBe(3);
+    expect(conf).toContain('set -g mouse on');
+  });
+
+  test('declining adds nothing and leaves the file untouched', () => {
+    const path = confWith('set -g mouse on\n');
+    expect(addTmuxRollupLines(path, () => false)).toHaveLength(0);
+    expect(readFileSync(path, 'utf8')).toBe('set -g mouse on\n');
+  });
+
+  test('idempotent: an already-configured conf is neither re-added nor re-asked', () => {
+    const path = confWith('set -g mouse on\n');
+    addTmuxRollupLines(path, () => true);
+    const before = readFileSync(path, 'utf8');
+    let asked = 0;
+    const added = addTmuxRollupLines(path, () => (asked++, true));
+    expect(added).toHaveLength(0);
+    expect(asked).toBe(0);
+    expect(readFileSync(path, 'utf8')).toBe(before);
+  });
+
+  test('missing conf file adds nothing', () => {
+    expect(addTmuxRollupLines('/nonexistent/tmux.conf', () => true)).toHaveLength(0);
   });
 });

--- a/src/cli/install.test.ts
+++ b/src/cli/install.test.ts
@@ -311,3 +311,29 @@ describe('addTmuxRollupLines', () => {
     expect(addTmuxRollupLines('/nonexistent/tmux.conf', () => true)).toHaveLength(0);
   });
 });
+
+// Regression lock for "fleet install rewrote my tmux statusline". The two
+// conf writers reachable from runInstall — addTmuxConfLine (unconditional) and
+// addTmuxKeybindLines (only when the user accepts a prompt) — must never emit a
+// window-status-format override. addTmuxRollupLines is the sole writer that
+// does, and it is deliberately not wired into runInstall (see install.ts), so
+// installing fleet cannot clobber a user's themed window formatting.
+describe('install conf writers never touch window-status-format', () => {
+  test('addTmuxConfLine adds only the statusline hook', () => {
+    writeFileSync(confFile, 'set -g mouse on\n');
+    addTmuxConfLine(confFile);
+    const conf = readFileSync(confFile, 'utf8');
+    expect(conf).toContain('run-shell "fleet statusline --inject"');
+    expect(conf).not.toContain('window-status-format');
+    expect(conf).not.toContain('@fleet_rollup');
+  });
+
+  test('accepting every keybind prompt still writes no window-status-format', () => {
+    writeFileSync(confFile, 'set -g mouse on\n');
+    addTmuxKeybindLines(confFile, () => true);
+    const conf = readFileSync(confFile, 'utf8');
+    expect(conf).toContain('bind-key');
+    expect(conf).not.toContain('window-status-format');
+    expect(conf).not.toContain('@fleet_rollup');
+  });
+});

--- a/src/cli/install.test.ts
+++ b/src/cli/install.test.ts
@@ -226,7 +226,7 @@ describe('addTmuxKeybindLines', () => {
     const added = addTmuxKeybindLines(path, () => true);
     expect(added).toHaveLength(2);
     const conf = readFileSync(path, 'utf8');
-    expect(conf).toContain('bind-key f split-window');
+    expect(conf).toContain('bind-key f split-window -hbf');
     expect(conf).toContain('bind-key F display-popup');
     expect(conf.match(/# fleet-managed/g)?.length).toBe(2);
   });

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -1,12 +1,26 @@
 import { existsSync, mkdirSync, readFileSync, readSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
-import { runStatusLineInject, runStatusLineRemove } from './statusline.ts';
+import {
+  runStatusLineInject,
+  runStatusLineRemove,
+  buildRollupEnableCommands,
+  WINDOW_STATUS_FORMAT,
+  WINDOW_STATUS_CURRENT_FORMAT,
+} from './statusline.ts';
 
 const FLEET_MANAGED_MARKER = '# fleet-managed';
 const FLEET_TMUX_LINE = `run-shell "fleet statusline --inject" ${FLEET_MANAGED_MARKER}`;
 const FLEET_KEYBIND_SIDEBAR = `bind-key f split-window -hbf -l 34 fleet ${FLEET_MANAGED_MARKER}`;
 const FLEET_KEYBIND_POPUP = `bind-key F display-popup -E -w 80% -h 60% fleet ${FLEET_MANAGED_MARKER}`;
+
+// Window state rollup opt-in: gate option + both window-status format overrides,
+// built from the same shared format constants as the live enable commands so the
+// persisted conf and the live server never drift.
+const FLEET_ROLLUP_GATE_LINE = `set -g @fleet_rollup 1 ${FLEET_MANAGED_MARKER}`;
+const FLEET_ROLLUP_FORMAT_LINE = `set -g window-status-format "${WINDOW_STATUS_FORMAT}" ${FLEET_MANAGED_MARKER}`;
+const FLEET_ROLLUP_CURRENT_FORMAT_LINE = `set -g window-status-current-format "${WINDOW_STATUS_CURRENT_FORMAT}" ${FLEET_MANAGED_MARKER}`;
+const FLEET_ROLLUP_LINES = [FLEET_ROLLUP_GATE_LINE, FLEET_ROLLUP_FORMAT_LINE, FLEET_ROLLUP_CURRENT_FORMAT_LINE];
 
 export function resolvePluginDir(candidates: string[]): string | null {
   for (const dir of candidates) {
@@ -90,6 +104,32 @@ export function addTmuxKeybindLines(path: string, ask: (question: string) => boo
     } else {
       process.stdout.write(`  skipped — add it yourself anytime:\n    ${cand.line}\n`);
     }
+  }
+  if (added.length > 0) writeFileSync(path, contents);
+  return added;
+}
+
+// Offer the window state rollup as a single y/N (three conf lines move together:
+// the gate option + both window-status format overrides). `ask` is injected so
+// tests don't touch a TTY. On yes the lines are appended and returned so the
+// caller can apply them live; on no they're printed for manual adoption.
+// Idempotent: an already-configured conf (gate line present) is neither re-asked
+// nor duplicated. Uninstall needs no changes: removeTmuxConfLine strips every
+// marker line.
+export function addTmuxRollupLines(path: string, ask: (question: string) => boolean): string[] {
+  if (!existsSync(path)) return [];
+  let contents = readFileSync(path, 'utf8');
+  if (contents.includes(FLEET_ROLLUP_GATE_LINE)) return [];
+  if (!ask('Recolor tmux window list by worst agent state (window rollup)? [y/N] ')) {
+    process.stdout.write('  skipped — add it yourself anytime:\n');
+    for (const line of FLEET_ROLLUP_LINES) process.stdout.write(`    ${line}\n`);
+    return [];
+  }
+  const added: string[] = [];
+  for (const line of FLEET_ROLLUP_LINES) {
+    if (contents.includes(line)) continue;
+    contents += (contents.endsWith('\n') || contents.length === 0 ? '' : '\n') + line + '\n';
+    added.push(line);
   }
   if (added.length > 0) writeFileSync(path, contents);
   return added;
@@ -182,6 +222,15 @@ export function runInstall(): number {
     process.stdout.write(
       `Added ${addedBindings.length} fleet keybinding(s) — reload with: tmux source-file ${confPath}\n`,
     );
+  }
+
+  const addedRollup = addTmuxRollupLines(confPath, askYesNo);
+  if (addedRollup.length > 0) {
+    // Apply immediately so the recolor takes effect without a config reload.
+    for (const cmd of buildRollupEnableCommands()) {
+      Bun.spawnSync({ cmd, stdout: 'ignore', stderr: 'ignore' });
+    }
+    process.stdout.write('Enabled window state rollup — tmux windows recolor by agent state.\n');
   }
 
   runStatusLineInject();

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -29,7 +29,7 @@ export function resolvePluginDir(candidates: string[]): string | null {
   return null;
 }
 
-function fleetPluginDir(): string | null {
+export function fleetPluginDir(): string | null {
   const fromBin = resolve(dirname(process.execPath), '..');
   const fromDev = resolve(import.meta.dir, '../..');
   return resolvePluginDir([fromBin, fromDev]);

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -5,7 +5,7 @@ import { runStatusLineInject, runStatusLineRemove } from './statusline.ts';
 
 const FLEET_MANAGED_MARKER = '# fleet-managed';
 const FLEET_TMUX_LINE = `run-shell "fleet statusline --inject" ${FLEET_MANAGED_MARKER}`;
-const FLEET_KEYBIND_SIDEBAR = `bind-key f split-window -hb -l 34 fleet ${FLEET_MANAGED_MARKER}`;
+const FLEET_KEYBIND_SIDEBAR = `bind-key f split-window -hbf -l 34 fleet ${FLEET_MANAGED_MARKER}`;
 const FLEET_KEYBIND_POPUP = `bind-key F display-popup -E -w 80% -h 60% fleet ${FLEET_MANAGED_MARKER}`;
 
 export function resolvePluginDir(candidates: string[]): string | null {

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -4,7 +4,6 @@ import { dirname, join, resolve } from 'node:path';
 import {
   runStatusLineInject,
   runStatusLineRemove,
-  buildRollupEnableCommands,
   WINDOW_STATUS_FORMAT,
   WINDOW_STATUS_CURRENT_FORMAT,
 } from './statusline.ts';
@@ -224,15 +223,12 @@ export function runInstall(): number {
     );
   }
 
-  const addedRollup = addTmuxRollupLines(confPath, askYesNo);
-  if (addedRollup.length > 0) {
-    // Apply immediately so the recolor takes effect without a config reload.
-    for (const cmd of buildRollupEnableCommands()) {
-      Bun.spawnSync({ cmd, stdout: 'ignore', stderr: 'ignore' });
-    }
-    process.stdout.write('Enabled window state rollup — tmux windows recolor by agent state.\n');
-  }
-
+  // Window state rollup is intentionally NOT offered here. Its tmux config
+  // (see addTmuxRollupLines) overrides window-status-format wholesale, which
+  // would discard a user's themed window formatting — fleet extends tmux, it
+  // does not overwrite it. The runtime recolor stays dormant behind the
+  // @fleet_rollup option (index.ts gates emitWindowColors on rollupEnabled()),
+  // so it is a no-op unless a user deliberately opts in via their tmux.conf.
   runStatusLineInject();
   return 0;
 }

--- a/src/cli/status.test.ts
+++ b/src/cli/status.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { formatTmuxStatus, formatPlainStatus, formatStatusLine, formatAge } from './status.ts';
+import { formatTmuxStatus, formatPlainStatus, formatStatusLine, formatAge, windowColorArgs } from './status.ts';
 import { AgentStatus, ACK_ALL_RANGE, type AgentState } from '../state/types.ts';
 
 const makeState = (overrides: Partial<AgentState>): AgentState => ({
@@ -7,6 +7,7 @@ const makeState = (overrides: Partial<AgentState>): AgentState => ({
   paneNum: 42,
   session: 'test',
   window: 'main',
+  windowId: '@1',
   claudeName: null,
   status: AgentStatus.IDLE,
   tool: null,
@@ -205,5 +206,85 @@ describe('formatStatusLine', () => {
 
   test('omits the clear-all chip for an empty bar', () => {
     expect(formatStatusLine([])).not.toContain(ACK_ALL_RANGE);
+  });
+});
+
+describe('windowColorArgs', () => {
+  // Find the single arg list that targets a given window id (its position
+  // differs between the set and unset forms, so match by membership).
+  const argsFor = (all: string[][], windowId: string): string[] | undefined =>
+    all.find((a) => a.includes(windowId));
+
+  test('groups by window and reduces to the worst state: PERMIT window set, IDLE window unset', () => {
+    const args = windowColorArgs([
+      makeState({ windowId: '@1', status: AgentStatus.PERMIT, paneId: '%1' }),
+      makeState({ windowId: '@2', status: AgentStatus.IDLE, paneId: '%2' }),
+    ]);
+    expect(argsFor(args, '@1')).toEqual(['set', '-w', '-t', '@1', '@fleet_state', 'yellow']);
+    expect(argsFor(args, '@2')).toEqual(['set', '-w', '-u', '-t', '@2', '@fleet_state']);
+  });
+
+  test('maps PERMIT→yellow, QUESTION→magenta, DONE→green', () => {
+    const args = windowColorArgs([
+      makeState({ windowId: '@1', status: AgentStatus.PERMIT, paneId: '%1' }),
+      makeState({ windowId: '@2', status: AgentStatus.QUESTION, paneId: '%2' }),
+      makeState({ windowId: '@3', status: AgentStatus.DONE, paneId: '%3' }),
+    ]);
+    expect(argsFor(args, '@1')).toEqual(['set', '-w', '-t', '@1', '@fleet_state', 'yellow']);
+    expect(argsFor(args, '@2')).toEqual(['set', '-w', '-t', '@2', '@fleet_state', 'magenta']);
+    expect(argsFor(args, '@3')).toEqual(['set', '-w', '-t', '@3', '@fleet_state', 'green']);
+  });
+
+  test('an idle-only window emits the unset form, never a colored set (data shadow)', () => {
+    const args = windowColorArgs([makeState({ windowId: '@7', status: AgentStatus.IDLE })]);
+    expect(args).toHaveLength(1);
+    expect(args[0]).toEqual(['set', '-w', '-u', '-t', '@7', '@fleet_state']);
+  });
+
+  test('reduce-then-classify: BUSY+DONE in one window reduces to BUSY → unset (BUSY masks DONE)', () => {
+    // PRIORITY ranks BUSY above DONE, so the window reduces to BUSY, which is not
+    // in the attention set → unset. Documents the intentional mask; guards
+    // against a regression that would start tinting working windows.
+    const args = windowColorArgs([
+      makeState({ windowId: '@1', status: AgentStatus.BUSY, paneId: '%1' }),
+      makeState({ windowId: '@1', status: AgentStatus.DONE, paneId: '%2' }),
+    ]);
+    expect(args).toHaveLength(1);
+    expect(args[0]).toEqual(['set', '-w', '-u', '-t', '@1', '@fleet_state']);
+  });
+
+  test('a window with multiple attention agents tints by the most urgent (PERMIT over DONE)', () => {
+    const args = windowColorArgs([
+      makeState({ windowId: '@1', status: AgentStatus.DONE, paneId: '%1' }),
+      makeState({ windowId: '@1', status: AgentStatus.PERMIT, paneId: '%2' }),
+    ]);
+    expect(args).toHaveLength(1);
+    expect(args[0]).toEqual(['set', '-w', '-t', '@1', '@fleet_state', 'yellow']);
+  });
+
+  test('every distinct window id produces exactly one arg list', () => {
+    const args = windowColorArgs([
+      makeState({ windowId: '@1', status: AgentStatus.PERMIT, paneId: '%1' }),
+      makeState({ windowId: '@1', status: AgentStatus.IDLE, paneId: '%2' }),
+      makeState({ windowId: '@2', status: AgentStatus.DONE, paneId: '%3' }),
+    ]);
+    expect(args).toHaveLength(2);
+    expect(argsFor(args, '@1')).toBeDefined();
+    expect(argsFor(args, '@2')).toBeDefined();
+  });
+
+  test('a state with an empty window id is skipped (graceful degrade, no malformed set)', () => {
+    const args = windowColorArgs([
+      makeState({ windowId: '', status: AgentStatus.PERMIT, paneId: '%1' }),
+      makeState({ windowId: '@2', status: AgentStatus.QUESTION, paneId: '%2' }),
+    ]);
+    expect(args).toHaveLength(1);
+    expect(argsFor(args, '@2')).toEqual(['set', '-w', '-t', '@2', '@fleet_state', 'magenta']);
+    // No arg list contains an empty target.
+    expect(args.some((a) => a.includes(''))).toBe(false);
+  });
+
+  test('returns no args for an empty state list', () => {
+    expect(windowColorArgs([])).toHaveLength(0);
   });
 });

--- a/src/cli/status.test.ts
+++ b/src/cli/status.test.ts
@@ -213,8 +213,7 @@ describe('formatStatusLine', () => {
 describe('windowColorArgs', () => {
   // Find the single arg list that targets a given window id (its position
   // differs between the set and unset forms, so match by membership).
-  const argsFor = (all: string[][], windowId: string): string[] | undefined =>
-    all.find((a) => a.includes(windowId));
+  const argsFor = (all: string[][], windowId: string): string[] | undefined => all.find((a) => a.includes(windowId));
 
   test('groups by window and reduces to the worst state: PERMIT window set, IDLE window unset', () => {
     const args = windowColorArgs([

--- a/src/cli/status.test.ts
+++ b/src/cli/status.test.ts
@@ -9,6 +9,7 @@ const makeState = (overrides: Partial<AgentState>): AgentState => ({
   window: 'main',
   windowId: '@1',
   claudeName: null,
+  customName: null,
   status: AgentStatus.IDLE,
   tool: null,
   project: '~/Developer/test',

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -69,6 +69,38 @@ export function formatTmuxStatus(states: AgentState[], session: string): string 
   return `#[fg=${display.color}] ${display.icon} `;
 }
 
+// Group agents by their tmux window id, reduce each window to its most-urgent
+// status (mirroring formatTmuxStatus), and return per-window tmux arg lists
+// (WITHOUT the leading "tmux") so the runner can batch them into one invocation
+// with ";" separators. A window whose worst state needs you is tinted its color;
+// every other present window is explicitly UNSET so a stale tint can't linger.
+export function windowColorArgs(states: AgentState[]): string[][] {
+  const byWindow = new Map<string, AgentState[]>();
+  for (const s of states) {
+    if (s.windowId.length === 0) continue; // old binary / parse miss — degrade to no tint
+    const list = byWindow.get(s.windowId) ?? [];
+    list.push(s);
+    byWindow.set(s.windowId, list);
+  }
+
+  const attention: AgentStatus[] = [AgentStatus.PERMIT, AgentStatus.QUESTION, AgentStatus.DONE];
+  const args: string[][] = [];
+  for (const [windowId, group] of byWindow) {
+    group.sort((a, b) => compareStatus(a.status, b.status));
+    const worst = group[0]!.status;
+    if (attention.includes(worst)) {
+      args.push(['set', '-w', '-t', windowId, '@fleet_state', STATUS_DISPLAY[worst].color]);
+    } else {
+      // Data shadow: a window whose agent just went idle/working MUST be unset
+      // this same refresh, or a stale tint lingers. We enumerate every present
+      // window and set-or-unset — the process is stateless, so we cannot
+      // "remember" which we set last time.
+      args.push(['set', '-w', '-u', '-t', windowId, '@fleet_state']);
+    }
+  }
+  return args;
+}
+
 export function runStatus(args: string[], states: AgentState[]): string {
   const tmuxMode = args.includes('--tmux');
   const statusLineMode = args.includes('--statusline');

--- a/src/cli/statusline.test.ts
+++ b/src/cli/statusline.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from 'bun:test';
-import { buildInjectCommands, buildRemoveCommands } from './statusline.ts';
+import {
+  buildInjectCommands,
+  buildRemoveCommands,
+  buildRollupEnableCommands,
+  WINDOW_STATUS_FORMAT,
+  WINDOW_STATUS_CURRENT_FORMAT,
+} from './statusline.ts';
 
 describe('buildInjectCommands', () => {
   test('returns status-2, status-format[1], both mouse binds, and the focus hook', () => {
@@ -35,6 +41,14 @@ describe('buildInjectCommands', () => {
     for (const cmd of cmds) {
       expect(cmd[0]).toBe('tmux');
     }
+  });
+
+  test('does not touch window-status-format — the rollup format lives in the conf, not the inject', () => {
+    const cmds = buildInjectCommands();
+    expect(cmds).toHaveLength(6);
+    expect(cmds.some((c) => c.some((a) => a.includes('window-status-format')))).toBe(false);
+    expect(cmds.some((c) => c.some((a) => a.includes('window-status-current-format')))).toBe(false);
+    expect(cmds.some((c) => c.some((a) => a.includes('@fleet_rollup')))).toBe(false);
   });
 
   test('bind uses MouseDown1Status with if-shell guard for row 1 only', () => {
@@ -73,7 +87,7 @@ describe('buildInjectCommands', () => {
 });
 
 describe('buildRemoveCommands', () => {
-  test('unsets status-format[1], resets status, unbinds both mouse buttons, and removes the focus hook', () => {
+  test('unsets status-format[1], resets status, unbinds both mouse buttons, removes the focus hook, and reverts the rollup', () => {
     const cmds = buildRemoveCommands();
     expect(cmds).toEqual([
       ['tmux', 'set', '-g', '-u', 'status-format[1]'],
@@ -81,6 +95,9 @@ describe('buildRemoveCommands', () => {
       ['tmux', 'unbind', '-T', 'root', 'MouseDown1Status'],
       ['tmux', 'unbind', '-T', 'root', 'MouseDown3Status'],
       ['tmux', 'set-hook', '-gu', 'pane-focus-in[99]'],
+      ['tmux', 'set', '-g', '-u', 'window-status-format'],
+      ['tmux', 'set', '-g', '-u', 'window-status-current-format'],
+      ['tmux', 'set', '-g', '-u', '@fleet_rollup'],
     ]);
   });
 
@@ -105,5 +122,31 @@ describe('buildRemoveCommands', () => {
     const unbinds = cmds.filter((c) => c[1] === 'unbind');
     expect(unbinds.some((c) => c.includes('MouseDown1Status'))).toBe(true);
     expect(unbinds.some((c) => c.includes('MouseDown3Status'))).toBe(true);
+  });
+});
+
+describe('buildRollupEnableCommands', () => {
+  test('sets the gate option and both window-status formats from the shared constants', () => {
+    const cmds = buildRollupEnableCommands();
+    expect(cmds).toEqual([
+      ['tmux', 'set', '-g', '@fleet_rollup', '1'],
+      ['tmux', 'set', '-g', 'window-status-format', WINDOW_STATUS_FORMAT],
+      ['tmux', 'set', '-g', 'window-status-current-format', WINDOW_STATUS_CURRENT_FORMAT],
+    ]);
+  });
+
+  test('the format constants tint only when @fleet_state is present', () => {
+    // Conditional expansion: colored branch reads #{@fleet_state}, empty branch
+    // leaves the entry untinted.
+    expect(WINDOW_STATUS_FORMAT).toContain('#{?#{@fleet_state},#[fg=#{@fleet_state}],}');
+    expect(WINDOW_STATUS_CURRENT_FORMAT).toContain('#{?#{@fleet_state},#[fg=#{@fleet_state}],}');
+    // Current-window format keeps the bold emphasis.
+    expect(WINDOW_STATUS_CURRENT_FORMAT).toContain('#[bold]');
+  });
+
+  test('all commands invoke tmux', () => {
+    for (const cmd of buildRollupEnableCommands()) {
+      expect(cmd[0]).toBe('tmux');
+    }
   });
 });

--- a/src/cli/statusline.ts
+++ b/src/cli/statusline.ts
@@ -6,6 +6,9 @@
  * second-row format and restores the single-row status bar.
  */
 
+import { windowColorArgs } from './status.ts';
+import type { AgentState } from '../state/types.ts';
+
 // Fire only on row 1 (the fleet row) and only when the click landed on a named
 // range — either an agent's pane id or the "clear all" sentinel. Both route
 // through fleet, which decides what to do based on the range value.
@@ -20,6 +23,15 @@ const ROW1_RANGE_GUARD = '#{&&:#{==:#{mouse_status_line},1},#{!=:#{mouse_status_
 // hook at `[0]`; `-b` backgrounds it so a pane switch never waits on fleet.
 const FOCUS_HOOK_INDEX = 'pane-focus-in[99]';
 const FOCUS_HOOK_ACTION = 'run-shell -b "fleet ack \\"#{pane_id}\\""';
+
+// Window state rollup formats. The conditional `#{?#{@fleet_state},...,...}`
+// tints the entry only when the per-window option is present; unset windows
+// fall through to tmux's default look. `#F` keeps window flags; current-window
+// emphasis is preserved via the untouched window-status-current-style plus the
+// `#[bold]` prefix on the current format. Exported so install.ts can persist
+// them as `# fleet-managed` conf lines from the same source of truth.
+export const WINDOW_STATUS_FORMAT = '#{?#{@fleet_state},#[fg=#{@fleet_state}],}#I:#W#F';
+export const WINDOW_STATUS_CURRENT_FORMAT = '#{?#{@fleet_state},#[fg=#{@fleet_state}],}#[bold]#I:#W#F#[nobold]';
 
 export function buildInjectCommands(): string[][] {
   return [
@@ -57,6 +69,18 @@ export function buildInjectCommands(): string[][] {
   ];
 }
 
+// Live enable for the window state rollup: set the gate option and override the
+// window-status formats. Mirrors runStatusLineInject applying the statusline
+// live rather than waiting for a config reload. The persisted `# fleet-managed`
+// conf lines (written by install.ts) reapply this on every future tmux start.
+export function buildRollupEnableCommands(): string[][] {
+  return [
+    ['tmux', 'set', '-g', '@fleet_rollup', '1'],
+    ['tmux', 'set', '-g', 'window-status-format', WINDOW_STATUS_FORMAT],
+    ['tmux', 'set', '-g', 'window-status-current-format', WINDOW_STATUS_CURRENT_FORMAT],
+  ];
+}
+
 export function buildRemoveCommands(): string[][] {
   return [
     ['tmux', 'set', '-g', '-u', 'status-format[1]'],
@@ -66,6 +90,12 @@ export function buildRemoveCommands(): string[][] {
     // Remove only our indexed hook; leave focus-events as we found it (we can't
     // know the user's prior value, and leaving it on is harmless).
     ['tmux', 'set-hook', '-gu', FOCUS_HOOK_INDEX],
+    // Window state rollup revert. `set -g -u` reverts the format to tmux's
+    // DEFAULT (a user's own custom format reasserts on the next config reload
+    // after the # fleet-managed line is stripped — see spec Failure Modes).
+    ['tmux', 'set', '-g', '-u', 'window-status-format'],
+    ['tmux', 'set', '-g', '-u', 'window-status-current-format'],
+    ['tmux', 'set', '-g', '-u', '@fleet_rollup'],
   ];
 }
 
@@ -84,6 +114,58 @@ function runCommands(commands: string[][]): number {
   return 0;
 }
 
+// Gate: only emit window colors when the user opted in. Mirrors the
+// `tmux show -gqv @fleet-theme` read in src/terminal/theme.ts. Cheap (~2ms) and
+// only paid by users who have the statusline installed at all.
+export function rollupEnabled(): boolean {
+  try {
+    const p = Bun.spawnSync({ cmd: ['tmux', 'show', '-gqv', '@fleet_rollup'], stdout: 'pipe', stderr: 'pipe' });
+    return p.stdout.toString().trim() === '1';
+  } catch {
+    return false;
+  }
+}
+
+// One batched tmux call for all windows: `tmux set ... ; set -w -u ... ; ...`.
+// tmux treats a lone ";" arg as a command separator, so N windows = 1 spawn.
+export function emitWindowColors(states: AgentState[]): void {
+  const groups = windowColorArgs(states);
+  if (groups.length === 0) return;
+  const flat: string[] = [];
+  for (let i = 0; i < groups.length; i++) {
+    if (i > 0) flat.push(';');
+    flat.push(...groups[i]!);
+  }
+  try {
+    Bun.spawnSync({ cmd: ['tmux', ...flat], stdout: 'ignore', stderr: 'ignore' });
+  } catch {
+    // Not in tmux, or a window closed mid-batch — non-critical, next redraw retries.
+  }
+}
+
+// Sweep every window's @fleet_state so no stale tint lingers after uninstall —
+// including windows that have no fleet pane. Dynamic (lists live windows), so it
+// lives outside the static buildRemoveCommands array.
+export function clearAllWindowStates(): void {
+  try {
+    const p = Bun.spawnSync({
+      cmd: ['tmux', 'list-windows', '-a', '-F', '#{window_id}'],
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    if (p.exitCode !== 0) return;
+    const flat: string[] = [];
+    for (const id of p.stdout.toString().split('\n')) {
+      if (id.length === 0) continue;
+      if (flat.length > 0) flat.push(';');
+      flat.push('set', '-w', '-u', '-t', id, '@fleet_state');
+    }
+    if (flat.length > 0) Bun.spawnSync({ cmd: ['tmux', ...flat], stdout: 'ignore', stderr: 'ignore' });
+  } catch {
+    // Not in tmux — nothing to sweep.
+  }
+}
+
 export function runStatusLineInject(): number {
   const code = runCommands(buildInjectCommands());
   if (code === 0) {
@@ -94,6 +176,9 @@ export function runStatusLineInject(): number {
 
 export function runStatusLineRemove(): number {
   const code = runCommands(buildRemoveCommands());
+  // Sweep any residual per-window @fleet_state left by the rollup, regardless of
+  // the command exit code — the options must not survive an uninstall.
+  clearAllWindowStates();
   if (code === 0) {
     process.stdout.write('Fleet status line removed. tmux status bar reset to single row.\n');
   }

--- a/src/cli/wait.test.ts
+++ b/src/cli/wait.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, test } from 'bun:test';
+import { runWait, parseWaitState } from './wait.ts';
+import { AgentStatus, type AgentState } from '../state/types.ts';
+
+const makeState = (overrides: Partial<AgentState>): AgentState => ({
+  paneId: '%42',
+  paneNum: 42,
+  session: 'test',
+  window: 'main',
+  claudeName: null,
+  status: AgentStatus.IDLE,
+  tool: null,
+  project: '~/Developer/test',
+  branch: 'main',
+  ports: [],
+  ts: Math.floor(Date.now() / 1000),
+  agentType: 'claude',
+  ...overrides,
+});
+
+// Returns each scripted frame in turn; the last frame sticks so a "never
+// reaches" script keeps returning the same non-matching state.
+function scripted(frames: AgentState[][]) {
+  let i = 0;
+  return () => frames[Math.min(i++, frames.length - 1)]!;
+}
+
+// Deterministic clock: sleep advances virtual time instead of waiting, so a
+// timeout crosses its deadline in a few polls without any real delay.
+function fakeClock() {
+  let t = 0;
+  return {
+    now: () => t,
+    sleep: async (ms: number) => {
+      t += ms;
+    },
+  };
+}
+
+function capture() {
+  const lines: string[] = [];
+  return { sink: (s: string) => lines.push(s), text: () => lines.join('') };
+}
+
+describe('parseWaitState', () => {
+  test('maps display labels to enums (case-insensitive, trimmed)', () => {
+    expect(parseWaitState('ready')).toBe(AgentStatus.DONE);
+    expect(parseWaitState('waiting')).toBe(AgentStatus.PERMIT);
+    expect(parseWaitState('asking')).toBe(AgentStatus.QUESTION);
+    expect(parseWaitState('working')).toBe(AgentStatus.BUSY);
+    expect(parseWaitState('idle')).toBe(AgentStatus.IDLE);
+    expect(parseWaitState('READY')).toBe(AgentStatus.DONE);
+    expect(parseWaitState('  Working  ')).toBe(AgentStatus.BUSY);
+  });
+
+  test('maps raw enum names to enums (case-insensitive)', () => {
+    expect(parseWaitState('DONE')).toBe(AgentStatus.DONE);
+    expect(parseWaitState('done')).toBe(AgentStatus.DONE);
+    expect(parseWaitState('PERMIT')).toBe(AgentStatus.PERMIT);
+    expect(parseWaitState('QUESTION')).toBe(AgentStatus.QUESTION);
+    expect(parseWaitState('BUSY')).toBe(AgentStatus.BUSY);
+    expect(parseWaitState('IDLE')).toBe(AgentStatus.IDLE);
+  });
+
+  test('rejects unknown, non-waitable, and empty inputs', () => {
+    expect(parseWaitState('bogus')).toBeNull();
+    expect(parseWaitState('shell')).toBeNull();
+    expect(parseWaitState('down')).toBeNull();
+    expect(parseWaitState('')).toBeNull();
+  });
+});
+
+describe('runWait', () => {
+  test('reaches state → 0 as the session progresses across frames', async () => {
+    const clock = fakeClock();
+    const code = await runWait({
+      session: 'test',
+      stateArg: 'ready',
+      timeoutArg: undefined,
+      getStates: scripted([
+        [makeState({ status: AgentStatus.BUSY })],
+        [makeState({ status: AgentStatus.BUSY })],
+        [makeState({ status: AgentStatus.DONE })],
+      ]),
+      sleep: clock.sleep,
+      now: clock.now,
+    });
+    expect(code).toBe(0);
+  });
+
+  test('timeout → 124 when the target never appears', async () => {
+    const clock = fakeClock();
+    const code = await runWait({
+      session: 'test',
+      stateArg: 'ready',
+      timeoutArg: '1', // deadline at t=1000ms; POLL_MS=500 crosses it in a few polls
+      getStates: scripted([[makeState({ status: AgentStatus.BUSY })]]),
+      sleep: clock.sleep,
+      now: clock.now,
+    });
+    expect(code).toBe(124);
+  });
+
+  test('unknown --state → exit 1 with "Unknown state"', async () => {
+    const cap = capture();
+    const code = await runWait({
+      session: 'test',
+      stateArg: 'bogus',
+      timeoutArg: undefined,
+      getStates: () => [],
+      sleep: async () => {},
+      now: () => 0,
+      stderr: cap.sink,
+    });
+    expect(code).toBe(1);
+    expect(cap.text()).toContain('Unknown state');
+  });
+
+  test('non-waitable --state (shell) → exit 1 with "Unknown state"', async () => {
+    const cap = capture();
+    const code = await runWait({
+      session: 'test',
+      stateArg: 'shell',
+      timeoutArg: undefined,
+      getStates: () => [],
+      sleep: async () => {},
+      now: () => 0,
+      stderr: cap.sink,
+    });
+    expect(code).toBe(1);
+    expect(cap.text()).toContain('Unknown state');
+  });
+
+  test('unknown session at start → exit 1 with "No agents found"', async () => {
+    const cap = capture();
+    const code = await runWait({
+      session: 'test',
+      stateArg: 'ready',
+      timeoutArg: undefined,
+      getStates: () => [makeState({ session: 'other' })],
+      sleep: async () => {},
+      now: () => 0,
+      stderr: cap.sink,
+    });
+    expect(code).toBe(1);
+    expect(cap.text()).toContain("No agents found in session 'test'");
+  });
+
+  test('already satisfied at start → 0 with zero sleep calls', async () => {
+    const clock = fakeClock();
+    let sleepCalls = 0;
+    const code = await runWait({
+      session: 'test',
+      stateArg: 'ready',
+      timeoutArg: undefined,
+      getStates: scripted([[makeState({ status: AgentStatus.DONE })]]),
+      sleep: async (ms) => {
+        sleepCalls++;
+        await clock.sleep(ms);
+      },
+      now: clock.now,
+    });
+    expect(code).toBe(0);
+    expect(sleepCalls).toBe(0);
+  });
+
+  test('any-pane match: only the second pane in the session is at target → 0', async () => {
+    const clock = fakeClock();
+    const code = await runWait({
+      session: 'test',
+      stateArg: 'ready',
+      timeoutArg: undefined,
+      getStates: scripted([
+        [makeState({ paneId: '%1', status: AgentStatus.BUSY }), makeState({ paneId: '%2', status: AgentStatus.DONE })],
+      ]),
+      sleep: clock.sleep,
+      now: clock.now,
+    });
+    expect(code).toBe(0);
+  });
+
+  test('session disappears mid-wait → exit 1 with "disappeared while waiting"', async () => {
+    const cap = capture();
+    const clock = fakeClock();
+    const code = await runWait({
+      session: 'test',
+      stateArg: 'ready',
+      timeoutArg: undefined,
+      getStates: scripted([[makeState({ status: AgentStatus.BUSY })], []]),
+      sleep: clock.sleep,
+      now: clock.now,
+      stderr: cap.sink,
+    });
+    expect(code).toBe(1);
+    expect(cap.text()).toContain("Session 'test' disappeared while waiting");
+  });
+
+  test('--timeout 0 → one check then 124 without sleeping', async () => {
+    const clock = fakeClock();
+    let sleepCalls = 0;
+    const code = await runWait({
+      session: 'test',
+      stateArg: 'ready',
+      timeoutArg: '0',
+      getStates: scripted([[makeState({ status: AgentStatus.BUSY })]]),
+      sleep: async (ms) => {
+        sleepCalls++;
+        await clock.sleep(ms);
+      },
+      now: clock.now,
+    });
+    expect(code).toBe(124);
+    expect(sleepCalls).toBe(0);
+  });
+
+  test('invalid --timeout → exit 1 with "Invalid --timeout"', async () => {
+    const cap = capture();
+    const code = await runWait({
+      session: 'test',
+      stateArg: 'ready',
+      timeoutArg: 'abc',
+      getStates: () => [],
+      sleep: async () => {},
+      now: () => 0,
+      stderr: cap.sink,
+    });
+    expect(code).toBe(1);
+    expect(cap.text()).toContain('Invalid --timeout');
+  });
+
+  test('missing session → usage error, exit 1', async () => {
+    const cap = capture();
+    const code = await runWait({
+      session: undefined,
+      stateArg: 'ready',
+      timeoutArg: undefined,
+      getStates: () => [],
+      sleep: async () => {},
+      now: () => 0,
+      stderr: cap.sink,
+    });
+    expect(code).toBe(1);
+    expect(cap.text()).toContain('Usage: fleet wait');
+  });
+});

--- a/src/cli/wait.test.ts
+++ b/src/cli/wait.test.ts
@@ -7,6 +7,7 @@ const makeState = (overrides: Partial<AgentState>): AgentState => ({
   paneNum: 42,
   session: 'test',
   window: 'main',
+  windowId: '@1',
   claudeName: null,
   status: AgentStatus.IDLE,
   tool: null,

--- a/src/cli/wait.test.ts
+++ b/src/cli/wait.test.ts
@@ -9,6 +9,7 @@ const makeState = (overrides: Partial<AgentState>): AgentState => ({
   window: 'main',
   windowId: '@1',
   claudeName: null,
+  customName: null,
   status: AgentStatus.IDLE,
   tool: null,
   project: '~/Developer/test',

--- a/src/cli/wait.ts
+++ b/src/cli/wait.ts
@@ -1,0 +1,98 @@
+import { AgentStatus, type AgentState } from '../state/types.ts';
+
+// Matches the app's FAST_REFRESH_MS (index.ts:40) — poll on the same cadence the
+// TUI refreshes, so `wait` observes state transitions as promptly as the app does.
+export const POLL_MS = 500;
+
+export interface RunWaitOptions {
+  session: string | undefined; // args[1]
+  stateArg: string | undefined; // value after --state
+  timeoutArg: string | undefined; // value after --timeout (seconds), if present
+  getStates: () => AgentState[]; // prod: () => fullRefreshStates(statusDirs)
+  sleep: (ms: number) => Promise<void>; // prod: (ms) => new Promise((r) => setTimeout(r, ms))
+  now: () => number; // prod: () => Date.now()  (epoch ms)
+  stderr?: (s: string) => void; // prod: (s) => { process.stderr.write(s); }
+}
+
+// Accepted --state values → AgentStatus, keyed by lowercased input. Both the
+// display labels (STATUS_DISPLAY, types.ts) and the raw enum names are accepted.
+// There is no READY enum — 'ready' is DONE's display label. SHELL/DOWN are
+// intentionally omitted: they are not meaningful orchestration targets.
+const WAIT_STATES: Record<string, AgentStatus> = {
+  // display labels (STATUS_DISPLAY)
+  ready: AgentStatus.DONE, // NOTE: 'ready' is DONE's label; there is no READY enum
+  waiting: AgentStatus.PERMIT,
+  asking: AgentStatus.QUESTION,
+  working: AgentStatus.BUSY,
+  idle: AgentStatus.IDLE,
+  // raw enum names (idle/IDLE coincide once lowercased)
+  done: AgentStatus.DONE,
+  permit: AgentStatus.PERMIT,
+  question: AgentStatus.QUESTION,
+  busy: AgentStatus.BUSY,
+};
+
+export function parseWaitState(input: string): AgentStatus | null {
+  return WAIT_STATES[input.trim().toLowerCase()] ?? null;
+}
+
+const USAGE = 'Usage: fleet wait <session> --state <state> [--timeout <seconds>]\n';
+
+export async function runWait(opts: RunWaitOptions): Promise<number> {
+  const err =
+    opts.stderr ??
+    ((s: string) => {
+      process.stderr.write(s);
+    });
+
+  if (!opts.session) {
+    err(USAGE);
+    return 1;
+  }
+  if (!opts.stateArg) {
+    err(USAGE);
+    return 1;
+  }
+
+  const target = parseWaitState(opts.stateArg);
+  if (target === null) {
+    err(`Unknown state '${opts.stateArg}'. Valid: ready|waiting|asking|working|idle\n`);
+    return 1;
+  }
+
+  let timeoutSecs: number | null = null;
+  if (opts.timeoutArg !== undefined) {
+    const n = Number(opts.timeoutArg);
+    if (!Number.isFinite(n) || n < 0) {
+      err(`Invalid --timeout '${opts.timeoutArg}': expected a non-negative number of seconds\n`);
+      return 1;
+    }
+    timeoutSecs = n;
+  }
+
+  const startMs = opts.now();
+  const deadlineMs = timeoutSecs === null ? null : startMs + timeoutSecs * 1000;
+  let firstPoll = true;
+
+  for (;;) {
+    const inSession = opts.getStates().filter((s) => s.session === opts.session);
+
+    // Missing before satisfied before expired: a first-poll miss is "not found",
+    // a later miss means the session vanished mid-wait.
+    if (inSession.length === 0) {
+      err(
+        firstPoll
+          ? `No agents found in session '${opts.session}'\n`
+          : `Session '${opts.session}' disappeared while waiting\n`,
+      );
+      return 1;
+    }
+
+    if (inSession.some((s) => s.status === target)) return 0; // reached → success
+
+    if (deadlineMs !== null && opts.now() >= deadlineMs) return 124; // timeout(1) convention
+
+    firstPoll = false;
+    await opts.sleep(POLL_MS);
+  }
+}

--- a/src/state/codex-detection.test.ts
+++ b/src/state/codex-detection.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'bun:test';
+import { detectFromPaneContent } from './scraper.ts';
+import { CODEX_MANIFEST } from './detection.ts';
+import { AgentStatus } from './types.ts';
+
+// The inlined Codex patterns run through the same Phase 2 detector as claude.
+// Every prompt rule is PERMIT (Codex has no Notification hook and no distinct
+// question dialog, so QUESTION is not currently sourced for it); BUSY/DONE come
+// from the hook, not scraping.
+describe('CODEX_MANIFEST classification', () => {
+  const permitCases: Array<{ name: string; lines: string[]; ruleId: string }> = [
+    { name: 'allow command?', lines: ['Allow command?'], ruleId: 'permit.allow' },
+    {
+      name: 'press enter to confirm',
+      lines: ['Press Enter to confirm or Esc to cancel'],
+      ruleId: 'permit.confirm',
+    },
+    { name: '[y/n]', lines: ['Overwrite file? [y/n]'], ruleId: 'permit.yn' },
+    { name: 'do you want to', lines: ['Do you want to apply this patch?'], ruleId: 'permit.do-you-want' },
+  ];
+
+  for (const c of permitCases) {
+    test(`${c.name} => PERMIT (${c.ruleId})`, () => {
+      const r = detectFromPaneContent(c.lines, CODEX_MANIFEST);
+      expect(r.status).toBe(AgentStatus.PERMIT);
+      expect(r.ruleId).toBe(c.ruleId);
+    });
+  }
+
+  test('bare prompt marker => IDLE', () => {
+    const r = detectFromPaneContent(['patch applied.', '', '❯'], CODEX_MANIFEST);
+    expect(r.status).toBe(AgentStatus.IDLE);
+    expect(r.ruleId).toBe('idle.prompt');
+  });
+
+  test('unrecognized content => null', () => {
+    const r = detectFromPaneContent(['$ ls', 'README.md', 'src'], CODEX_MANIFEST);
+    expect(r.status).toBeNull();
+    expect(r.ruleId).toBeNull();
+  });
+
+  test('first match wins on a line matching several rules', () => {
+    // Matches permit.allow, permit.yn AND permit.do-you-want; the earliest
+    // rule (permit.allow) must win.
+    const r = detectFromPaneContent(['Do you want to allow command? [y/n]'], CODEX_MANIFEST);
+    expect(r.status).toBe(AgentStatus.PERMIT);
+    expect(r.ruleId).toBe('permit.allow');
+  });
+});

--- a/src/state/detection.test.ts
+++ b/src/state/detection.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { detectFromPaneContent } from './scraper.ts';
+import { __resetManifestCache, CLAUDE_MANIFEST, loadDetectionManifest, type DetectionManifest } from './detection.ts';
+import { AgentStatus } from './types.ts';
+
+const originalXdg = process.env.XDG_CONFIG_HOME;
+let tempDirs: string[] = [];
+let stderrSpy!: ReturnType<typeof spyOn<typeof process.stderr, 'write'>>;
+
+function writeOverride(agent: string, contents: string): string {
+  const cfg = mkdtempSync(join(tmpdir(), 'fleet-detect-'));
+  const dir = join(cfg, 'fleet', 'detection');
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `${agent}.json`), contents);
+  tempDirs.push(cfg);
+  return cfg;
+}
+
+beforeEach(() => {
+  __resetManifestCache();
+  tempDirs = [];
+  // Silence + capture detection warnings; specific tests assert on the spy.
+  stderrSpy = spyOn(process.stderr, 'write').mockImplementation(() => true);
+});
+
+afterEach(() => {
+  stderrSpy.mockRestore();
+  if (originalXdg === undefined) delete process.env.XDG_CONFIG_HOME;
+  else process.env.XDG_CONFIG_HOME = originalXdg;
+  for (const d of tempDirs) rmSync(d, { recursive: true, force: true });
+  __resetManifestCache();
+});
+
+// 1. Built-in reproduction — an independent guard that CLAUDE_MANIFEST matches the
+//    pre-Phase-2 scraper, so a manifest edit that diverges is caught even if the
+//    frozen scraper.test.ts somehow didn't. Marker cases assert 'idle.prompt' (the
+//    id the regression lock asserts), not null.
+describe('CLAUDE_MANIFEST reproduces the pre-Phase-2 scraper', () => {
+  const cases: Array<{ name: string; lines: string[]; status: AgentStatus | null; ruleId: string | null }> = [
+    { name: 'permit [y/n]', lines: ['Allow Edit?', '[y/n]'], status: AgentStatus.PERMIT, ruleId: 'permit.yn' },
+    { name: 'permit [Y/n]', lines: ['Allow Read?', '[Y/n]'], status: AgentStatus.PERMIT, ruleId: 'permit.yn' },
+    {
+      name: 'permit do-you-want',
+      lines: ['Do you want to proceed?'],
+      status: AgentStatus.PERMIT,
+      ruleId: 'permit.do-you-want',
+    },
+    {
+      name: 'question enter-select',
+      lines: ['Enter to select · ↑/↓ to navigate · Esc to cancel'],
+      status: AgentStatus.QUESTION,
+      ruleId: 'question.enter-select',
+    },
+    {
+      name: 'busy token counter (minutes)',
+      lines: ['✻ Trapping Gollum… (1m 11s · ↓ 3.4k tokens)', '', '❯'],
+      status: AgentStatus.BUSY,
+      ruleId: 'busy.token-counter-min',
+    },
+    {
+      name: 'busy token counter (seconds)',
+      lines: ['✢ Sharting… (8s · ↑ 240 tokens)', '', '❯'],
+      status: AgentStatus.BUSY,
+      ruleId: 'busy.token-counter-sec',
+    },
+    {
+      name: 'busy esc to interrupt',
+      lines: ['Running command…', '', '(esc to interrupt)', '❯'],
+      status: AgentStatus.BUSY,
+      ruleId: 'busy.esc-interrupt',
+    },
+    { name: 'idle prompt marker', lines: ['Done!', '', '❯'], status: AgentStatus.IDLE, ruleId: 'idle.prompt' },
+    {
+      name: 'bare spinner + prompt reads idle via marker',
+      lines: ['✶ Thinking…', '', '❯'],
+      status: AgentStatus.IDLE,
+      ruleId: 'idle.prompt',
+    },
+    { name: 'no match', lines: ['$ ls', 'file1.ts', 'file2.ts'], status: null, ruleId: null },
+  ];
+  for (const c of cases) {
+    test(c.name, () => {
+      const r = detectFromPaneContent(c.lines, CLAUDE_MANIFEST);
+      expect(r.status).toBe(c.status);
+      expect(r.ruleId).toBe(c.ruleId);
+    });
+  }
+});
+
+// 2. Ordered precedence — proves "first match wins", not "most specific wins".
+test('ordered rules: the first matching rule wins on text that matches several', () => {
+  const both = ['Do you want to proceed? (8s · ↑ 240 tokens)'];
+  const permitFirst: DetectionManifest = {
+    agent: 't',
+    linesFromBottom: 15,
+    promptMarker: '',
+    rules: [
+      { id: 'p', pattern: 'Do you want to (proceed|allow)', state: 'PERMIT' },
+      { id: 'b', pattern: '\\(\\d+s\\s+·.*tokens?\\)', state: 'BUSY' },
+    ],
+  };
+  expect(detectFromPaneContent(both, permitFirst)).toEqual({ status: AgentStatus.PERMIT, ruleId: 'p' });
+
+  const busyFirst: DetectionManifest = { ...permitFirst, rules: [permitFirst.rules[1]!, permitFirst.rules[0]!] };
+  expect(detectFromPaneContent(both, busyFirst)).toEqual({ status: AgentStatus.BUSY, ruleId: 'b' });
+});
+
+// 3. Override replaces built-in wholesale (never merges).
+test('a valid user override replaces the built-in manifest entirely', () => {
+  const cfg = writeOverride(
+    'claude',
+    JSON.stringify({
+      agent: 'claude',
+      linesFromBottom: 15,
+      promptMarker: '❯',
+      rules: [{ id: 'q.only', pattern: 'PICK ONE', state: 'QUESTION' }],
+    }),
+  );
+  process.env.XDG_CONFIG_HOME = cfg;
+  __resetManifestCache();
+
+  const m = loadDetectionManifest('claude');
+  // Only the override's rule survives — built-in permit/busy rules are gone.
+  expect(m.rules.map((r) => r.id)).toEqual(['q.only']);
+  // A [y/n] screen the built-in would call PERMIT now matches nothing.
+  expect(detectFromPaneContent(['Allow Edit? [y/n]'], m).status).toBeNull();
+  // The override's own rule fires.
+  expect(detectFromPaneContent(['PICK ONE of these'], m)).toEqual({ status: AgentStatus.QUESTION, ruleId: 'q.only' });
+});
+
+// 4. Malformed override -> built-in + warn (must never throw). Two variants.
+test('a malformed-JSON override is ignored: built-in used, warning emitted, no throw', () => {
+  const cfg = writeOverride('claude', '{ this is not valid json ]');
+  process.env.XDG_CONFIG_HOME = cfg;
+  __resetManifestCache();
+
+  const m = loadDetectionManifest('claude');
+  expect(m).toBe(CLAUDE_MANIFEST); // exact built-in object, by reference
+  expect(stderrSpy).toHaveBeenCalled();
+});
+
+test('a schema-invalid override (rules not an array) is ignored: built-in used, warning emitted', () => {
+  const cfg = writeOverride('claude', JSON.stringify({ agent: 'claude', rules: { nope: true } }));
+  process.env.XDG_CONFIG_HOME = cfg;
+  __resetManifestCache();
+
+  const m = loadDetectionManifest('claude');
+  expect(m).toBe(CLAUDE_MANIFEST);
+  expect(stderrSpy).toHaveBeenCalled();
+});
+
+// 5. Bad-regex rule -> dropped (once, at load) + warn; sibling rules survive.
+test('an invalid-regex rule is dropped with a single warning; the good rule survives', () => {
+  const cfg = writeOverride(
+    'claude',
+    JSON.stringify({
+      agent: 'claude',
+      linesFromBottom: 15,
+      promptMarker: '❯',
+      rules: [
+        { id: 'bad', pattern: '(', state: 'BUSY' }, // unbalanced paren -> RegExp throws
+        { id: 'good', pattern: 'HELLO', state: 'QUESTION' },
+      ],
+    }),
+  );
+  process.env.XDG_CONFIG_HOME = cfg;
+  __resetManifestCache();
+
+  const m = loadDetectionManifest('claude');
+  expect(m.rules.map((r) => r.id)).toEqual(['good']); // bad dropped, good kept
+  expect(stderrSpy).toHaveBeenCalledTimes(1); // one warn, at load — not once per scrape
+  // Scraping again does not re-warn (regex is cached) and the good rule fires.
+  expect(detectFromPaneContent(['say HELLO now'], m)).toEqual({ status: AgentStatus.QUESTION, ruleId: 'good' });
+  expect(stderrSpy).toHaveBeenCalledTimes(1);
+});
+
+// 6. linesFromBottom bounds the rule-match window.
+test('linesFromBottom bounds the rule-match window', () => {
+  const m: DetectionManifest = {
+    agent: 't',
+    linesFromBottom: 5,
+    promptMarker: '',
+    rules: [{ id: 'hit', pattern: 'NEEDLE', state: 'BUSY' }],
+  };
+  const above = ['NEEDLE', ...Array.from({ length: 19 }, () => 'x')]; // NEEDLE at the top of 20 lines
+  expect(detectFromPaneContent(above, m).status).toBeNull(); // outside the 5-line window
+  const inside = [...Array.from({ length: 19 }, () => 'x'), 'NEEDLE']; // NEEDLE at the bottom
+  expect(detectFromPaneContent(inside, m)).toEqual({ status: AgentStatus.BUSY, ruleId: 'hit' });
+});
+
+// 7. Prompt-marker fallback, including the intentional full-buffer scan quirk.
+test('prompt-marker fallback: present => IDLE, absent => null, above-window still IDLE', () => {
+  const m: DetectionManifest = { agent: 't', linesFromBottom: 5, promptMarker: '❯', rules: [] };
+  // Marker in the bottom window.
+  expect(detectFromPaneContent(['work', '❯'], m)).toEqual({ status: AgentStatus.IDLE, ruleId: 'idle.prompt' });
+  // Marker absent entirely.
+  expect(detectFromPaneContent(['just some text'], m).status).toBeNull();
+  // Marker present only ABOVE linesFromBottom — still IDLE (marker scan spans the
+  // full buffer, unlike the windowed rule match; a preserved pre-Phase-2 quirk).
+  const deep = ['❯', ...Array.from({ length: 19 }, () => 'scrollback')];
+  expect(detectFromPaneContent(deep, m)).toEqual({ status: AgentStatus.IDLE, ruleId: 'idle.prompt' });
+});
+
+// 8. Unknown agent (no built-in, no override) -> empty manifest, safe null result.
+test('an unknown agent with no override yields an empty manifest and warns', () => {
+  const cfg = mkdtempSync(join(tmpdir(), 'fleet-detect-empty-'));
+  tempDirs.push(cfg);
+  process.env.XDG_CONFIG_HOME = cfg;
+  __resetManifestCache();
+
+  const m = loadDetectionManifest('does-not-exist');
+  expect(m.rules).toEqual([]);
+  expect(m.promptMarker).toBe('');
+  expect(stderrSpy).toHaveBeenCalled();
+  // Even with content the built-in would recognize, an empty manifest detects nothing.
+  expect(detectFromPaneContent(['[y/n]', '❯'], m)).toEqual({ status: null, ruleId: null });
+});

--- a/src/state/detection.ts
+++ b/src/state/detection.ts
@@ -107,8 +107,29 @@ export const CLAUDE_MANIFEST: DetectionManifest = {
   ],
 };
 
+// --- the embedded built-in `codex` manifest (Phase 3) ---
+// Codex fires PreToolUse+Stop hooks, so BUSY/DONE come from the hook (which is
+// authoritative and faster than any spinner regex) — no BUSY scrape rule is
+// needed. Codex has no Notification hook and its on-screen prompts don't cleanly
+// separate a permission request from a question, so every prompt rule is PERMIT
+// (QUESTION is not currently sourced for Codex — a documented limitation). Rules
+// are ORDERED, first match wins, exactly like CLAUDE_MANIFEST; ids follow the
+// same `<state>.<slug>` convention. A TS object literal (never a runtime file
+// read) so `bun build --compile` bundles it into the binary.
+export const CODEX_MANIFEST: DetectionManifest = {
+  agent: 'codex',
+  linesFromBottom: 15,
+  promptMarker: '❯',
+  rules: [
+    { id: 'permit.allow', pattern: 'allow command\\?', flags: 'i', state: 'PERMIT' },
+    { id: 'permit.confirm', pattern: 'press enter to confirm or esc to cancel', flags: 'i', state: 'PERMIT' },
+    { id: 'permit.yn', pattern: '\\[y/n\\]', flags: 'i', state: 'PERMIT' },
+    { id: 'permit.do-you-want', pattern: 'do you want to', flags: 'i', state: 'PERMIT' },
+  ],
+};
+
 // --- loader: built-in, replaced wholesale by a valid override ---
-const BUILTINS: Record<string, DetectionManifest> = { claude: CLAUDE_MANIFEST };
+const BUILTINS: Record<string, DetectionManifest> = { claude: CLAUDE_MANIFEST, codex: CODEX_MANIFEST };
 const manifestCache = new Map<string, DetectionManifest>();
 
 export function loadDetectionManifest(agent: string): DetectionManifest {

--- a/src/state/detection.ts
+++ b/src/state/detection.ts
@@ -1,0 +1,147 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+// `state` is the serialized (JSON) label; it maps 1:1 onto the subset of
+// AgentStatus values the scraper can emit (see RULE_STATE_TO_STATUS in scraper.ts).
+export type RuleState = 'PERMIT' | 'QUESTION' | 'BUSY' | 'IDLE';
+
+export interface DetectionRule {
+  id: string;
+  pattern: string; // JavaScript RegExp source (JSON-escaped on disk)
+  flags?: string; // e.g. "i"
+  state: RuleState;
+}
+
+export interface DetectionManifest {
+  agent: string;
+  linesFromBottom: number; // rule-match window; default 15 (matches the old scraper window)
+  promptMarker: string; // if NO rule matches, present => IDLE, absent => null
+  rules: DetectionRule[]; // ORDERED; first match wins
+}
+
+const DEFAULT_LINES_FROM_BOTTOM = 15;
+
+// The prompt-marker fallback is not a `rules` entry, but it still names the
+// branch that fired so `fleet explain` can show why the scraper read IDLE. This
+// is the id the post-Phase-1 regression lock (scraper.test.ts) asserts.
+export const PROMPT_MARKER_RULE_ID = 'idle.prompt';
+
+function warn(msg: string): void {
+  // Never throw from detection; degrade to built-in and tell stderr.
+  process.stderr.write(`fleet: ${msg}\n`);
+}
+
+// --- regex compile + cache (compile once per pattern+flags) ---
+const regexCache = new Map<string, RegExp | null>();
+
+export function getCompiledRegex(rule: DetectionRule): RegExp | null {
+  // Null byte separator so `{flags,pattern}` can never collide with a
+  // different `{flags,pattern}` pair that happens to concatenate the same way.
+  const key = `${rule.flags ?? ''}\0${rule.pattern}`;
+  const hit = regexCache.get(key);
+  if (hit !== undefined) return hit;
+  let re: RegExp | null;
+  try {
+    re = new RegExp(rule.pattern, rule.flags);
+  } catch (err) {
+    warn(`detection: skipping rule "${rule.id}" — bad pattern /${rule.pattern}/${rule.flags ?? ''}: ${String(err)}`);
+    re = null;
+  }
+  regexCache.set(key, re);
+  return re;
+}
+
+// --- override validation (schema only; JSON.parse already ran) ---
+const VALID_STATES: ReadonlySet<string> = new Set(['PERMIT', 'QUESTION', 'BUSY', 'IDLE']);
+
+function validateManifest(raw: unknown, agent: string): DetectionManifest {
+  if (typeof raw !== 'object' || raw === null) throw new Error('manifest is not an object');
+  const m = raw as Record<string, unknown>;
+  if (!Array.isArray(m.rules)) throw new Error('manifest.rules must be an array');
+
+  const rules: DetectionRule[] = [];
+  for (const r of m.rules) {
+    if (typeof r !== 'object' || r === null) continue;
+    const rule = r as Record<string, unknown>;
+    if (typeof rule.id !== 'string' || typeof rule.pattern !== 'string') continue;
+    if (typeof rule.state !== 'string' || !VALID_STATES.has(rule.state)) continue;
+    const flags = typeof rule.flags === 'string' ? rule.flags : undefined;
+    const candidate: DetectionRule = {
+      id: rule.id,
+      pattern: rule.pattern,
+      flags,
+      state: rule.state as RuleState,
+    };
+    // Drop bad-regex rules at load with one warning (not once per scrape).
+    if (getCompiledRegex(candidate) === null) continue;
+    rules.push(candidate);
+  }
+
+  return {
+    agent,
+    linesFromBottom:
+      typeof m.linesFromBottom === 'number' && m.linesFromBottom > 0 ? m.linesFromBottom : DEFAULT_LINES_FROM_BOTTOM,
+    promptMarker: typeof m.promptMarker === 'string' ? m.promptMarker : '',
+    rules,
+  };
+}
+
+// --- the embedded built-in `claude` manifest (byte-for-byte reproduction) ---
+// Each rule id, pattern, flag, and state is a direct translation of the literal
+// regexes the scraper used before Phase 2, in the same statement order. First
+// match wins, so PERMIT/QUESTION rules precede the BUSY rules exactly as the old
+// control flow did. Compiled into the binary (bun build --compile ships no
+// source tree), so this is a TS object literal, never a runtime file read.
+export const CLAUDE_MANIFEST: DetectionManifest = {
+  agent: 'claude',
+  linesFromBottom: 15,
+  promptMarker: '❯',
+  rules: [
+    { id: 'permit.yn', pattern: '\\[y/n\\]|\\[Y/n\\]', flags: 'i', state: 'PERMIT' },
+    { id: 'permit.do-you-want', pattern: 'Do you want to (proceed|allow)', state: 'PERMIT' },
+    { id: 'question.enter-select', pattern: 'Enter to select.*[↑↓]|Esc to cancel', state: 'QUESTION' },
+    { id: 'busy.token-counter-min', pattern: '\\(\\d+m\\s+\\d+s\\s+·.*tokens?\\)', state: 'BUSY' },
+    { id: 'busy.token-counter-sec', pattern: '\\(\\d+s\\s+·.*tokens?\\)', state: 'BUSY' },
+    { id: 'busy.esc-interrupt', pattern: 'esc to interrupt', flags: 'i', state: 'BUSY' },
+  ],
+};
+
+// --- loader: built-in, replaced wholesale by a valid override ---
+const BUILTINS: Record<string, DetectionManifest> = { claude: CLAUDE_MANIFEST };
+const manifestCache = new Map<string, DetectionManifest>();
+
+export function loadDetectionManifest(agent: string): DetectionManifest {
+  const cached = manifestCache.get(agent);
+  if (cached) return cached;
+
+  const builtin = BUILTINS[agent] ?? null;
+  const configDir = process.env.XDG_CONFIG_HOME ?? join(homedir(), '.config');
+  const overridePath = join(configDir, 'fleet', 'detection', `${agent}.json`);
+
+  let resolved: DetectionManifest | null = builtin;
+  if (existsSync(overridePath)) {
+    try {
+      const parsed: unknown = JSON.parse(readFileSync(overridePath, 'utf-8'));
+      resolved = validateManifest(parsed, agent); // override REPLACES built-in
+    } catch (err) {
+      warn(`detection: ignoring malformed override ${overridePath} — ${String(err)}; using built-in`);
+      resolved = builtin;
+    }
+  }
+
+  if (!resolved) {
+    warn(`detection: no built-in or override manifest for agent "${agent}"; scrape detection disabled`);
+    resolved = { agent, linesFromBottom: DEFAULT_LINES_FROM_BOTTOM, promptMarker: '', rules: [] };
+  }
+
+  manifestCache.set(agent, resolved);
+  return resolved;
+}
+
+// Test seam: overrides are memoized per agent; tests reset the caches between
+// cases so a fresh temp override (or a bad regex) is re-read, not served stale.
+export function __resetManifestCache(): void {
+  manifestCache.clear();
+  regexCache.clear();
+}

--- a/src/state/detection.ts
+++ b/src/state/detection.ts
@@ -128,8 +128,27 @@ export const CODEX_MANIFEST: DetectionManifest = {
   ],
 };
 
+// --- the embedded built-in `pi` manifest ---
+// pi (npm: @mariozechner/pi-coding-agent) is wired via a fleet extension, not
+// scraping:
+// the fleet-pi extension subscribes to pi's agent_start / tool_execution_start /
+// agent_end lifecycle events and writes working/done to ~/.cache/pi-status, so
+// BUSY/DONE/IDLE are hook-sourced and authoritative. pi auto-runs its tools —
+// there is no interactive "[y/n]" permission prompt or selection dialog on the
+// screen to match — so there are no PERMIT/QUESTION scrape rules (a documented
+// limitation, mirroring Codex's absent QUESTION). The manifest is intentionally
+// empty; it exists so `pi` resolves to a built-in (no "no manifest" warning) and
+// is a registered, known agent. A user can still drop a ~/.config/fleet/detection/
+// pi.json override to add scrape rules.
+export const PI_MANIFEST: DetectionManifest = {
+  agent: 'pi',
+  linesFromBottom: 15,
+  promptMarker: '',
+  rules: [],
+};
+
 // --- loader: built-in, replaced wholesale by a valid override ---
-const BUILTINS: Record<string, DetectionManifest> = { claude: CLAUDE_MANIFEST, codex: CODEX_MANIFEST };
+const BUILTINS: Record<string, DetectionManifest> = { claude: CLAUDE_MANIFEST, codex: CODEX_MANIFEST, pi: PI_MANIFEST };
 const manifestCache = new Map<string, DetectionManifest>();
 
 export function loadDetectionManifest(agent: string): DetectionManifest {

--- a/src/state/engine.test.ts
+++ b/src/state/engine.test.ts
@@ -14,7 +14,8 @@ describe('fuseState', () => {
       currentStatus: AgentStatus.IDLE,
       currentTs: now - 10,
     });
-    expect(result).toBe(AgentStatus.BUSY);
+    expect(result.status).toBe(AgentStatus.BUSY);
+    expect(result.decision.winner).toBe('hook');
   });
 
   test('freshness invariant rejects stale hook data', () => {
@@ -26,7 +27,10 @@ describe('fuseState', () => {
       currentStatus: AgentStatus.DONE,
       currentTs: now - 5,
     });
-    expect(result).toBe(AgentStatus.DONE);
+    expect(result.status).toBe(AgentStatus.DONE);
+    // Only the stale-hook shape reaches the freshness branch.
+    expect(result.decision.freshnessEvaluated).toBe(true);
+    expect(result.decision.winner).toBe('default');
   });
 
   test('event layer overrides hook when more specific', () => {
@@ -38,7 +42,8 @@ describe('fuseState', () => {
       currentStatus: AgentStatus.IDLE,
       currentTs: now - 10,
     });
-    expect(result).toBe(AgentStatus.BUSY);
+    expect(result.status).toBe(AgentStatus.BUSY);
+    expect(result.decision.winner).toBe('event');
   });
 
   test('scrape PERMIT always wins', () => {
@@ -47,10 +52,14 @@ describe('fuseState', () => {
       hookTs: now,
       eventStatus: AgentStatus.BUSY,
       scrapeStatus: AgentStatus.PERMIT,
+      scrapeRuleId: 'permit.yn',
       currentStatus: AgentStatus.BUSY,
       currentTs: now - 5,
     });
-    expect(result).toBe(AgentStatus.PERMIT);
+    expect(result.status).toBe(AgentStatus.PERMIT);
+    expect(result.decision.winner).toBe('scrape');
+    expect(result.decision.reason).toContain('permission');
+    expect(result.decision.scrapeRuleId).toBe('permit.yn');
   });
 
   test('scrape PERMIT overrides hook BUSY with no event', () => {
@@ -62,7 +71,8 @@ describe('fuseState', () => {
       currentStatus: AgentStatus.IDLE,
       currentTs: now - 10,
     });
-    expect(result).toBe(AgentStatus.PERMIT);
+    expect(result.status).toBe(AgentStatus.PERMIT);
+    expect(result.decision.winner).toBe('scrape');
   });
 
   test('DONE never auto-decays — a finished turn waits on you', () => {
@@ -76,7 +86,10 @@ describe('fuseState', () => {
       currentStatus: AgentStatus.IDLE,
       currentTs: 0,
     });
-    expect(result).toBe(AgentStatus.DONE);
+    expect(result.status).toBe(AgentStatus.DONE);
+    // Live wiring (currentStatus: IDLE, currentTs: 0) never reaches the freshness
+    // branch — this is the invariant fleet explain reports as "not evaluated".
+    expect(result.decision.freshnessEvaluated).toBe(false);
   });
 
   test('maps waiting to PERMIT', () => {
@@ -88,7 +101,7 @@ describe('fuseState', () => {
       currentStatus: AgentStatus.IDLE,
       currentTs: now - 10,
     });
-    expect(result).toBe(AgentStatus.PERMIT);
+    expect(result.status).toBe(AgentStatus.PERMIT);
   });
 
   test('scrape IDLE does not override a fresh working hook', () => {
@@ -102,7 +115,7 @@ describe('fuseState', () => {
       currentStatus: AgentStatus.IDLE,
       currentTs: 0,
     });
-    expect(result).toBe(AgentStatus.BUSY);
+    expect(result.status).toBe(AgentStatus.BUSY);
   });
 
   test('scrape IDLE clears a stale permit', () => {
@@ -116,7 +129,8 @@ describe('fuseState', () => {
       currentStatus: AgentStatus.IDLE,
       currentTs: 0,
     });
-    expect(result).toBe(AgentStatus.IDLE);
+    expect(result.status).toBe(AgentStatus.IDLE);
+    expect(result.decision.winner).toBe('scrape');
   });
 
   test('scrape BUSY wins over an idle hook', () => {
@@ -128,7 +142,8 @@ describe('fuseState', () => {
       currentStatus: AgentStatus.IDLE,
       currentTs: 0,
     });
-    expect(result).toBe(AgentStatus.BUSY);
+    expect(result.status).toBe(AgentStatus.BUSY);
+    expect(result.decision.winner).toBe('scrape');
   });
 
   test('scrape IDLE does not override a fresh DONE', () => {
@@ -144,7 +159,7 @@ describe('fuseState', () => {
       currentStatus: AgentStatus.IDLE,
       currentTs: 0,
     });
-    expect(result).toBe(AgentStatus.DONE);
+    expect(result.status).toBe(AgentStatus.DONE);
   });
 
   test('working hook past the timeout decays to idle', () => {
@@ -156,6 +171,8 @@ describe('fuseState', () => {
       currentStatus: AgentStatus.IDLE,
       currentTs: 0,
     });
-    expect(result).toBe(AgentStatus.IDLE);
+    expect(result.status).toBe(AgentStatus.IDLE);
+    expect(result.decision.workingTimeoutFired).toBe(true);
+    expect(result.decision.winner).toBe('default');
   });
 });

--- a/src/state/engine.ts
+++ b/src/state/engine.ts
@@ -1,4 +1,4 @@
-import { AgentStatus } from './types.ts';
+import { AgentStatus, type StateDecision } from './types.ts';
 
 const WORKING_TIMEOUT_SECS = 180;
 
@@ -6,9 +6,16 @@ export interface FuseInput {
   hookState: string;
   hookTs: number;
   eventStatus: AgentStatus | null;
+  eventTs?: number | null; // NEW (optional): last event ts, for the trace only
   scrapeStatus: AgentStatus | null;
+  scrapeRuleId?: string | null; // NEW (optional): matched scraper rule, for the trace only
   currentStatus: AgentStatus;
   currentTs: number;
+}
+
+export interface FuseResult {
+  status: AgentStatus;
+  decision: StateDecision;
 }
 
 function mapHookState(state: string): AgentStatus {
@@ -29,11 +36,33 @@ function mapHookState(state: string): AgentStatus {
   }
 }
 
-export function fuseState(input: FuseInput): AgentStatus {
+export function fuseState(input: FuseInput): FuseResult {
   const now = Math.floor(Date.now() / 1000);
+  const hookCandidate = mapHookState(input.hookState);
+  const decision: StateDecision = {
+    final: AgentStatus.IDLE,
+    candidates: { hook: hookCandidate, event: input.eventStatus, scrape: input.scrapeStatus },
+    hookTs: input.hookTs,
+    eventTs: input.eventTs ?? null,
+    now,
+    winner: 'hook',
+    reason: '',
+    workingTimeoutFired: false,
+    freshnessEvaluated: false,
+    scrapeRuleId: input.scrapeRuleId ?? null,
+  };
+  const finish = (status: AgentStatus, winner: StateDecision['winner'], reason: string): FuseResult => {
+    decision.final = status;
+    decision.winner = winner;
+    decision.reason = reason;
+    return { status, decision };
+  };
 
   // Freshness invariant: a newer in-memory state beats a staler hook write.
+  // DEAD in live — index.ts passes currentTs=0, currentStatus=IDLE, so the second
+  // clause is always false and this branch never fires outside engine.test.ts.
   if (input.hookTs <= input.currentTs && input.currentStatus !== AgentStatus.IDLE) {
+    decision.freshnessEvaluated = true;
     const age = now - input.currentTs;
     // A stuck "working" eventually retires — a crashed turn shouldn't spin
     // forever. But DONE never auto-decays: a finished turn is waiting on you and
@@ -41,29 +70,40 @@ export function fuseState(input: FuseInput): AgentStatus {
     // starts working again). Timing out a pending hand-off into "idle" is what
     // made questions silently disappear.
     if (input.currentStatus === AgentStatus.BUSY && age >= WORKING_TIMEOUT_SECS) {
-      return AgentStatus.IDLE;
+      decision.workingTimeoutFired = true;
+      return finish(AgentStatus.IDLE, 'default', `stale in-memory BUSY aged ${age}s ≥ ${WORKING_TIMEOUT_SECS}s`);
     }
-    return input.currentStatus;
+    return finish(
+      input.currentStatus,
+      'default',
+      'freshness invariant: newer in-memory state kept over a staler hook write',
+    );
   }
 
   // The scraper reliably reads permission prompts ([y/n], "Do you want to…") and
   // question dialogs ("Enter to select") — fixed on-screen strings the hook layer
   // can't tell apart. Trust those reads absolutely.
   if (input.scrapeStatus === AgentStatus.PERMIT || input.scrapeStatus === AgentStatus.QUESTION) {
-    return input.scrapeStatus;
+    return finish(
+      input.scrapeStatus,
+      'scrape',
+      'scraper read an on-screen permission/question prompt — trusted absolutely',
+    );
   }
 
   // Derive the hook/event activity status — the reliable BUSY/DONE signal.
   // PreToolUse fires the instant a tool runs; Stop fires when a turn ends.
-  let derived = input.eventStatus ?? mapHookState(input.hookState);
+  let derived = input.eventStatus ?? hookCandidate;
+  const fromEvent = input.eventStatus !== null;
   const hookAge = now - input.hookTs;
   if (derived === AgentStatus.BUSY && hookAge >= WORKING_TIMEOUT_SECS) {
     derived = AgentStatus.IDLE;
+    decision.workingTimeoutFired = true;
   }
 
   // Scraper BUSY is a positive activity read (running token counter on screen).
   if (input.scrapeStatus === AgentStatus.BUSY) {
-    return AgentStatus.BUSY;
+    return finish(AgentStatus.BUSY, 'scrape', 'scraper saw a live token counter / esc-to-interrupt');
   }
 
   // Scraper IDLE just means the live screen shows a bare prompt with no dialog
@@ -72,13 +112,17 @@ export function fuseState(input: FuseInput): AgentStatus {
   // between frames. So an idle screen can only retire a *stale prompt* — a
   // PERMIT/QUESTION that's since been answered and is gone from the screen. It
   // must never override a derived DONE or BUSY; time decay above retires those.
-  if (input.scrapeStatus === AgentStatus.IDLE) {
-    if (derived === AgentStatus.PERMIT || derived === AgentStatus.QUESTION) {
-      return AgentStatus.IDLE;
-    }
-    return derived;
+  if (input.scrapeStatus === AgentStatus.IDLE && (derived === AgentStatus.PERMIT || derived === AgentStatus.QUESTION)) {
+    return finish(AgentStatus.IDLE, 'scrape', 'screen shows a bare prompt — a stale permit/question was cleared');
   }
 
-  // No scrape result — fall back to the derived hook/event status.
-  return derived;
+  // Derived hook/event status wins (scrape IDLE never demotes a derived DONE/BUSY;
+  // scrape null falls here too).
+  const winner: StateDecision['winner'] = decision.workingTimeoutFired ? 'default' : fromEvent ? 'event' : 'hook';
+  const reason = decision.workingTimeoutFired
+    ? `hook BUSY aged ${hookAge}s ≥ ${WORKING_TIMEOUT_SECS}s — decayed to idle`
+    : fromEvent
+      ? 'derived from the latest JSONL event'
+      : 'derived from the hook status file';
+  return finish(derived, winner, reason);
 }

--- a/src/state/hooks.test.ts
+++ b/src/state/hooks.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, test } from 'bun:test';
-import { parseStatusFile, readStatusDir } from './hooks.ts';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parseStatusFile, readAllStatusDirs, readStatusDir } from './hooks.ts';
+import type { ResolvedHookStatus } from './types.ts';
 
 describe('parseStatusFile', () => {
   test('parses valid status JSON', () => {
@@ -21,6 +25,73 @@ describe('parseStatusFile', () => {
 
 describe('readStatusDir', () => {
   test('returns empty for non-existent dir', () => {
-    expect(readStatusDir('/tmp/nonexistent-fleet-test-dir')).toEqual([]);
+    expect(readStatusDir('/tmp/nonexistent-fleet-test-dir', 'claude')).toEqual([]);
+  });
+});
+
+// Agent-identity threading (Phase 3): each on-disk status is stamped with the
+// owning agent name and source dir, so index.ts can set agentType from `agent`
+// and read the matching .events.jsonl from `statusDir` without re-deriving.
+describe('readAllStatusDirs stamps agent + statusDir', () => {
+  let root: string;
+  let claudeDir: string;
+  let codexDir: string;
+
+  const writeStatus = (dir: string, paneNum: number, pane: string, ts: number, state = 'working') => {
+    writeFileSync(
+      join(dir, `${paneNum}.status`),
+      JSON.stringify({ state, pane, session: 's', tool: 'Bash', ts, tmux_pid: 1 }) + '\n',
+    );
+  };
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'fleet-hooks-test-'));
+    claudeDir = join(root, 'claude');
+    codexDir = join(root, 'codex');
+    mkdirSync(claudeDir, { recursive: true });
+    mkdirSync(codexDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test('each record carries its owning dir name + path', () => {
+    writeStatus(claudeDir, 1, '%1', 100);
+    writeStatus(codexDir, 2, '%2', 100);
+
+    const all = readAllStatusDirs([
+      { name: 'claude', statusDir: claudeDir },
+      { name: 'codex', statusDir: codexDir },
+    ]);
+    expect(all).toHaveLength(2);
+    const byPane = new Map(all.map((h: ResolvedHookStatus) => [h.pane, h]));
+
+    expect(byPane.get('%1')!.agent).toBe('claude');
+    expect(byPane.get('%1')!.statusDir).toBe(claudeDir);
+    expect(byPane.get('%2')!.agent).toBe('codex');
+    expect(byPane.get('%2')!.statusDir).toBe(codexDir);
+  });
+
+  test('same pane number in both dirs: both returned; freshness reduction keeps the newer', () => {
+    // Server-global tmux pane id %7 written in both dirs with different ts.
+    writeStatus(claudeDir, 7, '%7', 100);
+    writeStatus(codexDir, 7, '%7', 200);
+
+    const all = readAllStatusDirs([
+      { name: 'claude', statusDir: claudeDir },
+      { name: 'codex', statusDir: codexDir },
+    ]);
+    expect(all).toHaveLength(2);
+
+    // Same freshness-wins rule index.ts uses to build hookByPane.
+    const byPane = new Map<string, ResolvedHookStatus>();
+    for (const h of all) {
+      const prev = byPane.get(h.pane);
+      if (!prev || h.ts > prev.ts) byPane.set(h.pane, h);
+    }
+    expect(byPane.get('%7')!.agent).toBe('codex');
+    expect(byPane.get('%7')!.ts).toBe(200);
+    expect(byPane.get('%7')!.statusDir).toBe(codexDir);
   });
 });

--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -1,6 +1,7 @@
 import { readdirSync, readFileSync, existsSync, watch } from 'node:fs';
 import { join } from 'node:path';
-import type { HookStatus } from './types.ts';
+import type { HookStatus, ResolvedHookStatus } from './types.ts';
+import type { AgentDir } from '../agents/config.ts';
 
 export function parseStatusFile(content: string): HookStatus | null {
   try {
@@ -18,9 +19,12 @@ export function parseStatusFile(content: string): HookStatus | null {
   }
 }
 
-export function readStatusDir(dir: string): HookStatus[] {
+// Each record is stamped with its owning `agent` and source `statusDir` so the
+// caller (index.ts) knows which agent authored the status and which dir to read
+// the matching .events.jsonl from — the name travels with the data.
+export function readStatusDir(dir: string, agent: string): ResolvedHookStatus[] {
   if (!existsSync(dir)) return [];
-  const statuses: HookStatus[] = [];
+  const statuses: ResolvedHookStatus[] = [];
   try {
     const files = readdirSync(dir);
     for (const file of files) {
@@ -28,7 +32,7 @@ export function readStatusDir(dir: string): HookStatus[] {
       try {
         const content = readFileSync(join(dir, file), 'utf-8');
         const status = parseStatusFile(content);
-        if (status) statuses.push(status);
+        if (status) statuses.push({ ...status, agent, statusDir: dir });
       } catch {
         // Skip unreadable files
       }
@@ -39,10 +43,10 @@ export function readStatusDir(dir: string): HookStatus[] {
   return statuses;
 }
 
-export function readAllStatusDirs(dirs: string[]): HookStatus[] {
-  const all: HookStatus[] = [];
-  for (const dir of dirs) {
-    all.push(...readStatusDir(dir));
+export function readAllStatusDirs(dirs: AgentDir[]): ResolvedHookStatus[] {
+  const all: ResolvedHookStatus[] = [];
+  for (const d of dirs) {
+    all.push(...readStatusDir(d.statusDir, d.name));
   }
   return all;
 }

--- a/src/state/rename.test.ts
+++ b/src/state/rename.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { loadRenames, saveRename } from './rename.ts';
+
+let dir: string;
+let path: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'fleet-rename-test-'));
+  path = join(dir, 'renames.json');
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('rename store', () => {
+  test('round-trip: save then load returns the value', () => {
+    saveRename('s', 'Label', path);
+    expect(loadRenames(path).get('s')).toBe('Label');
+  });
+
+  test('persistence across reload (simulated restart)', () => {
+    saveRename('api-server', 'prod hotfix', path);
+    // A fresh load with no shared in-memory state — the contract's persistence criterion.
+    const reloaded = loadRenames(path);
+    expect(reloaded.get('api-server')).toBe('prod hotfix');
+  });
+
+  test('empty label clears the key', () => {
+    saveRename('s', 'Label', path);
+    saveRename('s', '', path);
+    expect(loadRenames(path).has('s')).toBe(false);
+  });
+
+  test('whitespace-only label clears the key', () => {
+    saveRename('s', 'Label', path);
+    saveRename('s', '   ', path);
+    expect(loadRenames(path).has('s')).toBe(false);
+  });
+
+  test('label is trimmed on save', () => {
+    saveRename('s', '  padded  ', path);
+    expect(loadRenames(path).get('s')).toBe('padded');
+  });
+
+  test('corrupt file yields an empty map without throwing', () => {
+    writeFileSync(path, '{not valid json');
+    expect(loadRenames(path).size).toBe(0);
+  });
+
+  test('missing file yields an empty map without throwing', () => {
+    const missing = join(dir, 'does-not-exist.json');
+    expect(existsSync(missing)).toBe(false);
+    expect(loadRenames(missing).size).toBe(0);
+  });
+
+  test('non-object JSON (array) yields an empty map', () => {
+    writeFileSync(path, '["a","b"]');
+    expect(loadRenames(path).size).toBe(0);
+  });
+
+  test('non-string values are ignored', () => {
+    writeFileSync(path, JSON.stringify({ good: 'ok', bad: 42, empty: '' }));
+    const map = loadRenames(path);
+    expect(map.get('good')).toBe('ok');
+    expect(map.has('bad')).toBe(false);
+    expect(map.has('empty')).toBe(false);
+  });
+
+  test('multi-key isolation: renaming one session leaves others intact', () => {
+    saveRename('one', 'first', path);
+    saveRename('two', 'second', path);
+    saveRename('one', 'first-updated', path);
+    const map = loadRenames(path);
+    expect(map.get('one')).toBe('first-updated');
+    expect(map.get('two')).toBe('second');
+  });
+});

--- a/src/state/rename.ts
+++ b/src/state/rename.ts
@@ -1,0 +1,42 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+// Rename store lives under the XDG cache root (mirrors the ~/.cache/<name>-status
+// convention in config.ts) so a user rename survives a fleet restart.
+export function renamesPath(): string {
+  const cache = process.env.XDG_CACHE_HOME ?? join(homedir(), '.cache');
+  return join(cache, 'fleet', 'renames.json');
+}
+
+// Flat session→label map. A corrupt, missing, or ill-typed file yields an empty
+// map rather than throwing — a bad store must never crash the TUI.
+export function loadRenames(path: string = renamesPath()): Map<string, string> {
+  const out = new Map<string, string>();
+  if (!existsSync(path)) return out;
+  try {
+    const data = JSON.parse(readFileSync(path, 'utf-8')) as Record<string, unknown>;
+    if (data && typeof data === 'object' && !Array.isArray(data)) {
+      for (const [k, v] of Object.entries(data)) {
+        if (typeof v === 'string' && v.length > 0) out.set(k, v);
+      }
+    }
+  } catch {
+    // Corrupt store — fall back to no renames rather than crash the TUI.
+  }
+  return out;
+}
+
+// Re-reads before writing so concurrent fleet instances don't clobber each
+// other's renames (last-writer-wins per key, not per file). An empty/blank
+// label deletes the key — a natural "clear rename".
+export function saveRename(session: string, label: string, path: string = renamesPath()): void {
+  const map = loadRenames(path);
+  const trimmed = label.trim();
+  if (trimmed.length === 0) map.delete(session);
+  else map.set(session, trimmed);
+  const obj: Record<string, string> = {};
+  for (const [k, v] of map) obj[k] = v;
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(obj) + '\n');
+}

--- a/src/state/scraper.test.ts
+++ b/src/state/scraper.test.ts
@@ -5,48 +5,62 @@ import { AgentStatus } from './types.ts';
 describe('detectFromPaneContent', () => {
   test('detects permission prompt [y/n]', () => {
     const lines = ['Some output...', '', 'Allow Edit to /path/file.ts?', '[y/n]'];
-    expect(detectFromPaneContent(lines)).toBe(AgentStatus.PERMIT);
+    const result = detectFromPaneContent(lines);
+    expect(result.status).toBe(AgentStatus.PERMIT);
+    expect(result.ruleId).toBe('permit.yn');
   });
 
   test('detects Y/n style permission', () => {
     const lines = ['Allow Read to /path?', '[Y/n]'];
-    expect(detectFromPaneContent(lines)).toBe(AgentStatus.PERMIT);
+    expect(detectFromPaneContent(lines).status).toBe(AgentStatus.PERMIT);
   });
 
   test('detects Enter to select as QUESTION', () => {
     const lines = ['1. Option A', '2. Option B', 'Enter to select · ↑/↓ to navigate · Esc to cancel'];
-    expect(detectFromPaneContent(lines)).toBe(AgentStatus.QUESTION);
+    const result = detectFromPaneContent(lines);
+    expect(result.status).toBe(AgentStatus.QUESTION);
+    expect(result.ruleId).toBe('question.enter-select');
   });
 
   test('detects working via token counter (minutes)', () => {
     const lines = ['✻ Trapping Gollum… (1m 11s · ↓ 3.4k tokens)', '', '❯'];
-    expect(detectFromPaneContent(lines)).toBe(AgentStatus.BUSY);
+    const result = detectFromPaneContent(lines);
+    expect(result.status).toBe(AgentStatus.BUSY);
+    expect(result.ruleId).toBe('busy.token-counter-min');
   });
 
   test('detects working via token counter (seconds only)', () => {
     const lines = ['✢ Sharting… (8s · ↑ 240 tokens)', '', '❯'];
-    expect(detectFromPaneContent(lines)).toBe(AgentStatus.BUSY);
+    const result = detectFromPaneContent(lines);
+    expect(result.status).toBe(AgentStatus.BUSY);
+    expect(result.ruleId).toBe('busy.token-counter-sec');
   });
 
   test('detects working via esc to interrupt', () => {
     const lines = ['Running command…', '', '(esc to interrupt)', '❯'];
-    expect(detectFromPaneContent(lines)).toBe(AgentStatus.BUSY);
+    const result = detectFromPaneContent(lines);
+    expect(result.status).toBe(AgentStatus.BUSY);
+    expect(result.ruleId).toBe('busy.esc-interrupt');
   });
 
   test('detects idle prompt as IDLE', () => {
     const lines = ['Done! Created the file.', '', '❯'];
-    expect(detectFromPaneContent(lines)).toBe(AgentStatus.IDLE);
+    const result = detectFromPaneContent(lines);
+    expect(result.status).toBe(AgentStatus.IDLE);
+    expect(result.ruleId).toBe('idle.prompt');
   });
 
   test('animated spinner glyph alone is not enough — needs counter', () => {
     // A bare spinner verb with no counter and a visible prompt reads as IDLE,
     // and the fusion engine keeps a fresh hook BUSY from being overridden.
     const lines = ['✶ Thinking…', '', '❯'];
-    expect(detectFromPaneContent(lines)).toBe(AgentStatus.IDLE);
+    expect(detectFromPaneContent(lines).status).toBe(AgentStatus.IDLE);
   });
 
   test('returns null for unrecognized content', () => {
     const lines = ['$ ls', 'file1.ts', 'file2.ts'];
-    expect(detectFromPaneContent(lines)).toBeNull();
+    const result = detectFromPaneContent(lines);
+    expect(result.status).toBeNull();
+    expect(result.ruleId).toBeNull();
   });
 });

--- a/src/state/scraper.ts
+++ b/src/state/scraper.ts
@@ -1,43 +1,53 @@
-import { AgentStatus } from './types.ts';
+import { AgentStatus, type DetectResult } from './types.ts';
 import { capturePane } from '../tmux/sessions.ts';
 
 const SCRAPE_LINES = 50;
+const BOTTOM_LINES = 15; // the window detectFromPaneContent evaluates
 
-export function scrapePane(paneId: string): AgentStatus | null {
-  let lines: string[];
-  try {
-    lines = capturePane(paneId, SCRAPE_LINES);
-  } catch {
-    return null;
-  }
-  return detectFromPaneContent(lines);
-}
-
-export function detectFromPaneContent(lines: string[]): AgentStatus | null {
-  const bottom = lines.slice(-15);
+export function detectFromPaneContent(lines: string[]): DetectResult {
+  const bottom = lines.slice(-BOTTOM_LINES);
   const bottomText = bottom.join('\n');
 
-  if (/\[y\/n\]|\[Y\/n\]/i.test(bottomText)) return AgentStatus.PERMIT;
-  if (/Do you want to (proceed|allow)/.test(bottomText)) return AgentStatus.PERMIT;
-  if (/Enter to select.*[↑↓]|Esc to cancel/.test(bottomText)) return AgentStatus.QUESTION;
+  if (/\[y\/n\]|\[Y\/n\]/i.test(bottomText)) return { status: AgentStatus.PERMIT, ruleId: 'permit.yn' };
+  if (/Do you want to (proceed|allow)/.test(bottomText))
+    return { status: AgentStatus.PERMIT, ruleId: 'permit.do-you-want' };
+  if (/Enter to select.*[↑↓]|Esc to cancel/.test(bottomText))
+    return { status: AgentStatus.QUESTION, ruleId: 'question.enter-select' };
 
   // Claude Code shows a working status line while a turn is in flight. The spinner
   // glyph and verb animate (✻ "Trapping Gollum…" -> ✢ "Sharting…"), so match the
   // stable parts instead: the elapsed/token counter "(1m 11s · ↓ 3.4k tokens)" and
   // the "esc to interrupt" affordance. Either is a definitive BUSY signal.
-  if (/\(\d+m\s+\d+s\s+·.*tokens?\)/.test(bottomText)) return AgentStatus.BUSY;
-  if (/\(\d+s\s+·.*tokens?\)/.test(bottomText)) return AgentStatus.BUSY;
-  if (/esc to interrupt/i.test(bottomText)) return AgentStatus.BUSY;
+  if (/\(\d+m\s+\d+s\s+·.*tokens?\)/.test(bottomText))
+    return { status: AgentStatus.BUSY, ruleId: 'busy.token-counter-min' };
+  if (/\(\d+s\s+·.*tokens?\)/.test(bottomText)) return { status: AgentStatus.BUSY, ruleId: 'busy.token-counter-sec' };
+  if (/esc to interrupt/i.test(bottomText)) return { status: AgentStatus.BUSY, ruleId: 'busy.esc-interrupt' };
 
-  let promptLine = -1;
   for (let i = lines.length - 1; i >= 0; i--) {
-    if (lines[i]!.includes('❯')) {
-      promptLine = i;
-      break;
-    }
+    if (lines[i]!.includes('❯')) return { status: AgentStatus.IDLE, ruleId: 'idle.prompt' };
   }
+  return { status: null, ruleId: null };
+}
 
-  if (promptLine === -1) return null;
+export function scrapePane(paneId: string): AgentStatus | null {
+  try {
+    return detectFromPaneContent(capturePane(paneId, SCRAPE_LINES)).status;
+  } catch {
+    return null;
+  }
+}
 
-  return AgentStatus.IDLE;
+export interface ScrapeDetail {
+  result: DetectResult;
+  snapshot: string[]; // the bottom window the detector evaluated
+}
+
+export function scrapePaneDetailed(paneId: string): ScrapeDetail | null {
+  let lines: string[];
+  try {
+    lines = capturePane(paneId, SCRAPE_LINES);
+  } catch {
+    return null; // capture-pane failed — explain renders "scrape unavailable"
+  }
+  return { result: detectFromPaneContent(lines), snapshot: lines.slice(-BOTTOM_LINES) };
 }

--- a/src/state/scraper.ts
+++ b/src/state/scraper.ts
@@ -1,40 +1,63 @@
 import { AgentStatus, type DetectResult } from './types.ts';
 import { capturePane } from '../tmux/sessions.ts';
+import {
+  CLAUDE_MANIFEST,
+  getCompiledRegex,
+  loadDetectionManifest,
+  PROMPT_MARKER_RULE_ID,
+  type DetectionManifest,
+} from './detection.ts';
 
 const SCRAPE_LINES = 50;
-const BOTTOM_LINES = 15; // the window detectFromPaneContent evaluates
 
-export function detectFromPaneContent(lines: string[]): DetectResult {
-  const bottom = lines.slice(-BOTTOM_LINES);
-  const bottomText = bottom.join('\n');
+// Maps a manifest rule's serialized state onto the AgentStatus the scraper emits.
+const RULE_STATE_TO_STATUS = {
+  PERMIT: AgentStatus.PERMIT,
+  QUESTION: AgentStatus.QUESTION,
+  BUSY: AgentStatus.BUSY,
+  IDLE: AgentStatus.IDLE,
+} as const;
 
-  if (/\[y\/n\]|\[Y\/n\]/i.test(bottomText)) return { status: AgentStatus.PERMIT, ruleId: 'permit.yn' };
-  if (/Do you want to (proceed|allow)/.test(bottomText))
-    return { status: AgentStatus.PERMIT, ruleId: 'permit.do-you-want' };
-  if (/Enter to select.*[↑↓]|Esc to cancel/.test(bottomText))
-    return { status: AgentStatus.QUESTION, ruleId: 'question.enter-select' };
+// Data-driven detection: walk the manifest's ordered rules (first match wins)
+// over the bottom `linesFromBottom` window, then fall back to the prompt marker.
+// Defaults to the built-in claude manifest so the regression tests can call it
+// with a single `lines` argument and touch no disk.
+export function detectFromPaneContent(lines: string[], manifest: DetectionManifest = CLAUDE_MANIFEST): DetectResult {
+  const bottomText = lines.slice(-manifest.linesFromBottom).join('\n');
 
-  // Claude Code shows a working status line while a turn is in flight. The spinner
-  // glyph and verb animate (✻ "Trapping Gollum…" -> ✢ "Sharting…"), so match the
-  // stable parts instead: the elapsed/token counter "(1m 11s · ↓ 3.4k tokens)" and
-  // the "esc to interrupt" affordance. Either is a definitive BUSY signal.
-  if (/\(\d+m\s+\d+s\s+·.*tokens?\)/.test(bottomText))
-    return { status: AgentStatus.BUSY, ruleId: 'busy.token-counter-min' };
-  if (/\(\d+s\s+·.*tokens?\)/.test(bottomText)) return { status: AgentStatus.BUSY, ruleId: 'busy.token-counter-sec' };
-  if (/esc to interrupt/i.test(bottomText)) return { status: AgentStatus.BUSY, ruleId: 'busy.esc-interrupt' };
-
-  for (let i = lines.length - 1; i >= 0; i--) {
-    if (lines[i]!.includes('❯')) return { status: AgentStatus.IDLE, ruleId: 'idle.prompt' };
+  for (const rule of manifest.rules) {
+    const re = getCompiledRegex(rule);
+    if (re && re.test(bottomText)) {
+      return { status: RULE_STATE_TO_STATUS[rule.state], ruleId: rule.id };
+    }
   }
+
+  // Prompt-marker fallback. NB: this scans the FULL captured buffer, not just
+  // the bottom window the rules use — preserved verbatim from the pre-Phase-2
+  // scraper (a stale prompt high in scrollback still reads as IDLE). Tightening
+  // it to the window would be a behavior change, so it stays.
+  if (manifest.promptMarker.length > 0) {
+    for (let i = lines.length - 1; i >= 0; i--) {
+      if (lines[i]!.includes(manifest.promptMarker)) {
+        return { status: AgentStatus.IDLE, ruleId: PROMPT_MARKER_RULE_ID };
+      }
+    }
+  }
+
   return { status: null, ruleId: null };
 }
 
-export function scrapePane(paneId: string): AgentStatus | null {
+export function scrapePane(paneId: string, manifest?: DetectionManifest): AgentStatus | null {
+  let lines: string[];
   try {
-    return detectFromPaneContent(capturePane(paneId, SCRAPE_LINES)).status;
+    lines = capturePane(paneId, SCRAPE_LINES);
   } catch {
     return null;
   }
+  // Agent identity is hardcoded 'claude' until Phase 3; resolve its manifest
+  // (built-in, or a user override) here so the live path honors overrides.
+  const m = manifest ?? loadDetectionManifest('claude');
+  return detectFromPaneContent(lines, m).status;
 }
 
 export interface ScrapeDetail {
@@ -42,12 +65,13 @@ export interface ScrapeDetail {
   snapshot: string[]; // the bottom window the detector evaluated
 }
 
-export function scrapePaneDetailed(paneId: string): ScrapeDetail | null {
+export function scrapePaneDetailed(paneId: string, manifest?: DetectionManifest): ScrapeDetail | null {
   let lines: string[];
   try {
     lines = capturePane(paneId, SCRAPE_LINES);
   } catch {
     return null; // capture-pane failed — explain renders "scrape unavailable"
   }
-  return { result: detectFromPaneContent(lines), snapshot: lines.slice(-BOTTOM_LINES) };
+  const m = manifest ?? loadDetectionManifest('claude');
+  return { result: detectFromPaneContent(lines, m), snapshot: lines.slice(-m.linesFromBottom) };
 }

--- a/src/state/scraper.ts
+++ b/src/state/scraper.ts
@@ -47,17 +47,17 @@ export function detectFromPaneContent(lines: string[], manifest: DetectionManife
   return { status: null, ruleId: null };
 }
 
-export function scrapePane(paneId: string, manifest?: DetectionManifest): AgentStatus | null {
+export function scrapePane(paneId: string, agent: string): AgentStatus | null {
   let lines: string[];
   try {
     lines = capturePane(paneId, SCRAPE_LINES);
   } catch {
     return null;
   }
-  // Agent identity is hardcoded 'claude' until Phase 3; resolve its manifest
-  // (built-in, or a user override) here so the live path honors overrides.
-  const m = manifest ?? loadDetectionManifest('claude');
-  return detectFromPaneContent(lines, m).status;
+  // Phase 3: the agent is real (was hardcoded 'claude'). Resolve its manifest
+  // (built-in, or a user override) so each agent's prompts classify against its
+  // own rules; an unknown agent degrades to an empty manifest (detects nothing).
+  return detectFromPaneContent(lines, loadDetectionManifest(agent)).status;
 }
 
 export interface ScrapeDetail {

--- a/src/state/types.test.ts
+++ b/src/state/types.test.ts
@@ -70,6 +70,7 @@ const base: AgentState = {
   paneNum: 1,
   session: 'dotfiles',
   window: 'editor',
+  windowId: '@1',
   claudeName: null,
   status: AgentStatus.IDLE,
   tool: null,

--- a/src/state/types.test.ts
+++ b/src/state/types.test.ts
@@ -5,6 +5,7 @@ import {
   compareStatus,
   extractClaudeName,
   displayName,
+  sessionDisplay,
   sessionLabel,
   windowLabel,
   type AgentState,
@@ -72,6 +73,7 @@ const base: AgentState = {
   window: 'editor',
   windowId: '@1',
   claudeName: null,
+  customName: null,
   status: AgentStatus.IDLE,
   tool: null,
   project: null,
@@ -116,5 +118,23 @@ describe('displayName', () => {
 
   test('falls back to session:window when no claudeName', () => {
     expect(displayName(base)).toBe('dotfiles:editor');
+  });
+
+  test('customName wins over claudeName and session', () => {
+    expect(displayName({ ...base, customName: 'prod hotfix', claudeName: 'Fix auth bug' })).toBe('prod hotfix');
+  });
+
+  test('claudeName is used when customName is null', () => {
+    expect(displayName({ ...base, customName: null, claudeName: 'Fix auth bug' })).toBe('Fix auth bug');
+  });
+});
+
+describe('sessionDisplay', () => {
+  test('returns customName when set', () => {
+    expect(sessionDisplay({ ...base, customName: 'prod hotfix' })).toBe('prod hotfix');
+  });
+
+  test('falls back to the raw session name when customName is null', () => {
+    expect(sessionDisplay(base)).toBe('dotfiles');
   });
 });

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -109,6 +109,16 @@ export interface HookStatus {
   tmux_pid: number;
 }
 
+// HookStatus stays the pure on-disk wire shape (unchanged). ResolvedHookStatus is
+// the in-memory record after we know which agent dir produced it: the owning
+// agent name and its source dir ride WITH the data, so the read path never has to
+// re-derive who authored a status. index.ts sets AgentState.agentType from
+// `agent`, and reads the matching .events.jsonl from `statusDir`.
+export interface ResolvedHookStatus extends HookStatus {
+  agent: string; // registry name of the owning AgentDir -> AgentState.agentType
+  statusDir: string; // the dir this file came from -> read the matching .events.jsonl
+}
+
 export interface EventEntry {
   event: string;
   ts: number;

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -56,6 +56,7 @@ export interface AgentState {
   paneNum: number;
   session: string;
   window: string;
+  windowId: string;
   claudeName: string | null;
   status: AgentStatus;
   tool: string | null;

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -108,3 +108,26 @@ export interface EventEntry {
   background_tasks?: boolean;
   notification_type?: string;
 }
+
+// Scraper return — was: AgentStatus | null. `ruleId` names the match branch that
+// fired (namespaced state.marker, e.g. 'permit.yn', 'idle.prompt') so the fusion
+// trace can show *why* the scraper read what it did. null/null == no match.
+export interface DetectResult {
+  status: AgentStatus | null;
+  ruleId: string | null;
+}
+
+// Fusion trace — one per pane per refresh, discarded by the hot loop. Records
+// which layer authored the final state and why, for `fleet explain`.
+export interface StateDecision {
+  final: AgentStatus;
+  candidates: { hook: AgentStatus | null; event: AgentStatus | null; scrape: AgentStatus | null };
+  hookTs: number;
+  eventTs: number | null;
+  now: number;
+  winner: 'hook' | 'event' | 'scrape' | 'default';
+  reason: string; // human-readable why
+  workingTimeoutFired: boolean;
+  freshnessEvaluated: boolean; // MUST be false under live wiring — see engine notes
+  scrapeRuleId: string | null;
+}

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -58,6 +58,7 @@ export interface AgentState {
   window: string;
   windowId: string;
   claudeName: string | null;
+  customName: string | null; // user rename for this pane's session, or null
   status: AgentStatus;
   tool: string | null;
   project: string | null;
@@ -88,8 +89,15 @@ export function windowLabel(state: AgentState): string {
   return state.window;
 }
 
+// Precedence for a row's primary label: user rename > Claude auto-name > session.
 export function displayName(state: AgentState): string {
-  return state.claudeName ?? sessionLabel(state);
+  return state.customName ?? state.claudeName ?? sessionLabel(state);
+}
+
+// Session-level display string (rename wins over the raw session name). Used by
+// the dashboard's session column/header; window sub-labels are unaffected.
+export function sessionDisplay(state: AgentState): string {
+  return state.customName ?? state.session;
 }
 
 export interface HookStatus {

--- a/src/tmux/sessions.test.ts
+++ b/src/tmux/sessions.test.ts
@@ -1,9 +1,63 @@
 import { describe, expect, test } from 'bun:test';
-import { listPanes } from './sessions.ts';
+import { listPanes, parsePanesOutput } from './sessions.ts';
 
 describe('listPanes', () => {
   test('returns array (may be empty if not in tmux)', () => {
     const panes = listPanes();
     expect(Array.isArray(panes)).toBe(true);
+  });
+});
+
+describe('parsePanesOutput', () => {
+  test('parses a synthetic 8-field line, capturing window id and index', () => {
+    const line = ['%3', 'mysession', 'mywindow', '@5', '2', '/home/me/proj', '12345', '✳ Fix bug'].join('\t');
+    const panes = parsePanesOutput(line);
+    expect(panes).toHaveLength(1);
+    const p = panes[0]!;
+    expect(p.paneId).toBe('%3');
+    expect(p.paneNum).toBe(3);
+    expect(p.sessionName).toBe('mysession');
+    expect(p.windowName).toBe('mywindow');
+    expect(p.windowId).toBe('@5');
+    expect(p.windowIndex).toBe(2);
+    expect(p.currentPath).toBe('/home/me/proj');
+    expect(p.panePid).toBe(12345);
+    expect(p.paneTitle).toBe('✳ Fix bug');
+  });
+
+  test('skips a line with fewer than 8 tab fields', () => {
+    // A 6-field line (the old format) is too short and must be dropped, not
+    // parsed with undefined window fields.
+    const line = ['%1', 'sess', 'win', '/path', '999', 'title'].join('\t');
+    expect(parsePanesOutput(line)).toHaveLength(0);
+  });
+
+  test('skips blank lines', () => {
+    expect(parsePanesOutput('')).toHaveLength(0);
+    expect(parsePanesOutput('\n\n')).toHaveLength(0);
+  });
+
+  test('a stray tab in the pane title does not corrupt the window id', () => {
+    // pane_title is LAST in the format, so an embedded tab spills into trailing
+    // (ignored) parts instead of shifting window_id/window_index.
+    const line = ['%7', 'sess', 'win', '@9', '4', '/path', '321', '✳ Fix\ttab bug'].join('\t');
+    const panes = parsePanesOutput(line);
+    expect(panes).toHaveLength(1);
+    const p = panes[0]!;
+    expect(p.windowId).toBe('@9');
+    expect(p.windowIndex).toBe(4);
+    expect(p.currentPath).toBe('/path');
+    expect(p.panePid).toBe(321);
+  });
+
+  test('parses multiple lines', () => {
+    const stdout = [
+      ['%1', 's', 'w1', '@1', '0', '/a', '10', 't1'].join('\t'),
+      ['%2', 's', 'w2', '@2', '1', '/b', '20', 't2'].join('\t'),
+    ].join('\n');
+    const panes = parsePanesOutput(stdout);
+    expect(panes).toHaveLength(2);
+    expect(panes[0]!.windowId).toBe('@1');
+    expect(panes[1]!.windowId).toBe('@2');
   });
 });

--- a/src/tmux/sessions.ts
+++ b/src/tmux/sessions.ts
@@ -5,39 +5,51 @@ export interface PaneInfo {
   paneNum: number;
   sessionName: string;
   windowName: string;
+  windowId: string; // e.g. "@5" — stable, server-unique; the grouping key + `set -t` target
+  windowIndex: number; // e.g. 2 — per-session position; captured for debugging, NOT a key
   currentPath: string;
   panePid: number;
   paneTitle: string;
 }
 
-const PANE_FORMAT = '#{pane_id}\t#{session_name}\t#{window_name}\t#{pane_current_path}\t#{pane_pid}\t#{pane_title}';
+// window_id / window_index inserted after window_name so pane_title stays LAST:
+// a stray tab in a pane title then lands in trailing (ignored) parts instead of
+// shifting a window field.
+const PANE_FORMAT =
+  '#{pane_id}\t#{session_name}\t#{window_name}\t#{window_id}\t#{window_index}\t#{pane_current_path}\t#{pane_pid}\t#{pane_title}';
 
 export interface ListPanesResult {
   ok: boolean;
   panes: PaneInfo[];
 }
 
-export function listPanesResult(): ListPanesResult {
-  const result = tmux(['list-panes', '-a', '-F', PANE_FORMAT]);
-  if (result.exitCode !== 0) return { ok: false, panes: [] };
-
+// Extracted so windowId/windowIndex parsing is unit-testable without live tmux.
+export function parsePanesOutput(stdout: string): PaneInfo[] {
   const panes: PaneInfo[] = [];
-  for (const line of result.stdout.split('\n')) {
+  for (const line of stdout.split('\n')) {
     if (line.length === 0) continue;
     const parts = line.split('\t');
-    if (parts.length < 6) continue;
+    if (parts.length < 8) continue;
     const paneId = parts[0]!;
     panes.push({
       paneId,
       paneNum: parseInt(paneId.replace('%', ''), 10),
       sessionName: parts[1]!,
       windowName: parts[2]!,
-      currentPath: parts[3]!,
-      panePid: parseInt(parts[4]!, 10),
-      paneTitle: parts[5]!,
+      windowId: parts[3]!,
+      windowIndex: parseInt(parts[4]!, 10),
+      currentPath: parts[5]!,
+      panePid: parseInt(parts[6]!, 10),
+      paneTitle: parts[7]!,
     });
   }
-  return { ok: true, panes };
+  return panes;
+}
+
+export function listPanesResult(): ListPanesResult {
+  const result = tmux(['list-panes', '-a', '-F', PANE_FORMAT]);
+  if (result.exitCode !== 0) return { ok: false, panes: [] };
+  return { ok: true, panes: parsePanesOutput(result.stdout) };
 }
 
 export function listPanes(): PaneInfo[] {

--- a/src/tui/app.test.ts
+++ b/src/tui/app.test.ts
@@ -7,6 +7,7 @@ const makeState = (session: string, status: AgentStatus, paneId?: string, window
   paneNum: Math.floor(Math.random() * 1000),
   session,
   window: window ?? 'main',
+  windowId: '@1',
   claudeName: null,
   status,
   tool: null,

--- a/src/tui/app.test.ts
+++ b/src/tui/app.test.ts
@@ -9,6 +9,7 @@ const makeState = (session: string, status: AgentStatus, paneId?: string, window
   window: window ?? 'main',
   windowId: '@1',
   claudeName: null,
+  customName: null,
   status,
   tool: null,
   project: `~/Developer/${session}`,
@@ -176,7 +177,7 @@ describe('grouped rows', () => {
     ]);
     const rows = app.dashboardRows();
     expect(rows).toHaveLength(3);
-    expect(rows[0]).toEqual({ kind: 'header', session: 'cli', count: 2, aggregate: AgentStatus.PERMIT });
+    expect(rows[0]).toEqual({ kind: 'header', session: 'cli', label: 'cli', count: 2, aggregate: AgentStatus.PERMIT });
     expect(rows[1]!.kind).toBe('agent');
     expect(rows[2]!.kind).toBe('agent');
     expect(rows.slice(1).every((r) => r.kind === 'agent' && r.grouped)).toBe(true);

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -3,13 +3,14 @@ import { AgentStatus, compareStatus, windowLabel, type AgentState } from '../sta
 // A rendered dashboard line: sessions with 2+ agents get a header row followed
 // by grouped (indented, window-named) agent rows; singletons render inline.
 export type DashboardRow =
-  | { kind: 'header'; session: string; count: number; aggregate: AgentStatus }
+  | { kind: 'header'; session: string; label: string; count: number; aggregate: AgentStatus }
   | { kind: 'agent'; state: AgentState; grouped: boolean };
 
 export const TuiMode = {
   DASHBOARD: 'DASHBOARD',
   PREVIEW: 'PREVIEW',
   SEND: 'SEND',
+  RENAME: 'RENAME',
   HELP: 'HELP',
   PASSTHROUGH: 'PASSTHROUGH',
   CONFIRM_KILL: 'CONFIRM_KILL',
@@ -36,8 +37,10 @@ export class TuiApp {
   selectedIndex: number = 0;
   mode: TuiMode = TuiMode.DASHBOARD;
   private modeBeforeSend: TuiMode = TuiMode.DASHBOARD;
+  private modeBeforeRename: TuiMode = TuiMode.DASHBOARD;
   private modeBeforeKill: TuiMode = TuiMode.DASHBOARD;
   sendBuffer: string = '';
+  renameBuffer: string = '';
   shouldQuit: boolean = false;
   tmuxDown: boolean = false;
   hooksMissing: boolean = false;
@@ -114,7 +117,13 @@ export class TuiApp {
       if (members.length === 1) {
         rows.push({ kind: 'agent', state: members[0]!, grouped: false });
       } else {
-        rows.push({ kind: 'header', session, count: members.length, aggregate: members[0]!.status });
+        rows.push({
+          kind: 'header',
+          session,
+          label: members[0]!.customName ?? session,
+          count: members.length,
+          aggregate: members[0]!.status,
+        });
         for (const member of members) rows.push({ kind: 'agent', state: member, grouped: true });
       }
       i = j;
@@ -142,6 +151,7 @@ export class TuiApp {
         s.session.toLowerCase().includes(lower) ||
         s.window.toLowerCase().includes(lower) ||
         (s.claudeName?.toLowerCase().includes(lower) ?? false) ||
+        (s.customName?.toLowerCase().includes(lower) ?? false) ||
         (s.project?.toLowerCase().includes(lower) ?? false),
     );
   }
@@ -182,6 +192,17 @@ export class TuiApp {
   exitSend(): void {
     this.mode = this.modeBeforeSend;
     this.sendBuffer = '';
+  }
+
+  enterRename(prefill: string): void {
+    this.modeBeforeRename = this.mode;
+    this.mode = TuiMode.RENAME;
+    this.renameBuffer = prefill;
+  }
+
+  exitRename(): void {
+    this.mode = this.modeBeforeRename;
+    this.renameBuffer = '';
   }
 
   enterKillConfirm(): void {

--- a/src/tui/dashboard.test.ts
+++ b/src/tui/dashboard.test.ts
@@ -19,6 +19,7 @@ const makeState = (
   paneNum: 1,
   session,
   window,
+  windowId: '@1',
   claudeName: null,
   status,
   tool: null,

--- a/src/tui/dashboard.test.ts
+++ b/src/tui/dashboard.test.ts
@@ -21,6 +21,7 @@ const makeState = (
   window,
   windowId: '@1',
   claudeName: null,
+  customName: null,
   status,
   tool: null,
   project: `~/Developer/${session}`,

--- a/src/tui/help.ts
+++ b/src/tui/help.ts
@@ -12,6 +12,7 @@ export function renderHelp(): string[] {
   lines.push(`  ${C.yellowBold}s${C.reset}${C.gray}           Send prompt to session${C.reset}`);
   lines.push(`  ${C.yellowBold}/${C.reset}${C.gray}           Filter sessions by name${C.reset}`);
   lines.push(`  ${C.yellowBold}x${C.reset}${C.gray}           Kill selected session (asks to confirm)${C.reset}`);
+  lines.push(`  ${C.yellowBold}R${C.reset}${C.gray}           Rename selected session${C.reset}`);
   lines.push(`  ${C.yellowBold}?${C.reset}${C.gray}           This help${C.reset}`);
   lines.push(`  ${C.yellowBold}q or Esc${C.reset}${C.gray}    Quit${C.reset}`);
   lines.push('');

--- a/src/tui/kill.test.ts
+++ b/src/tui/kill.test.ts
@@ -7,6 +7,7 @@ const makeState = (overrides: Partial<AgentState>): AgentState => ({
   paneNum: 42,
   session: 'test',
   window: 'main',
+  windowId: '@1',
   claudeName: null,
   status: AgentStatus.IDLE,
   tool: null,

--- a/src/tui/kill.test.ts
+++ b/src/tui/kill.test.ts
@@ -9,6 +9,7 @@ const makeState = (overrides: Partial<AgentState>): AgentState => ({
   window: 'main',
   windowId: '@1',
   claudeName: null,
+  customName: null,
   status: AgentStatus.IDLE,
   tool: null,
   project: '~/Developer/test',

--- a/src/tui/layouts/cards.test.ts
+++ b/src/tui/layouts/cards.test.ts
@@ -11,6 +11,7 @@ const state = (over: Partial<AgentState>): AgentState => ({
   window: 'api',
   windowId: '@1',
   claudeName: null,
+  customName: null,
   status: AgentStatus.IDLE,
   tool: null,
   project: '~/Developer/api',

--- a/src/tui/layouts/cards.test.ts
+++ b/src/tui/layouts/cards.test.ts
@@ -9,6 +9,7 @@ const state = (over: Partial<AgentState>): AgentState => ({
   paneNum: 1,
   session: 'api',
   window: 'api',
+  windowId: '@1',
   claudeName: null,
   status: AgentStatus.IDLE,
   tool: null,

--- a/src/tui/layouts/cards.ts
+++ b/src/tui/layouts/cards.ts
@@ -1,6 +1,6 @@
 import { C } from '../../terminal/colors.ts';
 import { truncateAnsi, truncateWidth, visibleLength } from '../../terminal/ansi.ts';
-import { STATUS_DISPLAY, windowLabel, type AgentState } from '../../state/types.ts';
+import { STATUS_DISPLAY, sessionDisplay, windowLabel, type AgentState } from '../../state/types.ts';
 import type { TuiApp } from '../app.ts';
 import { formatAge, getAgeColor, getStateColor, stateIcon, type LayoutLines } from './shared.ts';
 
@@ -18,7 +18,7 @@ export function buildCardLines(app: TuiApp, cols: number): LayoutLines {
 
   for (const row of rows) {
     if (row.kind === 'header') {
-      const label = ` ${row.session} · ${row.count} `;
+      const label = ` ${row.label} · ${row.count} `;
       const fill = Math.max(0, cols - visibleLength(label) - 4);
       lines.push(truncateAnsi(`${C.gray}──${C.bold}${label}${C.reset}${C.gray}${'─'.repeat(fill)}${C.reset}`, cols));
       states.push(null);
@@ -35,7 +35,7 @@ export function buildCardLines(app: TuiApp, cols: number): LayoutLines {
     // line 1 visible budget: bar(1) sp(1) icon(1) sp(1) name … sp(1) age
     const nameW = Math.max(1, cols - 5 - age.length);
     const name = truncateWidth(
-      windowLabel(st) === st.session ? st.session : `${st.session} · ${windowLabel(st)}`,
+      windowLabel(st) === st.session ? sessionDisplay(st) : `${sessionDisplay(st)} · ${windowLabel(st)}`,
       nameW,
     );
     const gap = ' '.repeat(Math.max(1, nameW - visibleLength(name) + 1));

--- a/src/tui/layouts/table.ts
+++ b/src/tui/layouts/table.ts
@@ -1,6 +1,6 @@
 import { C } from '../../terminal/colors.ts';
 import { padAnsi, truncateAnsi, truncateWidth, visibleLength } from '../../terminal/ansi.ts';
-import { STATUS_DISPLAY, windowLabel, type AgentState } from '../../state/types.ts';
+import { STATUS_DISPLAY, sessionDisplay, windowLabel, type AgentState } from '../../state/types.ts';
 import type { DashboardRow, TuiApp } from '../app.ts';
 import { formatAge, getAgeColor, getStateColor, stateIcon, type LayoutLines } from './shared.ts';
 
@@ -36,13 +36,16 @@ export function computeColumnWidths(rows: DashboardRow[], cols: number): ColumnW
 function nameCell(row: Extract<DashboardRow, { kind: 'agent' }>): string {
   const label = windowLabel(row.state);
   if (row.grouped) return `  ${label}`;
-  return label === row.state.session ? row.state.session : `${row.state.session} · ${label}`;
+  // Window-presence logic keys on the real session (windowLabel compares against
+  // it); only the shown string swaps to the rename via sessionDisplay.
+  const session = sessionDisplay(row.state);
+  return label === row.state.session ? session : `${session} · ${label}`;
 }
 
 function formatHeaderRow(row: Extract<DashboardRow, { kind: 'header' }>, cols: number): string {
   const display = STATUS_DISPLAY[row.aggregate];
   const color = getStateColor(row.aggregate);
-  const line = `  ${color}${display.icon}${C.reset} ${C.bold}${row.session}${C.reset} ${C.dim}· ${row.count} agents${C.reset}`;
+  const line = `  ${color}${display.icon}${C.reset} ${C.bold}${row.label}${C.reset} ${C.dim}· ${row.count} agents${C.reset}`;
   return truncateAnsi(line, cols);
 }
 

--- a/src/tui/preview.test.ts
+++ b/src/tui/preview.test.ts
@@ -23,6 +23,7 @@ const makeState = (status: AgentStatus): AgentState => ({
   window: 'main',
   windowId: '@1',
   claudeName: null,
+  customName: null,
   status,
   tool: null,
   project: '~/Developer/test',

--- a/src/tui/preview.test.ts
+++ b/src/tui/preview.test.ts
@@ -21,6 +21,7 @@ const makeState = (status: AgentStatus): AgentState => ({
   paneNum: 1,
   session: 'test',
   window: 'main',
+  windowId: '@1',
   claudeName: null,
   status,
   tool: null,

--- a/src/tui/rename.ts
+++ b/src/tui/rename.ts
@@ -1,0 +1,13 @@
+import { C } from '../terminal/colors.ts';
+import { truncateAnsi } from '../terminal/ansi.ts';
+import type { AgentState } from '../state/types.ts';
+
+export function renderRenameMode(state: AgentState, buffer: string, cols: number): string[] {
+  return [
+    `${C.bold}Rename ${state.session}${C.reset}`,
+    '',
+    `${C.gray}Type a name, Enter to save, Esc to cancel. Empty clears the rename.${C.reset}`,
+    '',
+    truncateAnsi(`${C.cyan}> ${C.reset}${buffer}█`, cols),
+  ];
+}

--- a/src/tui/render.test.ts
+++ b/src/tui/render.test.ts
@@ -31,6 +31,7 @@ const makeState = (): AgentState => ({
   window: 'main',
   windowId: '@1',
   claudeName: null,
+  customName: null,
   status: AgentStatus.BUSY,
   tool: null,
   project: '~/Developer/test',

--- a/src/tui/render.test.ts
+++ b/src/tui/render.test.ts
@@ -29,6 +29,7 @@ const makeState = (): AgentState => ({
   paneNum: 1,
   session: 'agent-one',
   window: 'main',
+  windowId: '@1',
   claudeName: null,
   status: AgentStatus.BUSY,
   tool: null,

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -2,6 +2,7 @@ import { TuiMode, type TuiApp } from './app.ts';
 import { renderHeader, renderSessionList, renderFooter } from './dashboard.ts';
 import { renderPreview } from './preview.ts';
 import { renderSendMode } from './send.ts';
+import { renderRenameMode } from './rename.ts';
 import { renderKillConfirm } from './kill.ts';
 import { renderHelp } from './help.ts';
 import { C } from '../terminal/colors.ts';
@@ -43,6 +44,17 @@ export function render(app: TuiApp, size: TerminalSize): string {
       const sendLines = renderSendMode(selected, app.sendBuffer, cols);
       for (let i = 0; i < contentRows - 1 && i < sendLines.length; i++) {
         out.push(sendLines[i]! + '\x1b[K\r\n');
+        linesWritten++;
+      }
+    }
+  } else if (app.mode === TuiMode.RENAME) {
+    const selected = app.selectedState();
+    if (selected) {
+      out.push('\x1b[K\r\n');
+      linesWritten++;
+      const renameLines = renderRenameMode(selected, app.renameBuffer, cols);
+      for (let i = 0; i < contentRows - 1 && i < renameLines.length; i++) {
+        out.push(renameLines[i]! + '\x1b[K\r\n');
         linesWritten++;
       }
     }


### PR DESCRIPTION
## Summary

Agent-awareness enhancements for fleet, adapted from herdr and layered on tmux **without replacing it** — six from an ideation contract (specs in `docs/ideation/fleet-agent-awareness/`, kept untracked), plus first-class **pi** support added to close #18. This branch also carries one pre-existing commit unrelated to this work (`ec3233b`, full-height sidebar).

**Closes #18** (_harness support: codex/pi?_) — both **Codex** and **pi** are now first-class agents, labeled by name on the dashboard alongside `claude`. Codex via `fleet install codex` (wires its `hooks.json` + `config.toml`). pi has no shell hooks — it loads TypeScript extensions — so `fleet install pi` installs a fleet extension that publishes status from pi's `agent_start`/`tool_execution_start`/`agent_end` lifecycle events.

## What's here

| Change | Note |
| --- | --- |
| `fleet explain <session>` (+ `--show-snapshot`) | decision-trace for the 3-layer state engine — the clearest win |
| Detection manifests + **dir-drift bug fix** | scraper → data-driven JSON; the dir-drift fix repairs a real latent bug (README `agents.json` pointed at a dir nothing writes) |
| Enriched labels (`Bash: npm test`) + session rename | real, felt polish |
| `fleet wait <session> --state <s>` | scripting primitive for agent-orchestrates-agent |
| Codex first-class + `fleet install codex` | code-complete + unit-tested; see Known Limitations |
| **pi first-class + `fleet install pi`** | extension-based (pi has no hooks); publishes status from pi lifecycle events; closes #18 |
| Window state rollup | **dormant/opt-in only** — see below |

## Changes since this was opened as a draft

The draft flagged four things; each is now addressed:

1. **CI `format` job was failing.** Three files landed unformatted from the autopilot run; `oxfmt --check` (CI) failed while local `oxfmt` reformatted in place. Fixed (`style:` commit) — `format:check` is now clean.
2. **`fleet install` overwrote `window-status-format`.** The window-rollup opt-in prompt wrote a wholesale `set -g window-status-format` override, discarding a user's themed formatting — the "it rewrote my tmux statusline" surprise, and a violation of fleet's extend-don't-replace premise. **Removed the prompt from `runInstall`**; install no longer touches window formatting. The rollup runtime stays but is **dormant behind the `@fleet_rollup` option** (which install no longer sets), so it's a no-op unless a user deliberately opts in via their own tmux.conf. Regression tests lock that install's conf writers never emit `window-status-format`.
3. **Never exercised live.** Now validated against a real session with the compiled binary (see below).
4. **Unsigned commits.** See Signing note.

## Validation

`bun test` → **400 pass, 0 fail**; `tsc --noEmit`, `oxlint`, `oxfmt --check`, and `bun build` all clean.

**Live smoke tests** (compiled `dist/fleet` against a real tmux session):

- `fleet explain <session>` — renders the full decision trace: winning layer, all three candidates + timestamps, the matched manifest rule id (`busy.token-counter-min`), and the honest `freshness → not evaluated (live refresh is stateless)` annotation.
- `fleet explain --show-snapshot` — dumps the exact bottom-buffer the scraper evaluated.
- `fleet wait` — unknown-state and no-args exit 1; `--state ready --timeout 1` exits 124 on expiry.
- PreToolUse hook (isolated temp status dir) — writes `state: working` with the enriched `tool: "Bash: bun test --coverage"`, while the event stream keeps the RAW `"tool":"Bash"` (so AskUserQuestion detection is unaffected).
- pi extension — its status output is round-tripped through fleet's own `parseStatusFile` (schema-compat proof), and the event wiring (`agent_start`→working, `tool_execution_start`→label, `agent_end`→done, `session_shutdown`→remove) is tested against a temp status dir with a mock pi API.
- **pi — validated live** against a real pi session (anthropic model, real bash tool call). Captured the actual transitions: `working` → `working` + `tool: "Bash: echo fleet-pi-smoke-test"` (correct enriched label, correct pane/session/pid), then `session_shutdown` cleaned up the file on exit.

## Known limitations

- **Codex is not yet validated against a live Codex session** (pi now is — see Validation). Codex's integration is unit-tested (`hooks.json`/`config.toml` merge, idempotency, user-hook preservation, `CODEX_MANIFEST`, identity threading) but no real Codex process has driven the hooks here. It's inert until `fleet install codex`, so any integration bug is contained and never affects Claude-only use. Documented gaps: Codex QUESTION isn't sourced (no Notification hook); pi has no PERMIT/QUESTION because it auto-runs tools (working/done is full coverage).
- **pi fails to start if any auto-discovered pi extension throws at load** — pi's own behavior, not fleet's. (Discovered live: a pre-existing broken `mcp` extension in the test environment made pi exit 1 at startup, which would block fleet-pi too until that extension is fixed/removed. `fleet install pi` only adds its own extension and never touches others.)
- **Window rollup is dormant.** The feature ships but is never auto-enabled; a reviewer who wants it gone entirely can remove it as a follow-up (it's woven through a shared type, so a clean excision is a larger change than this PR).
- **Session rename** (TUI `R`) is interactive; it's unit-tested for persistence but not smoke-tested here.

## Signing

Several commits on this branch are **unsigned** (the `style:`/`fix:`/`feat: pi` commits made in this session, plus the existing `79e8265`) — 1Password's SSH agent can't sign non-interactively. Not a merge blocker (no signed-commit branch protection). Re-sign interactively before merge if desired:
`git rebase --exec 'git commit --amend -S --no-edit' e7b9273`

## Honest take

The high-confidence, low-risk core is **`fleet explain`, the dir-drift fix, labels/rename, and pi** — all validated live (pi against a real pi session). `wait` is a clean primitive with no consumer yet. **Codex** is now the only piece riding on unit tests + API-grounding alone (no live Codex run), and it's opt-in/inert until installed, so the risk is contained. With rollup neutralized, the Claude core + pi validated, and #18 answered end-to-end, this is defensible to merge; if you'd prefer to gate Codex on a live smoke test first, splitting it out remains reasonable.
