### PR TITLE
feat: double-click a sidebar row to jump to that agent

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -746,9 +746,10 @@ async function launchTui(): Promise<number> {
           return;
         }
 
-        // Click a session row → select it, and acknowledge it in place if it's
-        // ready. Lets you clear finished agents by clicking, without leaving the
-        // dashboard (statusline clicks switch instead — see `fleet switch`).
+        // Left-click a row → select it (single) or jump to it (double-click,
+        // the same action as Enter). A single click also acks a done agent in
+        // place, so you can clear finished agents without leaving the dashboard.
+        // Statusline clicks switch instead — see `fleet switch`.
         if (
           mouse.button === 'left' &&
           mouse.type === 'press' &&
@@ -756,11 +757,21 @@ async function launchTui(): Promise<number> {
         ) {
           const sel = listHit(mouse.x, mouse.y);
           if (sel) {
+            if (app.registerClick(sel.paneId, Date.now())) {
+              // Double-click → jump to the agent, mirroring the Enter handler.
+              verifyPaneState(sel, statusDirs);
+              acknowledgePane(sel.paneId, statusDirs);
+              finish(0);
+              switchClient(sel.paneId);
+              return;
+            }
             const idx = app.visibleStates().findIndex((s) => s.paneId === sel.paneId);
             if (idx >= 0) app.selectedIndex = idx;
             if (sel.status === AgentStatus.DONE) {
+              // Ack in place, but DON'T refresh now: a re-sort would slide the
+              // row out from under a second press and break double-click on done
+              // agents. The fast refresh timer reflects the ack within ~500ms.
               acknowledgePane(sel.paneId, statusDirs);
-              app.updateStates(refreshStates(dirs));
             }
             needsRender = true;
           }

--- a/src/tui/app.test.ts
+++ b/src/tui/app.test.ts
@@ -259,6 +259,33 @@ describe('hover', () => {
   });
 });
 
+describe('double-click detection', () => {
+  test('same pane pressed twice within the window is a double-click', () => {
+    const app = new TuiApp();
+    expect(app.registerClick('%1', 1000)).toBe(false); // first press: single
+    expect(app.registerClick('%1', 1300)).toBe(true); // within window: double
+  });
+
+  test('same pane pressed twice outside the window is two single-clicks', () => {
+    const app = new TuiApp();
+    expect(app.registerClick('%1', 1000)).toBe(false);
+    expect(app.registerClick('%1', 1600)).toBe(false); // too slow: not a double
+  });
+
+  test('a different pane is never a double-click', () => {
+    const app = new TuiApp();
+    expect(app.registerClick('%1', 1000)).toBe(false);
+    expect(app.registerClick('%2', 1100)).toBe(false); // different row, even if fast
+  });
+
+  test('triple-click does not read as two overlapping double-clicks', () => {
+    const app = new TuiApp();
+    expect(app.registerClick('%1', 1000)).toBe(false); // single
+    expect(app.registerClick('%1', 1200)).toBe(true); // double (resets)
+    expect(app.registerClick('%1', 1300)).toBe(false); // third press starts fresh
+  });
+});
+
 describe('split drag', () => {
   test('listWidth uses splitRatio', () => {
     const app = new TuiApp();

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -30,6 +30,10 @@ const MIN_SPLIT = 0.2;
 const MAX_SPLIT = 0.8;
 const DEFAULT_SPLIT = 0.45;
 
+// Two left-presses on the same row within this window count as a double-click
+// (the mouse "jump to agent" gesture, mirroring Enter).
+const DOUBLE_CLICK_MS = 400;
+
 export class TuiApp {
   private states: AgentState[] = [];
   private filter: string = '';
@@ -48,6 +52,8 @@ export class TuiApp {
   dragging: boolean = false;
   hoverPaneId: string | null = null;
   pulsePhase: boolean = false;
+  private lastClickPaneId: string | null = null;
+  private lastClickTs: number = 0;
 
   updateStates(newStates: AgentState[]): void {
     const selectedPaneId = this.selectedState()?.paneId ?? null;
@@ -256,6 +262,21 @@ export class TuiApp {
 
   endDrag(): void {
     this.dragging = false;
+  }
+
+  // True when this left-press completes a double-click: the same pane pressed
+  // again within DOUBLE_CLICK_MS. Resets on a match so a triple-click isn't read
+  // as two overlapping doubles. `now` (ms) is injected so callers stay testable.
+  registerClick(paneId: string, now: number): boolean {
+    const isDouble = paneId === this.lastClickPaneId && now - this.lastClickTs <= DOUBLE_CLICK_MS;
+    if (isDouble) {
+      this.lastClickPaneId = null;
+      this.lastClickTs = 0;
+    } else {
+      this.lastClickPaneId = paneId;
+      this.lastClickTs = now;
+    }
+    return isDouble;
   }
 
   private clampSelection(): void {


### PR DESCRIPTION
## What

Double-click a row in the fleet sidebar to jump to that agent — the same action as pressing **Enter**.

- **Single-click**: unchanged — selects the row, and acks a done agent in place (clear a finished agent without leaving the dashboard).
- **Double-click**: `verifyPaneState → acknowledgePane → finish(0) → switchClient`, mirroring the Enter handler.

## Why

The sidebar's whole job is navigation, but clicking a row only *selected* it — you still had to reach for Enter to actually jump. Double-click makes the mouse a first-class way to switch agents while keeping the existing click-to-clear gesture.

## How

- New `TuiApp.registerClick(paneId, now): boolean` — true when the same row is pressed again within 400 ms, resetting on a match so a triple-click isn't read as two overlapping doubles. `now` is injected (not `Date.now()` internally) so it's deterministic and unit-tested.
- The single-click in-place ack **no longer force-refreshes** the list. An immediate re-sort (done → idle) would slide the row out from under your second press and break double-click on *done* agents — the exact ones you most want to jump to. The fast refresh timer reflects the ack within ~500 ms.

## Test plan

- `bun test` — **404 pass** (incl. 4 new unit tests for `registerClick`: same-row-in-window = double; different row = not; too-slow = not; triple-click resets).
- `bun run typecheck` / `bun run lint` — clean.
- **End-to-end**: ran the compiled binary in a throwaway tmux with one agent rendered, then injected raw SGR mouse bytes into fleet's stdin — a single-click leaves fleet running; a double-click exits it via `finish(0)` (the jump path fired). Real tmux, real mouse sequences, real parse → `registerClick`.

Double-click matches Enter, so it closes the sidebar on jump — consistent with leaning on the persistent statusline as the always-visible surface.
