### PR TITLE
fix: honest sidebar labels and a stable preview divider

### DIFF
--- a/src/state/types.test.ts
+++ b/src/state/types.test.ts
@@ -95,6 +95,10 @@ describe('sessionLabel', () => {
   test('omits window when empty', () => {
     expect(sessionLabel({ ...base, window: '' })).toBe('dotfiles');
   });
+
+  test("masks fleet's advertised title with the project basename", () => {
+    expect(sessionLabel({ ...base, window: 'fleet', project: '~/Developer/sessions' })).toBe('dotfiles:sessions');
+  });
 });
 
 describe('windowLabel', () => {
@@ -108,6 +112,25 @@ describe('windowLabel', () => {
 
   test('falls back to session when window matches the session name', () => {
     expect(windowLabel({ ...base, window: 'dotfiles' })).toBe('dotfiles');
+  });
+
+  // A window named exactly 'fleet' was named by a title-aware renamer reading
+  // fleet's own OSC 2 pane title, not this agent — the label must not mask the
+  // agent's real project.
+  test("window named after fleet's advertised title falls back to the project basename", () => {
+    expect(windowLabel({ ...base, window: 'fleet', project: '~/Developer/sessions' })).toBe('sessions');
+  });
+
+  test('fleet-titled window with no project falls back to the session', () => {
+    expect(windowLabel({ ...base, window: 'fleet', project: null })).toBe('dotfiles');
+  });
+
+  test('fleet-titled window in the fleet repo still reads fleet', () => {
+    expect(windowLabel({ ...base, window: 'fleet', project: '~/Developer/fleet' })).toBe('fleet');
+  });
+
+  test('a window merely containing fleet is untouched', () => {
+    expect(windowLabel({ ...base, window: '󱙺 fleet', project: '~/Developer/sessions' })).toBe('󱙺 fleet');
   });
 });
 

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -75,17 +75,31 @@ export function extractClaudeName(paneTitle: string): string | null {
   return name.length > 0 ? name : null;
 }
 
+// The pane title fleet advertises via OSC 2 (tui/dashboard.ts paneTitle).
+// Title-aware window renamers copy the focused pane's title into the window
+// name, so a window ends up named after fleet itself whenever the fleet pane
+// holds focus — that name describes fleet, not the agents sharing the window.
+export const FLEET_PANE_TITLE = 'fleet';
+
 // tmux target-style label (`session:window`). The window is dropped when it adds
 // no information — empty, or auto-named after the session itself.
 export function sessionLabel(state: AgentState): string {
-  if (state.window.length === 0 || state.window === state.session) return state.session;
-  return `${state.session}:${state.window}`;
+  const label = windowLabel(state);
+  return label === state.session ? state.session : `${state.session}:${label}`;
 }
 
 // Window-first label: the window name is what distinguishes agents; the
-// session is the fallback when the window adds no information.
+// session is the fallback when the window adds no information. A window named
+// exactly after fleet's advertised pane title was named by a title-aware
+// renamer reading the fleet pane, not this agent — the agent's project
+// directory is the honest label there (and when the agent really is working
+// in a repo named fleet, the basename shows "fleet" anyway).
 export function windowLabel(state: AgentState): string {
   if (state.window.length === 0 || state.window === state.session) return state.session;
+  if (state.window === FLEET_PANE_TITLE) {
+    const project = state.project?.split('/').pop();
+    return project && project.length > 0 ? project : state.session;
+  }
   return state.window;
 }
 

--- a/src/tui/dashboard.ts
+++ b/src/tui/dashboard.ts
@@ -1,6 +1,6 @@
 import { C } from '../terminal/colors.ts';
 import { truncateAnsi } from '../terminal/ansi.ts';
-import { AgentStatus, type AgentState } from '../state/types.ts';
+import { AgentStatus, FLEET_PANE_TITLE, type AgentState } from '../state/types.ts';
 import { TuiMode, type TuiApp, type Summary } from './app.ts';
 import { buildTableLines } from './layouts/table.ts';
 import { buildCardLines } from './layouts/cards.ts';
@@ -43,7 +43,7 @@ function logo(): string {
 // agent count like renderHeader does. Keep it short — it lives in the
 // tmux status bar next to your other window names.
 export function paneTitle(_s: Summary, _shellCount: number): string {
-  return 'fleet';
+  return FLEET_PANE_TITLE;
 }
 
 export function renderHeader(app: TuiApp, cols: number): string[] {

--- a/src/tui/layouts/cards.test.ts
+++ b/src/tui/layouts/cards.test.ts
@@ -53,6 +53,22 @@ describe('buildCardLines', () => {
     expect(built.states[0]).toBeNull();
   });
 
+  test('grouped rows show only the window label — the header already names the session', () => {
+    const app = new TuiApp();
+    app.updateStates([state({ paneId: '%1', window: 'one' }), state({ paneId: '%2', window: 'two' })]);
+    const built = buildCardLines(app, 34);
+    // lines[0] is the "api · 2" header; lines[1] is the first agent row.
+    expect(built.lines[1]).toContain('one');
+    expect(built.lines[1]).not.toContain('api ·');
+  });
+
+  test('ungrouped row keeps the session · window label', () => {
+    const app = new TuiApp();
+    app.updateStates([state({ window: 'editor' })]);
+    const built = buildCardLines(app, 40);
+    expect(built.lines[0]).toContain('api · editor');
+  });
+
   test('no line exceeds the requested width', () => {
     const app = new TuiApp();
     app.updateStates([state({ branch: 'feature/very-long-branch-name-here', tool: 'WebFetch' })]);

--- a/src/tui/layouts/cards.ts
+++ b/src/tui/layouts/cards.ts
@@ -1,8 +1,8 @@
 import { C } from '../../terminal/colors.ts';
 import { truncateAnsi, truncateWidth, visibleLength } from '../../terminal/ansi.ts';
-import { STATUS_DISPLAY, sessionDisplay, windowLabel, type AgentState } from '../../state/types.ts';
+import { STATUS_DISPLAY, type AgentState } from '../../state/types.ts';
 import type { TuiApp } from '../app.ts';
-import { formatAge, getAgeColor, getStateColor, stateIcon, type LayoutLines } from './shared.ts';
+import { agentRowLabel, formatAge, getAgeColor, getStateColor, stateIcon, type LayoutLines } from './shared.ts';
 
 // Sidebar cards: every agent is a fixed 4-line block —
 //   ▌⚠ name            4s
@@ -34,10 +34,7 @@ export function buildCardLines(app: TuiApp, cols: number): LayoutLines {
     const age = formatAge(st.ts);
     // line 1 visible budget: bar(1) sp(1) icon(1) sp(1) name … sp(1) age
     const nameW = Math.max(1, cols - 5 - age.length);
-    const name = truncateWidth(
-      windowLabel(st) === st.session ? sessionDisplay(st) : `${sessionDisplay(st)} · ${windowLabel(st)}`,
-      nameW,
-    );
+    const name = truncateWidth(agentRowLabel(row), nameW);
     const gap = ' '.repeat(Math.max(1, nameW - visibleLength(name) + 1));
     lines.push(
       truncateAnsi(

--- a/src/tui/layouts/shared.ts
+++ b/src/tui/layouts/shared.ts
@@ -1,5 +1,6 @@
 import { C } from '../../terminal/colors.ts';
-import { AgentStatus, STATUS_DISPLAY, type AgentState } from '../../state/types.ts';
+import { AgentStatus, STATUS_DISPLAY, sessionDisplay, windowLabel, type AgentState } from '../../state/types.ts';
+import type { DashboardRow } from '../app.ts';
 
 // One entry per rendered line: states[i] is the agent on lines[i], or null for
 // chrome lines (headers, separators, indicators). Render and hit-testing both
@@ -7,6 +8,18 @@ import { AgentStatus, STATUS_DISPLAY, type AgentState } from '../../state/types.
 export interface LayoutLines {
   lines: string[];
   states: (AgentState | null)[];
+}
+
+// Row label shared by both layouts. Grouped rows sit under a session header,
+// so repeating the session per row is noise — the window label alone names
+// them. Ungrouped rows carry the session inline. Window-presence logic keys on
+// the real session (windowLabel compares against it); only the shown string
+// swaps to the rename via sessionDisplay.
+export function agentRowLabel(row: Extract<DashboardRow, { kind: 'agent' }>): string {
+  const label = windowLabel(row.state);
+  if (row.grouped) return label;
+  const session = sessionDisplay(row.state);
+  return label === row.state.session ? session : `${session} · ${label}`;
 }
 
 export function getStateColor(status: AgentStatus): string {

--- a/src/tui/layouts/table.ts
+++ b/src/tui/layouts/table.ts
@@ -1,8 +1,8 @@
 import { C } from '../../terminal/colors.ts';
 import { padAnsi, truncateAnsi, truncateWidth, visibleLength } from '../../terminal/ansi.ts';
-import { STATUS_DISPLAY, sessionDisplay, windowLabel, type AgentState } from '../../state/types.ts';
+import { STATUS_DISPLAY, type AgentState } from '../../state/types.ts';
 import type { DashboardRow, TuiApp } from '../app.ts';
-import { formatAge, getAgeColor, getStateColor, stateIcon, type LayoutLines } from './shared.ts';
+import { agentRowLabel, formatAge, getAgeColor, getStateColor, stateIcon, type LayoutLines } from './shared.ts';
 
 export interface ColumnWidths {
   name: number;
@@ -34,12 +34,7 @@ export function computeColumnWidths(rows: DashboardRow[], cols: number): ColumnW
 }
 
 function nameCell(row: Extract<DashboardRow, { kind: 'agent' }>): string {
-  const label = windowLabel(row.state);
-  if (row.grouped) return `  ${label}`;
-  // Window-presence logic keys on the real session (windowLabel compares against
-  // it); only the shown string swaps to the rename via sessionDisplay.
-  const session = sessionDisplay(row.state);
-  return label === row.state.session ? session : `${session} · ${label}`;
+  return row.grouped ? `  ${agentRowLabel(row)}` : agentRowLabel(row);
 }
 
 function formatHeaderRow(row: Extract<DashboardRow, { kind: 'header' }>, cols: number): string {

--- a/src/tui/render.test.ts
+++ b/src/tui/render.test.ts
@@ -76,3 +76,26 @@ describe('render preview pane isolation', () => {
     expect(row).toContain('\x1b[0m');
   });
 });
+
+describe('render preview divider alignment', () => {
+  test('divider stays in one column when window names carry surrogate-pair glyphs', async () => {
+    const { visibleLength } = await import('../terminal/ansi.ts');
+    const app = new TuiApp();
+    // 󱙺 (U+F167A) is a plane-15 nerd-font glyph: 2 UTF-16 code units but 1
+    // terminal column — exactly the shape that skews code-unit padding.
+    app.updateStates([
+      { ...makeState(), window: '󱙺 one' },
+      { ...makeState(), paneId: '%2', window: 'two' },
+    ]);
+    app.mode = TuiMode.PREVIEW;
+
+    const out = render(app, { cols: 100, rows: 40 });
+    const columns = new Set<number>();
+    for (const line of out.split('\r\n')) {
+      const bar = line.indexOf('│');
+      if (bar === -1) continue;
+      columns.add(visibleLength(line.slice(0, bar)));
+    }
+    expect(columns.size).toBe(1);
+  });
+});

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -6,6 +6,7 @@ import { renderRenameMode } from './rename.ts';
 import { renderKillConfirm } from './kill.ts';
 import { renderHelp } from './help.ts';
 import { C } from '../terminal/colors.ts';
+import { visibleLength } from '../terminal/ansi.ts';
 import type { TerminalSize } from '../terminal/terminal.ts';
 
 export function render(app: TuiApp, size: TerminalSize): string {
@@ -84,7 +85,10 @@ export function render(app: TuiApp, size: TerminalSize): string {
       const sessionLine = sessionLines[row] ?? '';
       const previewLine = previewLines[row] ?? '';
       out.push(sessionLine);
-      const sessionVis = visibleLengthFast(sessionLine);
+      // Must be the same width function the layout builders pad with — a
+      // code-unit count (string .length) disagrees on surrogate-pair glyphs
+      // like nerd-font icons in window names, shifting the divider per row.
+      const sessionVis = visibleLength(sessionLine);
       if (sessionVis < listWidth) out.push(' '.repeat(listWidth - sessionVis));
       out.push(app.dragging ? `${C.cyan}│${C.reset}` : `${C.gray}│${C.reset}`);
       out.push(previewLine);
@@ -123,10 +127,4 @@ export function render(app: TuiApp, size: TerminalSize): string {
   }
 
   return out.join('');
-}
-
-function visibleLengthFast(s: string): number {
-  // Quick approximation — strip ANSI codes
-  // oxlint-disable-next-line no-control-regex
-  return s.replace(/\x1b\[[0-9;:]*[@-~]/g, '').length;
 }


### PR DESCRIPTION
## What

Three sidebar rendering fixes, all visible in the daily-driver setup:

1. **Grouped rows dropped the redundant session prefix.** Rows under a `session · N agents` header showed `projects · fleet` — the header already names the session. Grouped rows now show only the window label; ungrouped (singleton-session) rows keep the inline `session · window` form. The logic is extracted to `agentRowLabel()` in `layouts/shared.ts` and shared by the cards and table layouts.

2. **Fleet's own OSC 2 title no longer masquerades as an agent's window label.** Title-aware window renamers copy the focused pane's title into the window name, so a window ends up named `fleet` whenever the fleet sidebar pane has focus — telling you nothing about the agent sharing that window. `windowLabel()` now detects a window named exactly `FLEET_PANE_TITLE` and falls back to the agent's project basename (an agent genuinely working in a repo named `fleet` still reads `fleet`). Names merely *containing* `fleet` (e.g. `󱙺 fleet`) are untouched.

3. **The list/preview divider now stays in one column.** `render.ts` padded the list column with a "fast" UTF-16 code-unit count while the layout builders measure terminal columns via `visibleLength`. Nerd-font plane-15 glyphs in window names (e.g. `󱙺` U+F167A: 2 code units, 1 column) made the two disagree, walking the `│` left on every row containing one. The divider padding now uses the same width-aware `visibleLength`.

## Testing

- `bun test` — 476 pass, including new regression tests for each fix (fleet-title masking incl. edge cases, grouped-row labels, divider alignment with a surrogate-pair glyph).
- Verified live: ran the dev TUI in a detached tmux session against 7 real agents at 120 and 40 columns — divider aligned in both layouts, grouped rows show window-only labels, and the agent in a `fleet`-named window now reads `sessions` (its actual project).