### PR TITLE
fix: survive brew upgrade and detect status without hooks

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -17,7 +17,7 @@ import {
 } from './src/terminal/terminal.ts';
 import { setThemeMode, C } from './src/terminal/colors.ts';
 import { detectThemeMode } from './src/terminal/theme.ts';
-import { fuseState } from './src/state/engine.ts';
+import { fuseDiscoveredState, fuseState } from './src/state/engine.ts';
 import { readAllStatusDirs, watchStatusDirs } from './src/state/hooks.ts';
 import { readLastEvents, deriveStatusFromEvents } from './src/state/events.ts';
 import { acknowledgePlan } from './src/state/acknowledge.ts';
@@ -362,11 +362,14 @@ function refreshStates(dirs: AgentDir[]): AgentState[] {
       }).status;
     } else {
       // No winning hook. Before falling to SHELL, check hook-less discovery: an
-      // allowlisted process in this pane surfaces as a synthetic agent — BUSY
-      // when the pane shows a spinner glyph, IDLE when it does not.
+      // allowlisted process in this pane surfaces as a synthetic agent. Its
+      // status fuses the spinner-glyph heuristic with the pane scrape that
+      // already ran this tick — an on-screen permission prompt, question
+      // dialog, or live token counter must not read as idle just because no
+      // hook is writing (e.g. the plugin's hooks were silently unloaded).
       const disc = discoveryCache.get(pane.paneId);
       if (disc) {
-        status = disc.working ? AgentStatus.BUSY : AgentStatus.IDLE;
+        status = fuseDiscoveredState(disc.working, scrapeCache.get(pane.paneId) ?? null, ts);
         agentType = disc.agentType;
       } else {
         status = AgentStatus.SHELL;

--- a/src/cli/doctor.test.ts
+++ b/src/cli/doctor.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { installedPluginHasHooks } from './doctor.ts';
+import { installedPluginHasHooks, marketplaceSourceOk } from './doctor.ts';
 
 let pluginsRoot: string;
 
@@ -72,5 +72,32 @@ describe('installedPluginHasHooks', () => {
     });
     expect(installedPluginHasHooks(pluginsRoot, 'custom@')).toBe(true);
     expect(installedPluginHasHooks(pluginsRoot, 'fleet@')).toBe(false);
+  });
+});
+
+describe('marketplaceSourceOk', () => {
+  test('returns true when the fleet source dir has hooks/hooks.json', () => {
+    const src = join(pluginsRoot, 'fleet');
+    mkdirSync(join(src, 'hooks'), { recursive: true });
+    writeFileSync(join(src, 'hooks', 'hooks.json'), '{}');
+    expect(marketplaceSourceOk(pluginsRoot)).toBe(true);
+  });
+
+  test('resolves through a healthy symlink (the fleet install layout)', () => {
+    const keg = join(pluginsRoot, 'keg');
+    mkdirSync(join(keg, 'hooks'), { recursive: true });
+    writeFileSync(join(keg, 'hooks', 'hooks.json'), '{}');
+    symlinkSync(keg, join(pluginsRoot, 'fleet'));
+    expect(marketplaceSourceOk(pluginsRoot)).toBe(true);
+  });
+
+  test('returns false for a dangling symlink (keg removed by brew upgrade)', () => {
+    symlinkSync(join(pluginsRoot, 'gone-keg'), join(pluginsRoot, 'fleet'));
+    expect(marketplaceSourceOk(pluginsRoot)).toBe(false);
+  });
+
+  test('returns false when the source dir lacks hooks', () => {
+    mkdirSync(join(pluginsRoot, 'fleet'), { recursive: true });
+    expect(marketplaceSourceOk(pluginsRoot)).toBe(false);
   });
 });

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { tmux } from '../tmux/ipc.ts';
 import { loadAgentDirs } from '../agents/config.ts';
+import { marketplaceDir } from './install.ts';
 
 interface Check {
   name: string;
@@ -34,6 +35,16 @@ export function installedPluginHasHooks(pluginsRoot: string, prefix = 'fleet@'):
     }
   }
   return false;
+}
+
+// The plugin cache can hold hooks while the marketplace *source* is broken —
+// e.g. a symlink into a Homebrew keg that `brew upgrade` deleted. Claude Code
+// then drops the plugin at session start and hooks silently stop firing, while
+// the cache-based check above still passes. existsSync follows symlinks, so a
+// dangling link reads as missing. Only meaningful when the marketplace root
+// exists at all (a source-less setup is reported by the plugin check instead).
+export function marketplaceSourceOk(mpDir: string): boolean {
+  return existsSync(join(mpDir, 'fleet', 'hooks', 'hooks.json'));
 }
 
 export function runDoctor(): number {
@@ -88,6 +99,18 @@ export function runDoctor(): number {
       ? 'registered'
       : 'installed plugin has no hooks/hooks.json — dashboard will stay empty (reinstall: fleet install)',
   });
+
+  const mpRoot = marketplaceDir();
+  if (existsSync(mpRoot)) {
+    const sourceOk = marketplaceSourceOk(mpRoot);
+    checks.push({
+      name: 'marketplace source',
+      ok: sourceOk,
+      detail: sourceOk
+        ? join(mpRoot, 'fleet')
+        : `${join(mpRoot, 'fleet')} does not resolve — likely a symlink into a Homebrew keg removed by brew upgrade; hooks silently stop loading (re-run: fleet install)`,
+    });
+  }
 
   let allOk = true;
   for (const check of checks) {

--- a/src/cli/install.test.ts
+++ b/src/cli/install.test.ts
@@ -18,6 +18,7 @@ import {
   linkPluginDir,
   removeTmuxConfLine,
   resolvePluginDir,
+  stableKegPath,
   tmuxConfPath,
 } from './install.ts';
 
@@ -163,6 +164,25 @@ describe('resolvePluginDir', () => {
     mkdirSync(join(plugin, 'hooks'), { recursive: true });
     writeFileSync(join(plugin, 'hooks', 'hooks.json'), '{}');
     expect(resolvePluginDir([bare, plugin])).toBe(plugin);
+  });
+});
+
+describe('stableKegPath', () => {
+  test('maps a versioned Cellar keg to the upgrade-stable opt path', () => {
+    expect(stableKegPath('/opt/homebrew/Cellar/fleet/0.15.0')).toBe('/opt/homebrew/opt/fleet');
+  });
+
+  test('handles non-standard brew prefixes', () => {
+    expect(stableKegPath('/home/linuxbrew/.linuxbrew/Cellar/fleet/1.2.3')).toBe('/home/linuxbrew/.linuxbrew/opt/fleet');
+  });
+
+  test('returns null for a non-Cellar path (dev checkout, plain install)', () => {
+    expect(stableKegPath('/Users/nicknisi/Developer/fleet')).toBeNull();
+    expect(stableKegPath('/usr/local/lib/fleet')).toBeNull();
+  });
+
+  test('returns null for a Cellar path without a version segment', () => {
+    expect(stableKegPath('/opt/homebrew/Cellar/fleet')).toBeNull();
   });
 });
 

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -28,13 +28,24 @@ export function resolvePluginDir(candidates: string[]): string | null {
   return null;
 }
 
+// A versioned Homebrew keg (…/Cellar/fleet/0.14.0) is deleted by `brew
+// upgrade`, which breaks the marketplace symlink pointing into it — Claude Code
+// then silently drops the plugin and hooks stop firing. Homebrew keeps
+// …/opt/<name> aimed at the current keg across upgrades, so map a Cellar path
+// to its stable opt equivalent. Null when the path isn't a Cellar keg.
+export function stableKegPath(dir: string): string | null {
+  const m = dir.match(/^(.*)\/Cellar\/([^/]+)\/[^/]+$/);
+  return m ? `${m[1]}/opt/${m[2]}` : null;
+}
+
 export function fleetPluginDir(): string | null {
   const fromBin = resolve(dirname(process.execPath), '..');
   const fromDev = resolve(import.meta.dir, '../..');
-  return resolvePluginDir([fromBin, fromDev]);
+  const candidates = [stableKegPath(fromBin), fromBin, fromDev].filter((c): c is string => c !== null);
+  return resolvePluginDir(candidates);
 }
 
-function marketplaceDir(): string {
+export function marketplaceDir(): string {
   return join(homedir(), '.local', 'share', 'fleet-marketplace');
 }
 

--- a/src/state/engine.test.ts
+++ b/src/state/engine.test.ts
@@ -1,6 +1,35 @@
 import { describe, expect, test } from 'bun:test';
-import { fuseState } from './engine.ts';
+import { fuseDiscoveredState, fuseState } from './engine.ts';
 import { AgentStatus } from './types.ts';
+
+describe('fuseDiscoveredState', () => {
+  const now = Math.floor(Date.now() / 1000);
+
+  test('scraped permission prompt outranks everything — even with no glyph', () => {
+    expect(fuseDiscoveredState(false, AgentStatus.PERMIT, now)).toBe(AgentStatus.PERMIT);
+  });
+
+  test('scraped question dialog reads QUESTION', () => {
+    expect(fuseDiscoveredState(false, AgentStatus.QUESTION, now)).toBe(AgentStatus.QUESTION);
+  });
+
+  test('scraped token counter reads BUSY without a spinner glyph', () => {
+    expect(fuseDiscoveredState(false, AgentStatus.BUSY, now)).toBe(AgentStatus.BUSY);
+  });
+
+  test('spinner glyph alone reads BUSY when the scraper sees nothing', () => {
+    expect(fuseDiscoveredState(true, null, now)).toBe(AgentStatus.BUSY);
+  });
+
+  test('a scraped bare prompt never demotes a live glyph', () => {
+    expect(fuseDiscoveredState(true, AgentStatus.IDLE, now)).toBe(AgentStatus.BUSY);
+  });
+
+  test('no glyph and no scrape reads IDLE', () => {
+    expect(fuseDiscoveredState(false, null, now)).toBe(AgentStatus.IDLE);
+    expect(fuseDiscoveredState(false, AgentStatus.IDLE, now)).toBe(AgentStatus.IDLE);
+  });
+});
 
 describe('fuseState', () => {
   const now = Math.floor(Date.now() / 1000);

--- a/src/state/engine.ts
+++ b/src/state/engine.ts
@@ -36,6 +36,23 @@ function mapHookState(state: string): AgentStatus {
   }
 }
 
+// Status for a hook-less discovered agent — the same fusion as the hook path
+// with the hook layer silenced. The scraper's positive reads (an on-screen
+// permission prompt, question dialog, or live token counter) outrank the
+// spinner-glyph heuristic; the glyph stands in as the activity (BUSY) signal
+// when the scraper sees nothing; a scraped bare prompt never demotes a live
+// glyph (the discovery debounce owns that decay).
+export function fuseDiscoveredState(working: boolean, scrapeStatus: AgentStatus | null, now: number): AgentStatus {
+  return fuseState({
+    hookState: 'idle',
+    hookTs: now, // anchors the BUSY decay window at "fresh" so it can't fire here
+    eventStatus: working ? AgentStatus.BUSY : null,
+    scrapeStatus,
+    currentStatus: AgentStatus.IDLE,
+    currentTs: 0,
+  }).status;
+}
+
 export function fuseState(input: FuseInput): FuseResult {
   const now = Math.floor(Date.now() / 1000);
   const hookCandidate = mapHookState(input.hookState);


### PR DESCRIPTION
## What broke

Status updates silently died after `brew upgrade fleet` (0.14.0 → 0.15.0). Last hook write: Jul 6 12:14 — the moment the upgrade deleted the old keg. Chain:

1. `fleet install` created the marketplace symlink from `resolve(dirname(process.execPath), '..')` — for a Homebrew binary that's the **versioned keg** `/opt/homebrew/Cellar/fleet/0.14.0`.
2. `brew upgrade` removed that keg → dangling symlink → Claude Code silently dropped the plugin at session start → no hooks in any new session.
3. Every agent fell to hook-less discovery, whose braille-glyph content heuristic never matches Claude Code's on-screen UI (`✻` spinners, token counters) → **everything read idle**, including agents blocked on permission prompts.
4. `fleet doctor` passed all checks — it validates the plugin *cache* (which still had hooks), not the marketplace *source*.

## Fixes

- **`stableKegPath()`** — `fleet install` maps a Cellar keg to Homebrew's upgrade-stable `…/opt/<name>` path before creating the marketplace symlink. Falls through to the old candidates for dev checkouts and non-brew installs (`resolvePluginDir` still requires `hooks/hooks.json`).
- **`fuseDiscoveredState()`** — hook-less discovered agents now fuse the pane scrape that already runs every slow tick, instead of discarding it: a scraped permission prompt or question dialog wins absolutely, a live token counter reads BUSY, the spinner glyph remains the fallback activity signal, and a scraped bare prompt never demotes a live glyph. Reuses `fuseState` so the priority rules can't drift from the hook path.
- **doctor "marketplace source" check** — catches the dangling-symlink failure mode: it flagged the real breakage on my machine while every existing check passed.

## Testing

- `bun test` — 482 pass (14 new: keg-path mapping, discovery fusion matrix, marketplace source resolution incl. dangling symlink).
- Live before/after: with hooks still dead, the dashboard went from `7 idle` to `1 need you · 1 working · 4 idle` — an agent sitting on a question dialog surfaced as ASKING and an actively-working pane read as working, both hook-lessly.
- `bun index.ts doctor` before repair: new check ✗ with the brew-upgrade hint; after re-pointing the symlink: ✓.

Note for existing installs: re-run `fleet install` (or re-point `~/.local/share/fleet-marketplace/fleet` at `/opt/homebrew/opt/fleet`) once; sessions started while the link was broken only regain hooks on restart, but the discovery fusion covers them meanwhile.