### PR TITLE
feat: harness-agnostic awareness — spinner-glyph detection, hook-less discovery, silent notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A terminal dashboard for managing multiple AI agent sessions in tmux.
 
-Fleet watches your Claude Code sessions, shows which agents need attention, and lets you send prompts — all from a single pane. It replaces a sprawl of bash scripts with a compiled Bun binary and a Claude Code plugin that hooks into the event system automatically.
+Fleet watches your Claude Code sessions, shows which agents need attention, and lets you send prompts — all from a single pane. It replaces a sprawl of bash scripts with a compiled Bun binary and a Claude Code plugin that hooks into the event system automatically. Beyond hooked agents (Claude Code, Codex, pi), it also surfaces ones it has no integration for — aider, opencode, and the like — by spotting them in the process table.
 
 <img width="3744" height="2402" alt="capture_20260527_180922" src="https://github.com/user-attachments/assets/0ad4ea10-948f-4e64-a509-9ad7ca2a2db4" />
 
@@ -193,6 +193,22 @@ Press `i` from the preview to enter passthrough mode. Every keystroke is forward
 
 This is the power feature: approve prompts, answer questions, type commands, and watch the output — all without switching panes. The footer shows `● LIVE` when passthrough is active.
 
+### Hook-less agents
+
+Fleet also surfaces agents it has **no** hook integration for. On its 5-second refresh it scans the process table for known agent commands — `aider`, `cursor`, `opencode`, `gemini`, `amp`, `droid` (plus `claude`/`codex`/`pi`) — maps each back to its tmux pane, and shows it on the dashboard labeled by type. No install, no config: start `aider` in a pane and it appears within ~5s.
+
+Discovered agents read as **working** or **idle** only — the animated braille spinner in the pane is the signal (present → working, absent → idle). The richer states (waiting/asking/ready) need a hook, so an agent you've wired up always wins its pane: when a `.status` file exists, the hooked reading takes over and you get the full seven states. Discovery only ever fills the gap where there's no hook.
+
+Tune it with tmux options (see [Configuration](#configuration)): `@fleet_discover off` turns it off, `@fleet_discover_agents` overrides the allowlist, `@fleet_discover_idle_secs` sets the debounce.
+
+### Desktop notifications
+
+When an agent finishes a turn — or stops to ask you something — while you're **not** looking, Fleet fires a **silent** OS-native desktop notification (`osascript` on macOS, `notify-send` on Linux). It's deliberately soundless: at fifteen agents, a chime per finish is noise, not a signal. Delivery is best-effort and no-ops cleanly when there's no desktop session (headless, SSH).
+
+Two suppressions keep toasts from being redundant: none for the pane you're **currently focused on**, and none at all while you're **watching the Fleet dashboard itself** (you can already see the change on screen). A toast fires only on a real working → stopped transition, exactly once, and re-arms when the agent starts working again.
+
+The in-tmux status-line flash still fires as before. The terminal **bell**, though, is now **off by default** — turn it back on with `tmux set -g @fleet_bell on` if you want the audible cue.
+
 ## Theming
 
 Fleet ships two palettes — Catppuccin Mocha for dark terminals, Catppuccin Latte for light ones — and picks between them automatically. Detection walks a chain and stops at the first hit:
@@ -204,6 +220,20 @@ Fleet ships two palettes — Catppuccin Mocha for dark terminals, Catppuccin Lat
 5. Otherwise it defaults to dark (Mocha).
 
 `NO_COLOR` is always honored: set it and Fleet renders monochrome, whatever the theme would have been.
+
+## Configuration
+
+Beyond the theme chain above, Fleet reads a handful of tmux user options — set them live with `tmux set -g <option> <value>` or drop them in `~/.tmux.conf`. All are optional, and changes take effect within one 5-second refresh (no restart).
+
+| Option                      | Default       | Description                                                                                                                                                                             |
+| --------------------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@fleet-theme`              | auto          | Pin the palette to `light` or `dark` (see [Theming](#theming)).                                                                                                                         |
+| `@fleet_bell`               | `off`         | Ring the terminal bell on a cross-session transition. Off keeps Fleet silent at scale; the visual flash fires regardless.                                                               |
+| `@fleet_discover`           | `on`          | Discover agents with no hook integration from the process table. Set `off` to disable.                                                                                                  |
+| `@fleet_discover_agents`    | built-in list | Comma-separated allowlist of command names to treat as agents. **Replaces** the default `claude,codex,pi,aider,cursor,opencode,gemini,amp,droid`, so keep the built-ins you still want. |
+| `@fleet_discover_idle_secs` | `3`           | Grace period (seconds) before a discovered agent flips working → idle, absorbing a single spinner-less frame.                                                                           |
+
+Environment variables `FLEET_THEME` (`light`/`dark`) and `NO_COLOR` are honored too — see [Theming](#theming).
 
 ## CLI Commands
 
@@ -284,7 +314,7 @@ Fleet doesn't trust any single signal. It fuses three layers for high-confidence
 
 2. **JSONL event stream** (Layer 2) — Each hook appends to a per-pane event log. The TUI reads only the last event. Key insight: a `stop_reason` of `tool_use` means the agent is about to run another tool (BUSY), while `end_turn` means actually done.
 
-3. **Pane scraping** (Layer 3, ~50ms) — `tmux capture-pane` as the visual arbiter. Detects permission prompts (`[y/n]`), question dialogs (`Enter to select`), the working token counter (`(1m 11s · ↓ 3.4k tokens)`), and idle prompts. The scraper is authoritative only for what it can read unambiguously off the screen — `PERMIT` and `QUESTION` always win. For working-vs-idle it defers to the hooks: a scraper miss (Claude's spinner animates between capture frames) can't downgrade a fresh `working` hook to idle, but a scraped idle prompt does clear a stale permission.
+3. **Pane scraping** (Layer 3, ~50ms) — `tmux capture-pane` as the visual arbiter. Detects permission prompts (`[y/n]`), question dialogs (`Enter to select`), the working token counter (`(1m 11s · ↓ 3.4k tokens)`), the animated **braille spinner glyph** (U+2800–U+28FF), and idle prompts. The spinner is a strong working signal: a harness paints it only while actually working, so — unlike the English strings — it can't be spoofed by a transcript that quotes them, and it still reads as working after the token-counter line scrolls off. Detection is an ordered, first-match-wins rule list, so `PERMIT` and `QUESTION` still win over any working rule. For working-vs-idle the scraper defers to the hooks — a scraper miss can't downgrade a fresh `working` hook to idle — but a scraped idle prompt does clear a stale permission. (The same spinner check drives [hook-less discovery](#hook-less-agents) for agents with no hook at all.)
 
 **Freshness invariant:** A state transition is only accepted if its timestamp is newer than the current state's timestamp. Prevents out-of-order hook deliveries from causing flicker.
 
@@ -313,7 +343,7 @@ The Claude Code plugin (`hooks/`) fires on five events:
 - **SubagentStop** — Subagent finished; parent keeps working
 - **SessionEnd** — Cleanup status and event files
 
-Each hook script sources `hooks/lib.sh` which handles status file writes, JSONL event appends, and tmux notifications (with self-notification suppression).
+Each hook script sources `hooks/lib.sh` which handles status file writes, JSONL event appends, and the in-tmux notification flash (with self-notification suppression). The flash always fires; the terminal bell it used to ring is now gated behind `@fleet_bell` (default off — see [Configuration](#configuration)). The silent desktop toasts are fired separately by the TUI, not the hooks (see [Desktop notifications](#desktop-notifications)).
 
 ### Performance
 
@@ -353,6 +383,8 @@ claude=$HOME/.cache/claude-status
 pi=$HOME/.cache/pi-status
 ```
 
+This file is only for **hooked** agents — ones that write status files. Agents picked up by [hook-less discovery](#hook-less-agents) need no entry here; they're found in the process table.
+
 ## Development
 
 Fleet is a zero-dependency Bun project.
@@ -361,7 +393,7 @@ Fleet is a zero-dependency Bun project.
 bun install              # Install dev dependencies
 bun run dev              # Run without compiling
 bun run build            # Compile to standalone binary (dist/fleet)
-bun test                 # Run tests (273 tests, ~70ms)
+bun test                 # Run tests (457 tests, ~150ms)
 bun run typecheck        # tsc --noEmit
 bun run lint             # oxlint
 bun run format           # oxfmt
@@ -373,7 +405,7 @@ bun run format:check     # oxfmt --check
 Tests are collocated (`*.test.ts` next to source). The state engine, ANSI utilities, TUI model, and CLI commands are unit-tested. Tmux-dependent code has integration-style tests that gracefully degrade outside tmux.
 
 ```bash
-bun test                 # 273 tests, ~70ms
+bun test                 # 457 tests, ~150ms
 bun test src/state/      # State engine only
 bun test src/terminal/   # Terminal primitives only
 bun test src/tui/        # TUI model only

--- a/hooks/lib.sh
+++ b/hooks/lib.sh
@@ -79,7 +79,10 @@ fleet_notify() {
 
   tmux display-message -d 3000 "$msg" 2>/dev/null
 
-  if [ "$current_session" != "$session" ]; then
+  # Only ring the bell when the user has opted in (@fleet_bell = on). Default:
+  # silent — the bell becomes noise at agent scale. The visual flash above stays.
+  # Pattern: theme.ts reads @fleet-theme via `tmux show -gqv`.
+  if [ "$(tmux show-option -gqv @fleet_bell 2>/dev/null)" = "on" ] && [ "$current_session" != "$session" ]; then
     tmux run-shell -t "$pane_id" "printf '\\a'" 2>/dev/null
   fi
 }

--- a/index.ts
+++ b/index.ts
@@ -22,7 +22,9 @@ import { readLastEvents, deriveStatusFromEvents } from './src/state/events.ts';
 import { acknowledgePlan } from './src/state/acknowledge.ts';
 import { scrapePane } from './src/state/scraper.ts';
 import { loadRenames, saveRename } from './src/state/rename.ts';
-import { AgentStatus, ACK_ALL_RANGE, extractClaudeName, type AgentState } from './src/state/types.ts';
+import { AgentStatus, ACK_ALL_RANGE, STATUS_DISPLAY, extractClaudeName, type AgentState } from './src/state/types.ts';
+import { decideNotifications, applySuppression } from './src/notify/transitions.ts';
+import { deliverDesktop } from './src/notify/deliver.ts';
 import { AgentRegistry } from './src/agents/registry.ts';
 import type { AgentDir } from './src/agents/config.ts';
 import { listPanesResult, switchClient, killPane, gitBranch } from './src/tmux/sessions.ts';
@@ -207,6 +209,20 @@ function refreshTmuxStatus(): void {
     Bun.spawnSync({ cmd: ['tmux', 'refresh-client', '-S'] });
   } catch {
     // Not in tmux, or refresh failed — non-critical
+  }
+}
+
+// The pane the user is currently focused on (active pane of the attached client's
+// current window). Returns null when tmux can't answer, which disables the
+// notifier's per-pane suppression — better a redundant toast than a missed one.
+function resolveActivePane(): string | null {
+  try {
+    const p = Bun.spawnSync({ cmd: ['tmux', 'display-message', '-p', '#{pane_id}'], stdout: 'pipe', stderr: 'pipe' });
+    if (p.exitCode !== 0) return null;
+    const v = p.stdout.toString().trim();
+    return v.length > 0 ? v : null;
+  } catch {
+    return null;
   }
 }
 
@@ -642,21 +658,36 @@ async function launchTui(): Promise<number> {
     process.stdout.write(render(app, size));
   };
 
-  const doRefresh = () => {
-    const states = refreshStates(dirs);
+  // The pane fleet itself runs in — used to suppress every toast while you're
+  // watching the dashboard. Null when launched outside tmux (harmless: per-pane
+  // suppression still works).
+  const fleetPaneId = process.env.TMUX_PANE ?? null;
+  let notifyPrev = new Map<string, AgentStatus>();
+
+  // Compare this snapshot's statuses to the last and fire a silent desktop toast
+  // on each work->stop transition, suppressing the pane you're focused on (and
+  // every toast while you're watching fleet itself). Detection advances notifyPrev
+  // every call, so a transition fires exactly once and re-arms on the next BUSY.
+  const maybeNotify = (states: AgentState[]) => {
+    const { candidates, previous } = decideNotifications(states, notifyPrev);
+    notifyPrev = previous;
+    if (candidates.length === 0) return; // resolve the active pane only when something fires
+    const activePaneId = resolveActivePane();
+    for (const n of applySuppression(candidates, activePaneId, fleetPaneId)) {
+      deliverDesktop(`${STATUS_DISPLAY[n.status].label}: ${n.label}`, n.agentType);
+    }
+  };
+
+  const applyStates = (states: AgentState[]) => {
     app.updateStates(states);
     app.tmuxDown = !lastTmuxOk;
     app.hooksMissing = !statusDirs.some((d) => existsSync(d));
     needsRender = true;
   };
 
-  const doFullRefresh = () => {
-    const states = fullRefreshStates(dirs);
-    app.updateStates(states);
-    app.tmuxDown = !lastTmuxOk;
-    app.hooksMissing = !statusDirs.some((d) => existsSync(d));
-    needsRender = true;
-  };
+  const doRefresh = () => applyStates(refreshStates(dirs));
+
+  const doFullRefresh = () => applyStates(fullRefreshStates(dirs));
 
   reloadRenameCache();
   doFullRefresh();
@@ -954,10 +985,14 @@ async function launchTui(): Promise<number> {
 
     const isTyping = () => app.mode === TuiMode.SEND || app.mode === TuiMode.RENAME || app.isFiltering();
 
-    // Fast timer: keep running in passthrough (preview needs live updates), skip during typing
+    // Fast timer: keep running in passthrough (preview needs live updates).
+    // Notification detection runs every tick even while typing — only the list
+    // refresh + render pause, so a background agent finishing still toasts.
     refreshTimer = setInterval(() => {
+      const states = refreshStates(dirs);
+      maybeNotify(states);
       if (isTyping()) return;
-      doRefresh();
+      applyStates(states);
       if (app.visibleStates().some((s) => s.status === AgentStatus.BUSY)) {
         app.pulsePhase = !app.pulsePhase;
         needsRender = true;

--- a/index.ts
+++ b/index.ts
@@ -20,13 +20,14 @@ import { fuseState } from './src/state/engine.ts';
 import { readAllStatusDirs, watchStatusDirs } from './src/state/hooks.ts';
 import { readLastEvents, deriveStatusFromEvents } from './src/state/events.ts';
 import { acknowledgePlan } from './src/state/acknowledge.ts';
-import { scrapePane } from './src/state/scraper.ts';
+import { scrapePane, scrapePaneCapture } from './src/state/scraper.ts';
 import { loadRenames, saveRename } from './src/state/rename.ts';
 import { AgentStatus, ACK_ALL_RANGE, STATUS_DISPLAY, extractClaudeName, type AgentState } from './src/state/types.ts';
 import { decideNotifications, applySuppression } from './src/notify/transitions.ts';
 import { deliverDesktop } from './src/notify/deliver.ts';
 import { AgentRegistry } from './src/agents/registry.ts';
 import type { AgentDir } from './src/agents/config.ts';
+import { scanDiscovered, type DiscoveredAgent } from './src/agents/discovery.ts';
 import { listPanesResult, switchClient, killPane, gitBranch } from './src/tmux/sessions.ts';
 import { detectPorts } from './src/tmux/ports.ts';
 import { sendKeys, sendRawKey } from './src/tmux/send.ts';
@@ -238,6 +239,12 @@ function shortenPath(path: string): string {
 const branchCache = new Map<string, string | null>();
 let portCache = new Map<string, number[]>();
 const scrapeCache = new Map<string, AgentStatus | null>();
+// Hook-less discovery (Phase 3): paneId -> synthetic agent, rebuilt on the slow
+// tick and read on every fast tick — same lifecycle as scrapeCache/portCache.
+// discoveryLastWorking carries the spinner-debounce timestamps across slow ticks
+// (pruned inside discoverAgents to only currently-discovered panes).
+let discoveryCache = new Map<string, DiscoveredAgent>();
+let discoveryLastWorking = new Map<string, number>();
 let lastTmuxOk = true;
 
 // User renames (session name → custom label), loaded once per entry point and
@@ -276,14 +283,34 @@ function refreshSlowCaches(panes: { paneId: string; currentPath: string }[], dir
     if (!prev || h.ts > prev.ts) paneAgent.set(h.pane, { agent: h.agent, ts: h.ts });
   }
 
-  // Layer 3: pane scraping (~50ms per pane) — slow cycle only
+  // Layer 3: pane scraping (~50ms per pane) — slow cycle only. Capture each pane
+  // ONCE and keep its lines so hook-less discovery can reuse them for the spinner
+  // check (zero extra capture-pane calls).
   const seen = new Set<string>();
+  const captureCache = new Map<string, string[]>();
   for (const p of panes) {
     seen.add(p.paneId);
-    scrapeCache.set(p.paneId, scrapePane(p.paneId, paneAgent.get(p.paneId)?.agent ?? 'claude'));
+    const { status, lines } = scrapePaneCapture(p.paneId, paneAgent.get(p.paneId)?.agent ?? 'claude');
+    scrapeCache.set(p.paneId, status);
+    if (lines.length > 0) captureCache.set(p.paneId, lines);
   }
   for (const paneId of scrapeCache.keys()) {
     if (!seen.has(paneId)) scrapeCache.delete(paneId);
+  }
+
+  // Hook-less agent discovery: map allowlisted processes with no .status file to
+  // their host pane and classify working from the spinner glyph, reusing the
+  // captures above (only one ps + one list-panes call is added). A synthetic
+  // agent here fills refreshStates' no-hook branch, so a hooked agent's status
+  // always wins its pane and discovery never shadows it. Failure -> empty, and
+  // the pane falls back to SHELL exactly as before Phase 3.
+  try {
+    const now = Math.floor(Date.now() / 1000);
+    const discovered = scanDiscovered(captureCache, discoveryLastWorking, now);
+    discoveryCache = new Map(discovered.agents.map((a) => [a.paneId, a]));
+    discoveryLastWorking = discovered.lastWorking;
+  } catch {
+    discoveryCache = new Map();
   }
 }
 
@@ -333,7 +360,16 @@ function refreshStates(dirs: AgentDir[]): AgentState[] {
         currentTs: 0,
       }).status;
     } else {
-      status = AgentStatus.SHELL;
+      // No winning hook. Before falling to SHELL, check hook-less discovery: an
+      // allowlisted process in this pane surfaces as a synthetic agent — BUSY
+      // when the pane shows a spinner glyph, IDLE when it does not.
+      const disc = discoveryCache.get(pane.paneId);
+      if (disc) {
+        status = disc.working ? AgentStatus.BUSY : AgentStatus.IDLE;
+        agentType = disc.agentType;
+      } else {
+        status = AgentStatus.SHELL;
+      }
     }
 
     states.push({

--- a/src/agents/discovery.test.ts
+++ b/src/agents/discovery.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  discoverAgents,
+  normalizeComm,
+  parsePsTable,
+  walkToPane,
+  parseDiscoveryConfig,
+  DEFAULT_ALLOWLIST,
+  DEFAULT_IDLE_SECS,
+  type DiscoveryOpts,
+} from './discovery.ts';
+
+// A braille spinner glyph (U+2839) — the working signal a harness paints while
+// actively running. Any char in U+2800–U+28FF works.
+const SPIN = '⠹';
+
+function opts(over: Partial<DiscoveryOpts> = {}): DiscoveryOpts {
+  return {
+    allowlist: new Set(['aider']),
+    idleSecs: 3,
+    now: 100,
+    lastWorking: new Map(),
+    ...over,
+  };
+}
+
+describe('normalizeComm', () => {
+  test('strips the login-shell dash', () => {
+    expect(normalizeComm('-zsh')).toBe('zsh');
+  });
+  test('strips a directory path to the basename', () => {
+    expect(normalizeComm('/usr/bin/aider')).toBe('aider');
+    expect(normalizeComm('/Applications/Foo.app/Contents/MacOS/opencode')).toBe('opencode');
+  });
+  test('strips a dash AND a path together', () => {
+    expect(normalizeComm('-/bin/zsh')).toBe('zsh');
+  });
+  test('leaves a bare command untouched and trims surrounding space', () => {
+    expect(normalizeComm('aider')).toBe('aider');
+    expect(normalizeComm('  cursor  ')).toBe('cursor');
+  });
+});
+
+describe('parsePsTable', () => {
+  test('parses pid/ppid/comm with padding and normalizes comm', () => {
+    const { commByPid, ppidByPid } = parsePsTable(['  100     1 -zsh', ' 300   200 /usr/local/bin/aider']);
+    expect(commByPid.get(100)).toBe('zsh');
+    expect(commByPid.get(300)).toBe('aider');
+    expect(ppidByPid.get(300)).toBe(200);
+  });
+  test('ignores blank and malformed lines', () => {
+    const { commByPid } = parsePsTable(['', '   ', 'garbage', ' 42 7 node']);
+    expect(commByPid.size).toBe(1);
+    expect(commByPid.get(42)).toBe('node');
+  });
+});
+
+describe('walkToPane', () => {
+  const panePids = new Map<number, string>([[100, '%1']]);
+
+  test('2-hop chain reaches the pane', () => {
+    const ppidByPid = new Map<number, number>([
+      [300, 200],
+      [200, 100],
+    ]);
+    expect(walkToPane(300, ppidByPid, panePids)).toBe('%1');
+  });
+  test('a chain that never reaches a pane returns null', () => {
+    const ppidByPid = new Map<number, number>([
+      [300, 200],
+      [200, 1],
+    ]);
+    expect(walkToPane(300, ppidByPid, panePids)).toBeNull();
+  });
+  test('a ppid cycle is visited-guarded, not an infinite loop', () => {
+    const ppidByPid = new Map<number, number>([
+      [300, 400],
+      [400, 300],
+    ]);
+    expect(walkToPane(300, ppidByPid, panePids)).toBeNull();
+  });
+});
+
+describe('discoverAgents — mapping', () => {
+  // aider(300) -> node(200) -> shell(100)=pane_pid of %1
+  const psTable = ['  100     1 -zsh', '  200   100 node', '  300   200 /usr/local/bin/aider'];
+  const panePids = new Map<number, string>([[100, '%1']]);
+
+  test('(a) allowlisted aider via 2-hop chain, glyph present -> working', () => {
+    const captures = new Map([['%1', `thinking ${SPIN}`]]);
+    const { agents } = discoverAgents(psTable, panePids, captures, opts());
+    expect(agents).toEqual([{ paneId: '%1', agentType: 'aider', working: true }]);
+  });
+
+  test('(b) glyph absent, lastWorking stale -> not working', () => {
+    const captures = new Map([['%1', 'a bare prompt, no spinner']]);
+    const { agents } = discoverAgents(
+      psTable,
+      panePids,
+      captures,
+      opts({ now: 100, lastWorking: new Map([['%1', 90]]) }),
+    );
+    expect(agents).toEqual([{ paneId: '%1', agentType: 'aider', working: false }]);
+  });
+
+  test('(c) glyph absent but lastWorking within idleSecs -> still working (debounce)', () => {
+    const captures = new Map([['%1', 'no spinner right now']]);
+    const { agents } = discoverAgents(
+      psTable,
+      panePids,
+      captures,
+      opts({ now: 100, idleSecs: 3, lastWorking: new Map([['%1', 98]]) }),
+    );
+    expect(agents[0]!.working).toBe(true);
+  });
+
+  test('(d) allowlisted pid whose chain never reaches a pane -> not discovered', () => {
+    // pane_pid is 999, unreachable from the aider chain (tops out at 100).
+    const { agents } = discoverAgents(psTable, new Map([[999, '%9']]), new Map(), opts());
+    expect(agents).toHaveLength(0);
+  });
+
+  test('(e) non-allowlisted comm -> ignored', () => {
+    const { agents } = discoverAgents(psTable, panePids, new Map(), opts({ allowlist: new Set(['cursor']) }));
+    expect(agents).toHaveLength(0);
+  });
+
+  test('pathful comm normalizes and matches the bare allowlist entry', () => {
+    // comm is /usr/local/bin/aider; allowlist is the bare "aider".
+    const captures = new Map([['%1', SPIN]]);
+    const { agents } = discoverAgents(psTable, panePids, captures, opts({ allowlist: new Set(['aider']) }));
+    expect(agents[0]!.agentType).toBe('aider');
+  });
+
+  test('two allowlisted processes in one pane -> one discovered agent (first match wins)', () => {
+    // Both aider(300) and cursor(250) live under pane %1's shell.
+    const twoAgents = [...psTable, '  250   100 cursor'];
+    const { agents } = discoverAgents(
+      twoAgents,
+      panePids,
+      new Map(),
+      opts({ allowlist: new Set(['aider', 'cursor']) }),
+    );
+    expect(agents).toHaveLength(1);
+    expect(agents[0]!.paneId).toBe('%1');
+  });
+
+  test('empty allowlist -> zero discovered', () => {
+    const { agents } = discoverAgents(psTable, panePids, new Map(), opts({ allowlist: new Set() }));
+    expect(agents).toHaveLength(0);
+  });
+
+  test('no panes -> zero discovered', () => {
+    const { agents } = discoverAgents(psTable, new Map(), new Map(), opts());
+    expect(agents).toHaveLength(0);
+  });
+});
+
+describe('discoverAgents — debounce anchoring + prune', () => {
+  const psTable = ['  100     1 -zsh', '  300   100 aider'];
+  const panePids = new Map<number, string>([[100, '%1']]);
+
+  test('grace stays anchored to the last glyph, so a pane sampled faster than idleSecs still expires', () => {
+    // Tick 1: glyph present at t=100.
+    const t1 = discoverAgents(psTable, panePids, new Map([['%1', SPIN]]), opts({ now: 100 }));
+    expect(t1.agents[0]!.working).toBe(true);
+    expect(t1.lastWorking.get('%1')).toBe(100);
+
+    // Tick 2: glyph gone at t=102 (2s later). 102-100 < 3 -> debounced working.
+    const t2 = discoverAgents(
+      psTable,
+      panePids,
+      new Map([['%1', 'idle']]),
+      opts({ now: 102, lastWorking: t1.lastWorking }),
+    );
+    expect(t2.agents[0]!.working).toBe(true);
+    // Anchor is preserved (still 100), NOT refreshed to 102.
+    expect(t2.lastWorking.get('%1')).toBe(100);
+
+    // Tick 3: glyph still gone at t=104. 104-100=4 >= 3 -> expires. Had tick 2
+    // refreshed the anchor to 102, this would wrongly still read working.
+    const t3 = discoverAgents(
+      psTable,
+      panePids,
+      new Map([['%1', 'idle']]),
+      opts({ now: 104, lastWorking: t2.lastWorking }),
+    );
+    expect(t3.agents[0]!.working).toBe(false);
+  });
+
+  test('lastWorking is pruned to currently-discovered panes', () => {
+    // %9 was working last tick but is no longer discovered this tick.
+    const stale = new Map([
+      ['%1', 100],
+      ['%9', 50],
+    ]);
+    const { lastWorking } = discoverAgents(psTable, panePids, new Map([['%1', SPIN]]), opts({ lastWorking: stale }));
+    expect(lastWorking.has('%9')).toBe(false);
+    expect(lastWorking.has('%1')).toBe(true);
+  });
+
+  test('a pane observed idle from first sight (no prior glyph) is not working', () => {
+    const { agents } = discoverAgents(
+      psTable,
+      panePids,
+      new Map([['%1', 'no spinner']]),
+      opts({ lastWorking: new Map() }),
+    );
+    expect(agents[0]!.working).toBe(false);
+  });
+});
+
+describe('parseDiscoveryConfig', () => {
+  test('all unset -> enabled, default allowlist, default idle secs', () => {
+    const cfg = parseDiscoveryConfig({ discover: null, agents: null, idleSecs: null });
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.idleSecs).toBe(DEFAULT_IDLE_SECS);
+    expect(cfg.allowlist).toEqual(new Set(DEFAULT_ALLOWLIST));
+  });
+
+  test('@fleet_discover off -> disabled', () => {
+    expect(parseDiscoveryConfig({ discover: 'off', agents: null, idleSecs: null }).enabled).toBe(false);
+  });
+
+  test('@fleet_discover_agents override is split, normalized, trimmed', () => {
+    const cfg = parseDiscoveryConfig({ discover: null, agents: 'aider, cursor ,/opt/x/opencode', idleSecs: null });
+    expect(cfg.allowlist).toEqual(new Set(['aider', 'cursor', 'opencode']));
+  });
+
+  test('empty agents override yields an empty allowlist (nothing discovered)', () => {
+    const cfg = parseDiscoveryConfig({ discover: null, agents: '   ,,  ', idleSecs: null });
+    expect(cfg.allowlist.size).toBe(0);
+  });
+
+  test('idle secs parses a valid int; junk / negative fall back to the default', () => {
+    expect(parseDiscoveryConfig({ discover: null, agents: null, idleSecs: '8' }).idleSecs).toBe(8);
+    expect(parseDiscoveryConfig({ discover: null, agents: null, idleSecs: 'abc' }).idleSecs).toBe(DEFAULT_IDLE_SECS);
+    expect(parseDiscoveryConfig({ discover: null, agents: null, idleSecs: '-1' }).idleSecs).toBe(DEFAULT_IDLE_SECS);
+    expect(parseDiscoveryConfig({ discover: null, agents: null, idleSecs: '0' }).idleSecs).toBe(0);
+  });
+});

--- a/src/agents/discovery.ts
+++ b/src/agents/discovery.ts
@@ -1,0 +1,295 @@
+// Hook-less agent discovery (Phase 3). Fleet has no hook integration for agents
+// like aider, cursor, opencode or gemini-cli, so they never write a `.status`
+// file and are invisible to the registry. This module surfaces them the
+// harness-agnostic way agent-radar proves out: scan the process table for
+// allowlisted command names, map each back to its host tmux pane by walking the
+// ppid chain, and classify "working" from the animated braille spinner glyph the
+// harness paints on-screen. The result is a synthetic agent per pane, folded into
+// fleet's state engine at the ONE place a pane currently falls to SHELL — the
+// no-winning-hook branch in refreshStates. Because discovery only fills that
+// branch, dedup is automatic: a hooked agent's `.status` always wins its pane and
+// discovery never shadows it.
+//
+// The file is split into a pure core (parse ps + walk ppid chains + classify the
+// glyph → discovered agents) that takes fixture strings, and a thin I/O shell
+// (spawn ps, call tmux, read config) the app wires up. All logic lives in the
+// pure core so it is unit-testable without a live process table or tmux server.
+
+import { WORKING_GLYPH_PATTERN } from '../state/detection.ts';
+
+export interface DiscoveredAgent {
+  paneId: string;
+  agentType: string;
+  working: boolean;
+}
+
+export interface DiscoveryOpts {
+  allowlist: Set<string>; // command names counted as agents (normalized)
+  idleSecs: number; // grace before working->stopped (debounce), default 3
+  now: number; // epoch seconds
+  lastWorking: Map<string, number>; // paneId -> last ts a glyph was seen (carried across ticks)
+}
+
+// Compiled once. WORKING_GLYPH_PATTERN is Phase 1's braille range (U+2800–U+28FF)
+// — reused verbatim so discovery and the claude manifest rule can never drift.
+const GLYPH = new RegExp(WORKING_GLYPH_PATTERN);
+
+// Strip the login-shell dash and any directory path before allowlist matching:
+// a login shell reports `-zsh`; a pathful comm reports `/usr/bin/aider` (macOS
+// `ps -o comm` gives the executable's full path). Mirrors agent-radar's
+// `agent_for_tty` normalization so `aider`, `-zsh`, `/usr/bin/aider` all reduce
+// to their bare command name.
+export function normalizeComm(comm: string): string {
+  let c = comm.trim();
+  if (c.startsWith('-')) c = c.slice(1); // login-shell marker
+  const slash = c.lastIndexOf('/');
+  if (slash >= 0) c = c.slice(slash + 1); // basename
+  return c;
+}
+
+// Parse `ps -eo pid=,ppid=,comm=` lines into pid->comm and pid->ppid maps. The
+// `=` suffixes suppress headers, so every non-blank line is a record: leading
+// pad, right-aligned pid, ppid, then comm (which may itself contain spaces or a
+// path, so it is the whole remainder of the line). comm is normalized at parse
+// time so callers compare against bare command names.
+export function parsePsTable(psTable: string[]): {
+  commByPid: Map<number, string>;
+  ppidByPid: Map<number, number>;
+} {
+  const commByPid = new Map<number, string>();
+  const ppidByPid = new Map<number, number>();
+  for (const line of psTable) {
+    const m = line.match(/^\s*(\d+)\s+(\d+)\s+(.+)$/);
+    if (!m) continue;
+    const pid = parseInt(m[1]!, 10);
+    const ppid = parseInt(m[2]!, 10);
+    if (Number.isNaN(pid) || Number.isNaN(ppid)) continue;
+    commByPid.set(pid, normalizeComm(m[3]!));
+    ppidByPid.set(pid, ppid);
+  }
+  return { commByPid, ppidByPid };
+}
+
+// Walk a pid up its parent chain until a pid is a known pane_pid, returning that
+// pane's id (or null if the chain reaches init/root without ever hitting a pane).
+// Pure, in-memory version of ports.ts:findPaneForPid — no per-hop `ps` spawn
+// because the whole table is already parsed. Visited-guarded against cycles
+// exactly like ports.ts:56-57.
+export function walkToPane(
+  startPid: number,
+  ppidByPid: Map<number, number>,
+  panePids: Map<number, string>,
+): string | null {
+  let checkPid = startPid;
+  const visited = new Set<number>();
+  while (checkPid > 1 && !visited.has(checkPid)) {
+    visited.add(checkPid);
+    const paneId = panePids.get(checkPid);
+    if (paneId) return paneId;
+    const ppid = ppidByPid.get(checkPid);
+    if (ppid === undefined || ppid <= 1) break;
+    checkPid = ppid;
+  }
+  return null;
+}
+
+// The pure core. Given the process table, the pane_pid->paneId map, and per-pane
+// captures (bottom-of-pane text), return the discovered agent per pane with a
+// debounced working state, plus the pruned lastWorking map to carry to the next
+// tick.
+//
+// 1. Parse ps -> commByPid, ppidByPid.
+// 2. For each allowlisted pid, walk its ppid chain to a pane; first match per
+//    pane wins (agentType = its normalized comm).
+// 3. For each discovered pane, classify the glyph and debounce:
+//    - glyph present -> working, and re-anchor lastWorking[pane] = now.
+//    - glyph absent  -> working iff now - lastWorking[pane] < idleSecs (grace),
+//      carrying the OLD lastWorking timestamp forward so the grace window stays
+//      anchored to the last glyph actually seen (never refreshed while idle, or a
+//      pane sampled faster than idleSecs would never expire).
+// 4. Return agents + lastWorking pruned to currently-discovered panes.
+export function discoverAgents(
+  psTable: string[],
+  panePids: Map<number, string>,
+  captures: Map<string, string>,
+  opts: DiscoveryOpts,
+): { agents: DiscoveredAgent[]; lastWorking: Map<string, number> } {
+  const agents: DiscoveredAgent[] = [];
+  const nextLastWorking = new Map<string, number>();
+
+  if (opts.allowlist.size === 0 || panePids.size === 0) {
+    return { agents, lastWorking: nextLastWorking };
+  }
+
+  const { commByPid, ppidByPid } = parsePsTable(psTable);
+
+  // paneId -> agentType, first allowlisted match per pane wins.
+  const agentByPane = new Map<string, string>();
+  for (const [pid, comm] of commByPid) {
+    if (!opts.allowlist.has(comm)) continue;
+    const paneId = walkToPane(pid, ppidByPid, panePids);
+    if (paneId === null) continue;
+    if (!agentByPane.has(paneId)) agentByPane.set(paneId, comm);
+  }
+
+  for (const [paneId, agentType] of agentByPane) {
+    const glyph = GLYPH.test(captures.get(paneId) ?? '');
+    if (glyph) {
+      nextLastWorking.set(paneId, opts.now);
+      agents.push({ paneId, agentType, working: true });
+    } else {
+      const last = opts.lastWorking.get(paneId);
+      if (last !== undefined) nextLastWorking.set(paneId, last); // keep grace anchored to last glyph
+      const working = last !== undefined && opts.now - last < opts.idleSecs;
+      agents.push({ paneId, agentType, working });
+    }
+  }
+
+  return { agents, lastWorking: nextLastWorking };
+}
+
+// ---- config (pure parse + I/O read) ----
+
+export interface DiscoveryConfig {
+  enabled: boolean;
+  allowlist: Set<string>;
+  idleSecs: number;
+}
+
+// Conservative built-in allowlist. claude/codex/pi are harmless here — a hooked
+// instance already won its pane in the hook branch, so discovery only ever labels
+// a hook-LESS instance of them. User-overridable via @fleet_discover_agents.
+export const DEFAULT_ALLOWLIST: readonly string[] = [
+  'claude',
+  'codex',
+  'pi',
+  'aider',
+  'cursor',
+  'opencode',
+  'gemini',
+  'amp',
+  'droid',
+];
+export const DEFAULT_IDLE_SECS = 3;
+
+// Bottom-of-pane window the glyph check runs over — matches the manifest's
+// default rule window (detection.ts DEFAULT_LINES_FROM_BOTTOM) so a spinner high
+// in scrollback can't read as working.
+const DISCOVERY_LINES = 15;
+
+// Pure: turn the three raw tmux option strings (null = unset) into a config.
+// @fleet_discover: `off` disables discovery entirely (default on).
+// @fleet_discover_agents: comma-separated allowlist override.
+// @fleet_discover_idle_secs: debounce grace in seconds.
+export function parseDiscoveryConfig(raw: {
+  discover: string | null;
+  agents: string | null;
+  idleSecs: string | null;
+}): DiscoveryConfig {
+  const enabled = raw.discover?.trim() !== 'off';
+
+  const allowlist = raw.agents
+    ? new Set(
+        raw.agents
+          .split(',')
+          .map((s) => normalizeComm(s))
+          .filter((s) => s.length > 0),
+      )
+    : new Set<string>(DEFAULT_ALLOWLIST);
+
+  const parsed = raw.idleSecs ? parseInt(raw.idleSecs, 10) : NaN;
+  const idleSecs = Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_IDLE_SECS;
+
+  return { enabled, allowlist, idleSecs };
+}
+
+// ---- I/O shell: spawn ps, call tmux, read config, delegate to the pure core ----
+
+function showOption(name: string): string | null {
+  try {
+    const p = Bun.spawnSync({ cmd: ['tmux', 'show', '-gqv', name], stdout: 'pipe', stderr: 'pipe' });
+    if (p.exitCode !== 0) return null;
+    const v = p.stdout.toString().trim();
+    return v.length > 0 ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+export function readDiscoveryConfig(): DiscoveryConfig {
+  return parseDiscoveryConfig({
+    discover: showOption('@fleet_discover'),
+    agents: showOption('@fleet_discover_agents'),
+    idleSecs: showOption('@fleet_discover_idle_secs'),
+  });
+}
+
+// Build the pane_pid -> paneId map from one `tmux list-panes` call (pattern:
+// ports.ts:8-22). Empty on any tmux failure.
+function readPanePids(): Map<number, string> {
+  const panePids = new Map<number, string>();
+  try {
+    const p = Bun.spawnSync({
+      cmd: ['tmux', 'list-panes', '-a', '-F', '#{pane_id}:#{pane_pid}'],
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    if (p.exitCode !== 0) return panePids;
+    for (const line of p.stdout.toString().split('\n')) {
+      if (line.length === 0) continue;
+      const [paneId, pidStr] = line.split(':');
+      if (paneId && pidStr) {
+        const pid = parseInt(pidStr, 10);
+        if (!Number.isNaN(pid)) panePids.set(pid, paneId);
+      }
+    }
+  } catch {
+    return panePids;
+  }
+  return panePids;
+}
+
+// One `ps` pass over the whole process table. Empty on any failure (exotic
+// platform / different flags) so discovery degrades to no-op and fleet behaves as
+// pre-Phase-3 (the pane stays SHELL).
+function readPsTable(): string[] {
+  try {
+    const p = Bun.spawnSync({ cmd: ['ps', '-eo', 'pid=,ppid=,comm='], stdout: 'pipe', stderr: 'pipe' });
+    if (p.exitCode !== 0) return [];
+    return p.stdout.toString().split('\n');
+  } catch {
+    return [];
+  }
+}
+
+// Thin I/O wrapper the slow loop calls. `captures` are the per-pane lines already
+// taken for the scrape cache this tick (paneId -> captured lines), threaded in so
+// discovery adds ZERO extra capture-pane calls — only one `ps` and one
+// `list-panes`. `lastWorking` is carried across ticks by the caller. Returns the
+// discovered agents plus the pruned lastWorking to persist for the next tick.
+export function scanDiscovered(
+  captures: Map<string, string[]>,
+  lastWorking: Map<string, number>,
+  now: number,
+  config?: DiscoveryConfig,
+): { agents: DiscoveredAgent[]; lastWorking: Map<string, number> } {
+  const cfg = config ?? readDiscoveryConfig();
+  if (!cfg.enabled) return { agents: [], lastWorking: new Map() };
+
+  const panePids = readPanePids();
+  const psTable = readPsTable();
+
+  // Reduce each pane's captured lines to the bottom-of-pane window as one string
+  // for the glyph check.
+  const captureStrings = new Map<string, string>();
+  for (const [paneId, lines] of captures) {
+    captureStrings.set(paneId, lines.slice(-DISCOVERY_LINES).join('\n'));
+  }
+
+  return discoverAgents(psTable, panePids, captureStrings, {
+    allowlist: cfg.allowlist,
+    idleSecs: cfg.idleSecs,
+    now,
+    lastWorking,
+  });
+}

--- a/src/notify/deliver.ts
+++ b/src/notify/deliver.ts
@@ -1,0 +1,37 @@
+// Silent, best-effort desktop toast. Never sounds, never throws, and no-ops when
+// unsupported — a notifier must never crash the render loop (fleet's
+// never-crash-the-host principle). See the no-audible-cue constraint: no
+// `sound name` (macOS) / no `-u critical` (Linux), so these stay silent.
+
+// AppleScript-escape a string into a double-quoted literal. osascript is spawned
+// via argv (no shell), so only AppleScript-level escaping is needed: backslash and
+// quote are escaped; control chars are neutralized (a raw newline is a syntax
+// error inside a "..." literal). Session/window names can contain quotes.
+function q(s: string): string {
+  const escaped = s
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    // oxlint-disable-next-line no-control-regex
+    .replace(/[\x00-\x1f]/g, ' ');
+  return `"${escaped}"`;
+}
+
+// macOS: osascript display notification WITHOUT `sound name` => silent.
+// Linux: notify-send only when a desktop session is present.
+export function deliverDesktop(title: string, body: string): void {
+  try {
+    if (process.platform === 'darwin') {
+      const script = `display notification ${q(body)} with title ${q(title)}`; // no sound
+      Bun.spawn(['osascript', '-e', script], { stdout: 'ignore', stderr: 'ignore' });
+      return;
+    }
+    if (process.platform === 'linux') {
+      if (!process.env.DISPLAY && !process.env.WAYLAND_DISPLAY) return; // headless/SSH => no-op
+      Bun.spawn(['notify-send', '-u', 'normal', title, body], { stdout: 'ignore', stderr: 'ignore' });
+      return;
+    }
+    // other platforms: no-op
+  } catch {
+    /* missing binary / spawn failure: silently ignore */
+  }
+}

--- a/src/notify/notify.test.ts
+++ b/src/notify/notify.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from 'bun:test';
+import { applySuppression, decideNotifications, type Notification } from './transitions.ts';
+import { AgentStatus, type AgentState } from '../state/types.ts';
+
+// Minimal AgentState fixture — only paneId, status, agentType, session drive the
+// detection logic; the rest are filler the pure function ignores.
+function st(paneId: string, status: AgentStatus, session = 'sess', agentType = 'claude'): AgentState {
+  return {
+    paneId,
+    paneNum: Number(paneId.replace('%', '')) || 0,
+    session,
+    window: '',
+    windowId: '@0',
+    claudeName: null,
+    customName: null,
+    status,
+    tool: null,
+    project: null,
+    branch: null,
+    ports: [],
+    ts: 0,
+    agentType,
+  };
+}
+
+// Minimal Notification fixture for suppression tests.
+function notif(paneId: string): Notification {
+  return { paneId, agentType: 'claude', label: 'sess', status: AgentStatus.DONE };
+}
+
+describe('decideNotifications — detection', () => {
+  test('first sight IDLE (no BUSY predecessor) → zero candidates, map advanced', () => {
+    const { candidates, previous } = decideNotifications([st('%1', AgentStatus.IDLE)], new Map());
+    expect(candidates).toHaveLength(0);
+    expect(previous.get('%1')).toBe(AgentStatus.IDLE);
+  });
+
+  test('first sight DONE (no BUSY predecessor) → zero candidates', () => {
+    const { candidates } = decideNotifications([st('%1', AgentStatus.DONE)], new Map());
+    expect(candidates).toHaveLength(0);
+  });
+
+  test('BUSY → DONE → one candidate carrying pane/status/label/agentType', () => {
+    const arm = decideNotifications([st('%1', AgentStatus.BUSY)], new Map());
+    expect(arm.candidates).toHaveLength(0);
+
+    const { candidates } = decideNotifications([st('%1', AgentStatus.DONE, 'authkit')], arm.previous);
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]).toEqual({
+      paneId: '%1',
+      agentType: 'claude',
+      label: 'authkit',
+      status: AgentStatus.DONE,
+    });
+  });
+
+  test('BUSY → IDLE → one candidate (IDLE is a stop state for hook-less discovery)', () => {
+    const arm = decideNotifications([st('%1', AgentStatus.BUSY)], new Map());
+    const { candidates } = decideNotifications([st('%1', AgentStatus.IDLE)], arm.previous);
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]!.status).toBe(AgentStatus.IDLE);
+  });
+
+  test('BUSY → PERMIT and BUSY → QUESTION both fire', () => {
+    const armP = decideNotifications([st('%1', AgentStatus.BUSY)], new Map());
+    expect(decideNotifications([st('%1', AgentStatus.PERMIT)], armP.previous).candidates).toHaveLength(1);
+
+    const armQ = decideNotifications([st('%2', AgentStatus.BUSY)], new Map());
+    expect(decideNotifications([st('%2', AgentStatus.QUESTION)], armQ.previous).candidates).toHaveLength(1);
+  });
+
+  test('BUSY → SHELL / BUSY → DOWN do NOT fire (not stop states)', () => {
+    const armS = decideNotifications([st('%1', AgentStatus.BUSY)], new Map());
+    expect(decideNotifications([st('%1', AgentStatus.SHELL)], armS.previous).candidates).toHaveLength(0);
+
+    const armD = decideNotifications([st('%2', AgentStatus.BUSY)], new Map());
+    expect(decideNotifications([st('%2', AgentStatus.DOWN)], armD.previous).candidates).toHaveLength(0);
+  });
+
+  test('staying DONE does not re-fire; DONE → BUSY → DONE re-arms and fires on the second stop', () => {
+    // tick 1: DONE with no BUSY predecessor → no candidate
+    const t1 = decideNotifications([st('%1', AgentStatus.DONE)], new Map());
+    expect(t1.candidates).toHaveLength(0);
+    // tick 2: still DONE → no re-fire (previous is DONE, not BUSY)
+    const t2 = decideNotifications([st('%1', AgentStatus.DONE)], t1.previous);
+    expect(t2.candidates).toHaveLength(0);
+    // tick 3: back to BUSY → no candidate (BUSY is not a stop state), arms
+    const t3 = decideNotifications([st('%1', AgentStatus.BUSY)], t2.previous);
+    expect(t3.candidates).toHaveLength(0);
+    // tick 4: DONE again → fires (re-armed)
+    const t4 = decideNotifications([st('%1', AgentStatus.DONE)], t3.previous);
+    expect(t4.candidates).toHaveLength(1);
+  });
+
+  test('two panes transitioning in one tick → two candidates', () => {
+    const arm = decideNotifications([st('%1', AgentStatus.BUSY), st('%2', AgentStatus.BUSY)], new Map());
+    const { candidates } = decideNotifications(
+      [st('%1', AgentStatus.DONE), st('%2', AgentStatus.PERMIT)],
+      arm.previous,
+    );
+    expect(candidates.map((c) => c.paneId).sort()).toEqual(['%1', '%2']);
+  });
+
+  test('a pane that vanishes between ticks is dropped from previous and yields no candidate', () => {
+    const arm = decideNotifications([st('%1', AgentStatus.BUSY), st('%2', AgentStatus.BUSY)], new Map());
+    const { candidates, previous } = decideNotifications([st('%1', AgentStatus.DONE)], arm.previous);
+    expect(candidates.map((c) => c.paneId)).toEqual(['%1']);
+    expect(previous.has('%2')).toBe(false); // vanished pane drops out, no stale growth
+    expect(previous.has('%1')).toBe(true);
+  });
+});
+
+describe('applySuppression', () => {
+  const candidates = [notif('%1'), notif('%2')];
+
+  test('activePaneId === a candidate pane → that one dropped, others kept', () => {
+    expect(applySuppression(candidates, '%1', null)).toEqual([notif('%2')]);
+  });
+
+  test('activePaneId === fleetPaneId → all dropped (watching the dashboard)', () => {
+    expect(applySuppression(candidates, '%9', '%9')).toEqual([]);
+  });
+
+  test('watching fleet drops toasts even for a pane that is also a candidate', () => {
+    // Focus is fleet's pane, which happens to equal a candidate pane id.
+    expect(applySuppression(candidates, '%1', '%1')).toEqual([]);
+  });
+
+  test('activePaneId === null → nothing dropped (suppression disabled)', () => {
+    expect(applySuppression(candidates, null, null)).toEqual(candidates);
+  });
+
+  test('null active pane disables suppression even when fleetPaneId is set', () => {
+    expect(applySuppression(candidates, null, '%9')).toEqual(candidates);
+  });
+
+  test('active pane not among candidates → all kept', () => {
+    expect(applySuppression(candidates, '%7', '%9')).toEqual(candidates);
+  });
+});

--- a/src/notify/transitions.ts
+++ b/src/notify/transitions.ts
@@ -1,0 +1,52 @@
+import { AgentStatus, type AgentState, sessionLabel } from '../state/types.ts';
+
+// Stopped states that warrant attention. IDLE is included so hook-less discovered
+// agents (Phase 3: BUSY-glyph -> IDLE-no-glyph) notify; hooked agents normally land
+// on DONE/PERMIT/QUESTION. NB: relies on states being debounced upstream — Phase 3
+// must not flip discovered agents BUSY<->IDLE on single-frame flicker.
+const STOP_STATES: ReadonlySet<AgentStatus> = new Set([
+  AgentStatus.DONE,
+  AgentStatus.PERMIT,
+  AgentStatus.QUESTION,
+  AgentStatus.IDLE,
+]);
+
+export interface Notification {
+  paneId: string;
+  agentType: string;
+  label: string;
+  status: AgentStatus;
+}
+
+// Detection: pure work->stop transitions this tick, no suppression applied. The
+// returned `previous` is rebuilt from the current states, so a pane that vanished
+// drops out naturally (no stale entries, no unbounded growth). A transition only
+// fires when the pane's prior status was BUSY — a pane first observed already
+// stopped has no BUSY predecessor and never false-fires (the arming condition).
+export function decideNotifications(
+  states: AgentState[],
+  previous: Map<string, AgentStatus>,
+): { candidates: Notification[]; previous: Map<string, AgentStatus> } {
+  const next = new Map<string, AgentStatus>();
+  const candidates: Notification[] = [];
+  for (const s of states) {
+    next.set(s.paneId, s.status);
+    if (previous.get(s.paneId) === AgentStatus.BUSY && STOP_STATES.has(s.status)) {
+      candidates.push({ paneId: s.paneId, agentType: s.agentType, label: sessionLabel(s), status: s.status });
+    }
+  }
+  return { candidates, previous: next };
+}
+
+// Suppression: silent entirely while you're viewing fleet's own pane (you can see
+// the change on the dashboard); otherwise drop the one pane you're viewing.
+// activePaneId === null disables suppression (used when the active pane can't be
+// resolved — better a redundant toast than a missed one).
+export function applySuppression(
+  candidates: Notification[],
+  activePaneId: string | null,
+  fleetPaneId: string | null,
+): Notification[] {
+  if (activePaneId != null && activePaneId === fleetPaneId) return []; // watching the dashboard
+  return candidates.filter((c) => c.paneId !== activePaneId);
+}

--- a/src/state/detection.test.ts
+++ b/src/state/detection.test.ts
@@ -90,6 +90,112 @@ describe('CLAUDE_MANIFEST reproduces the pre-Phase-2 scraper', () => {
   }
 });
 
+// 1b. Phase 1 — braille working-glyph BUSY rule (busy.spinner-glyph). The animated
+//     braille glyph (U+2800–U+28FF) is a positive "working" signal no English string
+//     can spoof; a pane that merely QUOTES `esc to interrupt` (no live glyph) must not
+//     read BUSY via THIS rule. Range boundaries are asserted inclusive.
+describe('busy.spinner-glyph: braille working glyph → BUSY', () => {
+  const cases: Array<{ name: string; lines: string[]; status: AgentStatus | null; ruleId: string | null }> = [
+    {
+      name: 'braille glyph alone → BUSY via the glyph rule',
+      lines: ['⠹ Puzzling…', '', '❯'],
+      status: AgentStatus.BUSY,
+      ruleId: 'busy.spinner-glyph',
+    },
+    {
+      name: 'a different braille frame also matches',
+      lines: ['⠏ Herding…', '', '❯'],
+      status: AgentStatus.BUSY,
+      ruleId: 'busy.spinner-glyph',
+    },
+    // Inclusive range boundaries U+2800..U+28FF.
+    {
+      name: 'lower boundary U+2800 matches',
+      lines: ['⠀ working', '❯'],
+      status: AgentStatus.BUSY,
+      ruleId: 'busy.spinner-glyph',
+    },
+    {
+      name: 'upper boundary U+28FF matches',
+      lines: ['⣿ working', '❯'],
+      status: AgentStatus.BUSY,
+      ruleId: 'busy.spinner-glyph',
+    },
+    // Just outside the range must NOT read BUSY via the glyph (→ idle via marker).
+    {
+      name: 'just below range (U+27FF) is not a glyph',
+      lines: ['⟿ Thinking…', '❯'],
+      status: AgentStatus.IDLE,
+      ruleId: 'idle.prompt',
+    },
+    {
+      name: 'just above range (U+2900) is not a glyph',
+      lines: ['⤀ Thinking…', '❯'],
+      status: AgentStatus.IDLE,
+      ruleId: 'idle.prompt',
+    },
+    // Dingbat "star" spinners (U+2736 etc.) are NOT braille → no false BUSY here.
+    {
+      name: 'dingbat star spinner is not caught by the braille rule',
+      lines: ['✶ Thinking…', '', '❯'],
+      status: AgentStatus.IDLE,
+      ruleId: 'idle.prompt',
+    },
+    // Quoted `esc to interrupt` with NO glyph still resolves via busy.esc-interrupt,
+    // NOT via the glyph rule — guards the braille range against matching ASCII.
+    {
+      name: 'quoted esc-to-interrupt (no glyph) wins via the esc rule, not the glyph rule',
+      lines: ['(esc to interrupt)', '❯'],
+      status: AgentStatus.BUSY,
+      ruleId: 'busy.esc-interrupt',
+    },
+    // Pure ASCII punctuation (stars, brackets, mid-dot, em dash) → no BUSY via glyph.
+    {
+      name: 'ascii punctuation only → not BUSY via the glyph rule',
+      lines: ['done * [ok] a·b — no braille', '❯'],
+      status: AgentStatus.IDLE,
+      ruleId: 'idle.prompt',
+    },
+  ];
+  for (const c of cases) {
+    test(c.name, () => {
+      const r = detectFromPaneContent(c.lines, CLAUDE_MANIFEST);
+      expect(r.status).toBe(c.status);
+      expect(r.ruleId).toBe(c.ruleId);
+    });
+  }
+});
+
+// 1c. Ordering guard: busy.spinner-glyph is appended LAST, so any earlier rule wins
+//     even when a braille glyph is co-present on the same window (first-match-wins).
+describe('busy.spinner-glyph is last: earlier rules win when a glyph is also present', () => {
+  const cases: Array<{ name: string; lines: string[]; status: AgentStatus; ruleId: string }> = [
+    {
+      name: 'PERMIT [y/n] beats a co-present glyph',
+      lines: ['Allow Edit? [y/n]', '⠹ working', '❯'],
+      status: AgentStatus.PERMIT,
+      ruleId: 'permit.yn',
+    },
+    {
+      name: 'QUESTION selector beats a co-present glyph',
+      lines: ['Enter to select · ↑/↓ to navigate · Esc to cancel', '⠹', '❯'],
+      status: AgentStatus.QUESTION,
+      ruleId: 'question.enter-select',
+    },
+    {
+      name: 'token-counter beats the glyph (ruleId stays specific for `fleet explain`)',
+      lines: ['⠹ Trapping Gollum… (8s · ↑ 240 tokens)', '', '❯'],
+      status: AgentStatus.BUSY,
+      ruleId: 'busy.token-counter-sec',
+    },
+  ];
+  for (const c of cases) {
+    test(c.name, () => {
+      expect(detectFromPaneContent(c.lines, CLAUDE_MANIFEST)).toEqual({ status: c.status, ruleId: c.ruleId });
+    });
+  }
+});
+
 // 2. Ordered precedence — proves "first match wins", not "most specific wins".
 test('ordered rules: the first matching rule wins on text that matches several', () => {
   const both = ['Do you want to proceed? (8s · ↑ 240 tokens)'];

--- a/src/state/detection.ts
+++ b/src/state/detection.ts
@@ -87,6 +87,15 @@ function validateManifest(raw: unknown, agent: string): DetectionManifest {
   };
 }
 
+// Braille block U+2800–U+28FF: the animated progress glyph a harness paints only
+// while it is actively working, so it cannot be spoofed by transcript text and does
+// not depend on any English string. Exported so Phase 3's standalone discovery check
+// reuses this exact range rather than duplicating it.
+// Calibration source: the agent-radar reference poller matches this same range
+// byte-wise (E2 A0-A3 xx = U+2800–U+28FF) for the claude/codex/pi working glyph
+// (agent-radar scripts/agent-radar-poller, docs/adr/detection-mechanism.md).
+export const WORKING_GLYPH_PATTERN = '[\\u2800-\\u28FF]';
+
 // --- the embedded built-in `claude` manifest (byte-for-byte reproduction) ---
 // Each rule id, pattern, flag, and state is a direct translation of the literal
 // regexes the scraper used before Phase 2, in the same statement order. First
@@ -104,6 +113,10 @@ export const CLAUDE_MANIFEST: DetectionManifest = {
     { id: 'busy.token-counter-min', pattern: '\\(\\d+m\\s+\\d+s\\s+·.*tokens?\\)', state: 'BUSY' },
     { id: 'busy.token-counter-sec', pattern: '\\(\\d+s\\s+·.*tokens?\\)', state: 'BUSY' },
     { id: 'busy.esc-interrupt', pattern: 'esc to interrupt', flags: 'i', state: 'BUSY' },
+    // Last within the BUSY group so PERMIT/QUESTION rules and the richer
+    // token-counter / esc-interrupt rules still win first (first-match-wins): a
+    // pane showing both a spinner and a [y/n] prompt must still read PERMIT.
+    { id: 'busy.spinner-glyph', pattern: WORKING_GLYPH_PATTERN, state: 'BUSY' },
   ],
 };
 

--- a/src/state/scraper.ts
+++ b/src/state/scraper.ts
@@ -47,17 +47,25 @@ export function detectFromPaneContent(lines: string[], manifest: DetectionManife
   return { status: null, ruleId: null };
 }
 
-export function scrapePane(paneId: string, agent: string): AgentStatus | null {
+// Capture a pane ONCE and return both its classified status and the raw captured
+// lines. A caller that also needs the capture (hook-less discovery's spinner-glyph
+// check) reuses these lines instead of capturing the same pane a second time.
+// scrapePane is exactly this minus the lines.
+export function scrapePaneCapture(paneId: string, agent: string): { status: AgentStatus | null; lines: string[] } {
   let lines: string[];
   try {
     lines = capturePane(paneId, SCRAPE_LINES);
   } catch {
-    return null;
+    return { status: null, lines: [] };
   }
   // Phase 3: the agent is real (was hardcoded 'claude'). Resolve its manifest
   // (built-in, or a user override) so each agent's prompts classify against its
   // own rules; an unknown agent degrades to an empty manifest (detects nothing).
-  return detectFromPaneContent(lines, loadDetectionManifest(agent)).status;
+  return { status: detectFromPaneContent(lines, loadDetectionManifest(agent)).status, lines };
+}
+
+export function scrapePane(paneId: string, agent: string): AgentStatus | null {
+  return scrapePaneCapture(paneId, agent).status;
 }
 
 export interface ScrapeDetail {


### PR DESCRIPTION
## What

Three harness-agnostic **awareness** improvements, drawn from a comparison against the sibling `agent-radar` project and adapted to fleet's data-driven, tmux-native, zero-dependency design.

### 1. Spinner-glyph BUSY detection (`f117bc7`)

Reads the animated braille spinner (U+2800–U+28FF) as a working signal in the `claude` detection manifest, appended **last** in the BUSY group so first-match-wins ordering is preserved (PERMIT/QUESTION and the richer token-counter rules still win first). Unlike the English strings (`esc to interrupt`, the token counter), the glyph can't be spoofed by a transcript that quotes them and still reads as working after the token line scrolls off. Exported as `WORKING_GLYPH_PATTERN` so discovery reuses the exact range.

### 2. Silent desktop notifications + bell gate (`e6a86a0`)

TUI-fired, **silent** OS-native toasts (`osascript` / `notify-send`) on every work→stop transition, so an agent finishing reaches you outside tmux. Two pure functions (`decideNotifications` / `applySuppression`): fire exactly once per transition, re-arm on the next BUSY, suppress the focused pane, and stay fully silent while you're watching the fleet dashboard itself. Delivery is guarded to no-op with no desktop session (headless/SSH) and never throws — a notifier must never crash the render loop.

**Behavior change:** the terminal bell is now **off by default**, gated behind the `@fleet_bell` tmux option — it became noise at ~15 agents. The in-tmux status-line flash is unchanged.

### 3. Hook-less agent discovery (`75ba484`)

A 5s-loop `ps -eo pid=,ppid=,comm=` scan maps allowlisted agent commands (aider, cursor, opencode, gemini, amp, droid, …) to their tmux pane via an in-memory ppid walk, classifying working/idle from the same spinner glyph. It fills `refreshStates`' no-hook branch, so a hooked agent's `.status` always wins its pane (structural dedup) — you keep full 7-state depth where a hook exists, and gain working/idle visibility where none does. Surfaces agents fleet has zero integration for, with no install.

Config: `@fleet_discover` (default on), `@fleet_discover_agents` (allowlist override), `@fleet_discover_idle_secs` (debounce grace, default 3).

## Testing

- `bun test` — **457 pass / 0 fail** (adds unit suites for the glyph rule, notification transitions, and discovery parse/map/classify)
- `bun run typecheck` && `bun run lint` — clean
- **Zero runtime dependencies** added

Pure cores are fully unit-tested; the I/O edges (osascript/notify-send spawn, live `ps`/tmux scan) are verified by manual observation.

## Notes

- Commits are **unsigned** — created non-interactively (1Password SSH can't sign headless).
- Built via the ideation workflow; the contract + specs live under `docs/ideation/harness-agnostic-awareness/` and are intentionally kept local (not in this PR).

https://claude.ai/code/session_014wzpzGTEApWe7nqXoscMV5
