### PR TITLE
feat: advertise fleet via OSC 2 pane title for title-aware window naming

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,7 @@
 import packageJson from './package.json' with { type: 'json' };
 import { TuiApp, TuiMode } from './src/tui/app.ts';
 import { render } from './src/tui/render.ts';
-import { renderFooter, renderHeader, stateAtLine } from './src/tui/dashboard.ts';
+import { paneTitle, renderFooter, renderHeader, stateAtLine } from './src/tui/dashboard.ts';
 import { canSendTo } from './src/tui/send.ts';
 import { canKillSession } from './src/tui/kill.ts';
 import { parseKeyEvent } from './src/terminal/input.ts';
@@ -12,6 +12,7 @@ import {
   enterRawMode,
   enableMouse,
   restore,
+  setPaneTitle,
   getTerminalSize,
 } from './src/terminal/terminal.ts';
 import { setThemeMode, C } from './src/terminal/colors.ts';
@@ -692,6 +693,9 @@ async function launchTui(): Promise<number> {
   const draw = () => {
     const size = getTerminalSize();
     process.stdout.write(render(app, size));
+    // Advertise status in the pane title (deduped inside setPaneTitle);
+    // restore() clears it on exit so automatic-rename falls back cleanly.
+    setPaneTitle(paneTitle(app.summary(), app.shellCount()));
   };
 
   // The pane fleet itself runs in — used to suppress every toast while you're

--- a/src/terminal/ansi.test.ts
+++ b/src/terminal/ansi.test.ts
@@ -1,5 +1,19 @@
 import { describe, expect, test } from 'bun:test';
-import { padAnsi, stripAnsi, truncateAnsi, truncateWidth, visibleLength } from './ansi.ts';
+import { oscTitle, padAnsi, stripAnsi, truncateAnsi, truncateWidth, visibleLength } from './ansi.ts';
+
+describe('oscTitle', () => {
+  test('wraps title in an OSC 2 sequence', () => {
+    expect(oscTitle('fleet — 2 working')).toBe('\x1b]2;fleet — 2 working\x07');
+  });
+
+  test('strips control characters that would break the sequence', () => {
+    expect(oscTitle('a\x1bb\x07c\nd')).toBe('\x1b]2;abcd\x07');
+  });
+
+  test('empty title clears the pane title', () => {
+    expect(oscTitle('')).toBe('\x1b]2;\x07');
+  });
+});
 
 describe('stripAnsi', () => {
   test('removes SGR sequences', () => {

--- a/src/terminal/ansi.ts
+++ b/src/terminal/ansi.ts
@@ -5,6 +5,16 @@ export function stripAnsi(value: string): string {
   return value.replace(ANSI_PATTERN, '');
 }
 
+/**
+ * OSC 2 "set title" sequence. Inside tmux this sets `#{pane_title}` for the
+ * pane; outside tmux it sets the terminal window title. Control characters
+ * are stripped so a hostile payload can't terminate the sequence early.
+ */
+export function oscTitle(title: string): string {
+  // oxlint-disable-next-line no-control-regex
+  return `\x1b]2;${title.replace(/[\x00-\x1f\x7f]/g, '')}\x07`;
+}
+
 function charWidth(codePoint: number): number {
   if (codePoint < 0x20 || codePoint === 0x7f) return 0;
   // Zero-width joiners, variation selectors.

--- a/src/terminal/terminal.test.ts
+++ b/src/terminal/terminal.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { clearPaneTitle, restore, setPaneTitle } from './terminal.ts';
+
+// Capture stdout writes without leaking escape sequences into test output.
+function captureWrites(fn: () => void): string[] {
+  const writes: string[] = [];
+  const original = process.stdout.write.bind(process.stdout);
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    writes.push(String(chunk));
+    return true;
+  }) as typeof process.stdout.write;
+  try {
+    fn();
+  } finally {
+    process.stdout.write = original;
+  }
+  return writes;
+}
+
+afterEach(() => {
+  captureWrites(() => clearPaneTitle());
+});
+
+describe('setPaneTitle', () => {
+  test('emits an OSC 2 sequence', () => {
+    const writes = captureWrites(() => setPaneTitle('fleet'));
+    expect(writes).toEqual(['\x1b]2;fleet\x07']);
+  });
+
+  test('skips the write when the title is unchanged', () => {
+    const writes = captureWrites(() => {
+      setPaneTitle('fleet');
+      setPaneTitle('fleet');
+    });
+    expect(writes).toEqual(['\x1b]2;fleet\x07']);
+  });
+
+  test('emits again when the title changes', () => {
+    const writes = captureWrites(() => {
+      setPaneTitle('fleet');
+      setPaneTitle('fleet — 1 working');
+    });
+    expect(writes).toEqual(['\x1b]2;fleet\x07', '\x1b]2;fleet — 1 working\x07']);
+  });
+});
+
+describe('clearPaneTitle', () => {
+  test('resets the title after one was set', () => {
+    const writes = captureWrites(() => {
+      setPaneTitle('fleet');
+      clearPaneTitle();
+    });
+    expect(writes).toEqual(['\x1b]2;fleet\x07', '\x1b]2;\x07']);
+  });
+
+  test('does nothing when no title was ever set', () => {
+    const writes = captureWrites(() => clearPaneTitle());
+    expect(writes).toEqual([]);
+  });
+});
+
+describe('restore', () => {
+  test('clears a set pane title', () => {
+    const writes = captureWrites(() => {
+      setPaneTitle('fleet');
+      restore();
+    });
+    expect(writes).toContain('\x1b]2;\x07');
+  });
+});

--- a/src/terminal/terminal.ts
+++ b/src/terminal/terminal.ts
@@ -1,3 +1,5 @@
+import { oscTitle } from './ansi.ts';
+
 export interface TerminalSize {
   rows: number;
   cols: number;
@@ -69,6 +71,22 @@ export function disableMouse(): void {
   }
 }
 
+let lastTitle: string | null = null;
+
+// Sets the pane title (OSC 2) — inside tmux this is #{pane_title}, which the
+// user's automatic-rename hook can prefer over command+cwd naming.
+export function setPaneTitle(title: string): void {
+  if (title === lastTitle) return;
+  lastTitle = title;
+  process.stdout.write(oscTitle(title));
+}
+
+export function clearPaneTitle(): void {
+  if (lastTitle === null) return;
+  lastTitle = null;
+  process.stdout.write(oscTitle(''));
+}
+
 export function moveCursor(row: number, col: number): string {
   return `\x1b[${row};${col}H`;
 }
@@ -85,6 +103,7 @@ export function getTerminalSize(): TerminalSize {
 }
 
 export function restore(): void {
+  clearPaneTitle();
   disableMouse();
   showCursor();
   leaveAlternateScreen();

--- a/src/tui/dashboard.test.ts
+++ b/src/tui/dashboard.test.ts
@@ -3,8 +3,8 @@ import { disableColors } from '../terminal/colors.ts';
 
 disableColors();
 
-import { computeColumnWidths, renderHeader, renderSessionList, stateAtLine } from './dashboard.ts';
-import { TuiApp } from './app.ts';
+import { computeColumnWidths, paneTitle, renderHeader, renderSessionList, stateAtLine } from './dashboard.ts';
+import { TuiApp, type Summary } from './app.ts';
 import { stripAnsi, visibleLength } from '../terminal/ansi.ts';
 import { AgentStatus, type AgentState } from '../state/types.ts';
 
@@ -266,5 +266,28 @@ describe('header summary strip', () => {
     const header = renderHeader(app, 120).join('');
     expect(header).not.toContain('need you');
     expect(header).toContain('1 idle');
+  });
+});
+
+describe('paneTitle', () => {
+  const summary = (extra: Partial<Summary> = {}): Summary => ({
+    total: 0,
+    permit: 0,
+    question: 0,
+    done: 0,
+    busy: 0,
+    ...extra,
+  });
+
+  test('identifies the app when the fleet is quiet', () => {
+    expect(paneTitle(summary(), 0)).toBe('fleet');
+  });
+
+  test('never starts with the Claude title marker', () => {
+    // extractClaudeName treats a leading ✳ as "this pane is a Claude agent";
+    // fleet's own title must never be mistaken for one.
+    const busy = paneTitle(summary({ total: 5, busy: 2, permit: 1, question: 1, done: 1 }), 0);
+    expect(busy.startsWith('✳')).toBe(false);
+    expect(busy.length).toBeGreaterThan(0);
   });
 });

--- a/src/tui/dashboard.ts
+++ b/src/tui/dashboard.ts
@@ -1,7 +1,7 @@
 import { C } from '../terminal/colors.ts';
 import { truncateAnsi } from '../terminal/ansi.ts';
 import { AgentStatus, type AgentState } from '../state/types.ts';
-import { TuiMode, type TuiApp } from './app.ts';
+import { TuiMode, type TuiApp, type Summary } from './app.ts';
 import { buildTableLines } from './layouts/table.ts';
 import { buildCardLines } from './layouts/cards.ts';
 import { pickLayout } from './layouts/index.ts';
@@ -30,6 +30,20 @@ function getQuip(): string {
 
 function logo(): string {
   return `${C.permit}f${C.question}l${C.done}e${C.busy}e${C.idle}t${C.reset}`;
+}
+
+// The pane title fleet advertises via OSC 2 — surfaced as the tmux window
+// name by title-aware automatic-rename setups. Plain text only (no ANSI
+// colors: tmux renders window names literally). Must never start with ✳,
+// which extractClaudeName treats as a Claude agent marker.
+//
+// TODO(nicknisi): decide what the window name says in each state — e.g.
+// all quiet vs. "fleet ◉2" (busy) vs. "fleet ⚠1" (needs you). Inputs:
+// s.busy / s.permit / s.question / s.done, and shellCount to derive the
+// agent count like renderHeader does. Keep it short — it lives in the
+// tmux status bar next to your other window names.
+export function paneTitle(_s: Summary, _shellCount: number): string {
+  return 'fleet';
 }
 
 export function renderHeader(app: TuiApp, cols: number): string[] {


### PR DESCRIPTION
## Summary

Fleet now sets an OSC 2 pane title so title-aware tmux `automatic-rename` setups can name its window `fleet` instead of guessing from command+cwd (which produced names like `fleet nicknisi`, or `bun` in dev mode).

- `oscTitle()` in `src/terminal/ansi.ts` — pure OSC 2 sequence builder, sanitizes control chars so a payload can't terminate the sequence early
- `setPaneTitle()`/`clearPaneTitle()` in `src/terminal/terminal.ts` — emit-on-change dedupe; `restore()` clears the title on exit so tmux naming falls back cleanly
- `paneTitle()` in `src/tui/dashboard.ts` — the advertised title (static `fleet` for now; TODO marks the planned dynamic status format). Must never start with `✳`, which `extractClaudeName` treats as a Claude agent marker — a test pins this
- Wired into the `draw()` frame loop in `index.ts`

## Test plan

- [x] `bun test` — 468 pass
- [x] `bun run typecheck`, `bun run lint` clean
- [x] End-to-end in a scratch tmux session: `#{pane_title}` becomes `fleet` while running, cleared on exit