### PR TITLE
fix: bug sweep + simplification pass across the codebase

### DIFF
--- a/hooks/lib.sh
+++ b/hooks/lib.sh
@@ -26,22 +26,24 @@ fleet_sanitize_label() {
   printf '%s' "$1" | tr '\n\r\t' '   ' | LC_ALL=C tr -d '\000-\037' | cut -c1-60
 }
 
+# Write via a temp file + mv (atomic within a filesystem) so the TUI's reader
+# never catches a truncate-then-write window and sees partial JSON.
 fleet_write_status() {
-  local state="$1" tool
+  local state="$1" tool tmp="${FLEET_STATUS_FILE}.tmp.$$"
   tool=$(fleet_sanitize_label "${2:-}")
   if command -v jq >/dev/null 2>&1; then
     jq -cn \
       --arg state "$state" --arg pane "$FLEET_PANE_ID" --arg session "$FLEET_SESSION" \
       --arg tool "$tool" --argjson ts "$FLEET_TS" --argjson pid "${FLEET_TMUX_PID:-0}" \
       '{state:$state, pane:$pane, session:$session, tool:$tool, ts:$ts, tmux_pid:$pid}' \
-      > "$FLEET_STATUS_FILE"
+      > "$tmp" && mv -f "$tmp" "$FLEET_STATUS_FILE"
   else
     # jq absent: label already stripped of control chars; also drop " and \.
     local safe=${tool//\"/}
     safe=${safe//\\/}
     printf '{"state":"%s","pane":"%s","session":"%s","tool":"%s","ts":%s,"tmux_pid":%s}\n' \
       "$state" "$FLEET_PANE_ID" "$FLEET_SESSION" "$safe" "$FLEET_TS" "${FLEET_TMUX_PID:-0}" \
-      > "$FLEET_STATUS_FILE"
+      > "$tmp" && mv -f "$tmp" "$FLEET_STATUS_FILE"
   fi
 }
 

--- a/hooks/notification.sh
+++ b/hooks/notification.sh
@@ -12,20 +12,22 @@ INPUT=$(cat)
 #   auth_success         — auth confirmation; not actionable.
 NOTIFICATION_TYPE=$(echo "$INPUT" | jq -r '.notification_type // empty' 2>/dev/null)
 
+# Event BEFORE status in each branch: the reader prefers the last event, so
+# appending first means it never pairs a new status with the previous event.
 case "$NOTIFICATION_TYPE" in
   permission_prompt)
-    fleet_write_status "permit"
     fleet_append_event "Notification" "notification_type" "\"permission_prompt\""
+    fleet_write_status "permit"
     fleet_notify "permit" "$FLEET_SESSION" "$FLEET_PANE_ID" >/dev/null 2>&1 &
     ;;
   elicitation_dialog)
-    fleet_write_status "question"
     fleet_append_event "Notification" "notification_type" "\"elicitation_dialog\""
+    fleet_write_status "question"
     fleet_notify "question" "$FLEET_SESSION" "$FLEET_PANE_ID" >/dev/null 2>&1 &
     ;;
   idle_prompt)
-    fleet_write_status "done"
     fleet_append_event "Notification" "notification_type" "\"idle_prompt\""
+    fleet_write_status "done"
     fleet_notify "done" "$FLEET_SESSION" "$FLEET_PANE_ID" >/dev/null 2>&1 &
     ;;
   *)

--- a/hooks/pre-tool-use.sh
+++ b/hooks/pre-tool-use.sh
@@ -7,7 +7,10 @@ RAW_TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || ech
 LABEL=$(printf '%s' "$INPUT" | fleet_tool_label)
 [ -z "$LABEL" ] && LABEL="$RAW_TOOL"          # fall back to the bare tool name
 
-fleet_write_status "working" "$LABEL"          # enriched → .status label
+# Event BEFORE status: the reader derives from the last event and prefers it
+# over the status file, so appending first means it can never see a new status
+# paired with the previous (stale) event.
 fleet_append_event "PreToolUse" "tool" "$(printf '%s' "$RAW_TOOL" | jq -Rs .)"  # RAW → event (slurp: empty → "")
+fleet_write_status "working" "$LABEL"          # enriched → .status label
 
 exit 0

--- a/index.ts
+++ b/index.ts
@@ -4,7 +4,7 @@ import { render } from './src/tui/render.ts';
 import { paneTitle, renderFooter, renderHeader, stateAtLine } from './src/tui/dashboard.ts';
 import { canSendTo } from './src/tui/send.ts';
 import { canKillSession } from './src/tui/kill.ts';
-import { parseKeyEvent } from './src/terminal/input.ts';
+import { parseKeyEvent, parseKeyEvents } from './src/terminal/input.ts';
 import { isMouseSequence, parseMouseEvent } from './src/terminal/mouse.ts';
 import {
   enterAlternateScreen,
@@ -17,26 +17,50 @@ import {
 } from './src/terminal/terminal.ts';
 import { setThemeMode, C } from './src/terminal/colors.ts';
 import { detectThemeMode } from './src/terminal/theme.ts';
-import { fuseState } from './src/state/engine.ts';
-import { readAllStatusDirs, watchStatusDirs } from './src/state/hooks.ts';
+import { fuseState, hookStateForStatus } from './src/state/engine.ts';
+import {
+  readAllStatusDirs,
+  watchStatusDirs,
+  statusFilePath,
+  eventsFilePath,
+  writeFileAtomic,
+} from './src/state/hooks.ts';
 import { readLastEvents, deriveStatusFromEvents } from './src/state/events.ts';
 import { acknowledgePlan } from './src/state/acknowledge.ts';
-import { detectFromPaneContent, detectFromTitle, scrapePane, scrapePaneCapture } from './src/state/scraper.ts';
+import { detectFromPaneContent, detectFromTitle, scrapePane, capturePaneLines } from './src/state/scraper.ts';
 import { loadDetectionManifest } from './src/state/detection.ts';
 import { loadRenames, saveRename } from './src/state/rename.ts';
-import { AgentStatus, ACK_ALL_RANGE, STATUS_DISPLAY, extractClaudeName, type AgentState } from './src/state/types.ts';
+import {
+  AgentStatus,
+  ACK_ALL_RANGE,
+  STATUS_DISPLAY,
+  extractClaudeName,
+  type AgentState,
+  type ResolvedHookStatus,
+} from './src/state/types.ts';
 import { decideNotifications, applySuppression } from './src/notify/transitions.ts';
 import { deliverDesktop } from './src/notify/deliver.ts';
 import { AgentRegistry } from './src/agents/registry.ts';
 import type { AgentDir } from './src/agents/config.ts';
 import {
+  parsePsTable,
   pruneDoneTracking,
+  readPsTable,
   resolveDiscoveredStatus,
   scanDiscovered,
   type DiscoveredAgent,
   type DoneTracking,
 } from './src/agents/discovery.ts';
-import { listPanesResult, switchClient, killPane, gitBranch } from './src/tmux/sessions.ts';
+import {
+  listPanesResult,
+  switchClient,
+  killPane,
+  gitBranch,
+  currentPaneId,
+  type ListPanesResult,
+  type PaneInfo,
+} from './src/tmux/sessions.ts';
+import { tmux, tmuxOrNull } from './src/tmux/ipc.ts';
 import { detectPorts } from './src/tmux/ports.ts';
 import { sendKeys, sendRawKey } from './src/tmux/send.ts';
 import { runStatus } from './src/cli/status.ts';
@@ -50,8 +74,7 @@ import { runReconcile } from './src/cli/reconcile.ts';
 import { runExplain } from './src/cli/explain.ts';
 import { runStatusLineInject, runStatusLineRemove, emitWindowColors, rollupEnabled } from './src/cli/statusline.ts';
 import { runWait } from './src/cli/wait.ts';
-import { readFileSync, writeFileSync, appendFileSync, existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { readFileSync, appendFileSync, existsSync } from 'node:fs';
 
 const VERSION: string = packageJson.version;
 const FAST_REFRESH_MS = 500;
@@ -110,28 +133,12 @@ function verifyPaneState(state: AgentState, statusDirs: string[]): void {
   if (scraped === null) return;
   if (scraped === state.status) return;
 
-  const paneNum = state.paneId.replace('%', '');
   const now = Math.floor(Date.now() / 1000);
-  const tmuxPid = (() => {
-    try {
-      const result = Bun.spawnSync({ cmd: ['tmux', 'display-message', '-p', '#{pid}'], stdout: 'pipe' });
-      return parseInt(result.stdout.toString().trim(), 10) || 0;
-    } catch {
-      return 0;
-    }
-  })();
-
-  const hookStateMap: Record<string, string> = {
-    PERMIT: 'permit',
-    QUESTION: 'question',
-    DONE: 'done',
-    BUSY: 'working',
-    IDLE: 'idle',
-  };
-  const newHookState = hookStateMap[scraped] ?? 'idle';
+  const tmuxPid = parseInt(tmuxOrNull(['display-message', '-p', '#{pid}']) ?? '', 10) || 0;
+  const newHookState = hookStateForStatus(scraped);
 
   for (const dir of statusDirs) {
-    const file = join(dir, `${paneNum}.status`);
+    const file = statusFilePath(dir, state.paneId);
     try {
       const content = readFileSync(file, 'utf-8');
       const existing = JSON.parse(content);
@@ -151,7 +158,7 @@ function verifyPaneState(state: AgentState, statusDirs: string[]): void {
           ts: now,
           tmux_pid: tmuxPid,
         });
-        writeFileSync(file, updated + '\n');
+        writeFileAtomic(file, updated + '\n');
         scrapeCache.set(state.paneId, scraped);
         return;
       }
@@ -167,10 +174,9 @@ function verifyPaneState(state: AgentState, statusDirs: string[]): void {
 // idle). Either signal alone is enough to clear the agent. Self-gating: a
 // working/waiting/asking agent derives neither, so it's left untouched.
 function acknowledgePane(paneId: string, statusDirs: string[]): void {
-  const paneNum = paneId.replace('%', '');
   const now = Math.floor(Date.now() / 1000);
   for (const dir of statusDirs) {
-    const statusFile = join(dir, `${paneNum}.status`);
+    const statusFile = statusFilePath(dir, paneId);
     let current: Record<string, unknown>;
     try {
       current = JSON.parse(readFileSync(statusFile, 'utf-8')) as Record<string, unknown>;
@@ -179,13 +185,13 @@ function acknowledgePane(paneId: string, statusDirs: string[]): void {
     }
     if (current.pane !== paneId) continue;
 
-    const eventsFile = join(dir, `${paneNum}.events.jsonl`);
+    const eventsFile = eventsFilePath(dir, paneId);
     const recent = existsSync(eventsFile) ? readLastEvents(eventsFile, 12) : [];
     const plan = acknowledgePlan(current, recent, now);
 
     if (plan.status) {
       try {
-        writeFileSync(statusFile, JSON.stringify(plan.status) + '\n');
+        writeFileAtomic(statusFile, JSON.stringify(plan.status) + '\n');
       } catch {
         // Best effort — acknowledgement is non-critical
       }
@@ -212,27 +218,10 @@ function acknowledgeAllReady(dirs: AgentDir[]): void {
 }
 
 // Force the tmux status bar to redraw now. Without this, an ack-in-place click
-// wouldn't visibly clear until the next status-interval (~15s). Best-effort.
+// wouldn't visibly clear until the next status-interval (~15s). Best-effort:
+// tmux() swallows "not in tmux" into a non-zero exit.
 function refreshTmuxStatus(): void {
-  try {
-    Bun.spawnSync({ cmd: ['tmux', 'refresh-client', '-S'] });
-  } catch {
-    // Not in tmux, or refresh failed — non-critical
-  }
-}
-
-// The pane the user is currently focused on (active pane of the attached client's
-// current window). Returns null when tmux can't answer, which disables the
-// notifier's per-pane suppression — better a redundant toast than a missed one.
-function resolveActivePane(): string | null {
-  try {
-    const p = Bun.spawnSync({ cmd: ['tmux', 'display-message', '-p', '#{pane_id}'], stdout: 'pipe', stderr: 'pipe' });
-    if (p.exitCode !== 0) return null;
-    const v = p.stdout.toString().trim();
-    return v.length > 0 ? v : null;
-  } catch {
-    return null;
-  }
+  tmux(['refresh-client', '-S']);
 }
 
 function shortenPath(path: string): string {
@@ -247,6 +236,10 @@ function shortenPath(path: string): string {
 const branchCache = new Map<string, string | null>();
 let portCache = new Map<string, number[]>();
 const scrapeCache = new Map<string, AgentStatus | null>();
+// When the scrape cache was last rebuilt (epoch seconds). A hook/event write
+// newer than this means the screen has changed since the snapshot — the cached
+// read is stale and must not mask the fresher signal.
+let scrapeCacheTs = 0;
 // Hook-less discovery (Phase 3): paneId -> synthetic agent, rebuilt on the slow
 // tick and read on every fast tick — same lifecycle as scrapeCache/portCache.
 // discoveryLastWorking carries the spinner-debounce timestamps across slow ticks
@@ -268,7 +261,7 @@ function reloadRenameCache(): void {
   renameCache = loadRenames();
 }
 
-function refreshSlowCaches(panes: { paneId: string; currentPath: string }[], dirs: AgentDir[]): void {
+function refreshSlowCaches(panes: PaneInfo[], hookStatuses: ResolvedHookStatus[]): void {
   const paths = new Set<string>();
   for (const p of panes) paths.add(p.currentPath);
   branchCache.clear();
@@ -276,9 +269,18 @@ function refreshSlowCaches(panes: { paneId: string; currentPath: string }[], dir
     branchCache.set(path, gitBranch(path));
   }
 
+  // One pane_pid map (from the caller's list-panes) and one ps pass, shared by
+  // port detection and hook-less discovery — no extra tmux/ps spawns.
+  const panePids = new Map<number, string>();
+  for (const p of panes) {
+    if (!Number.isNaN(p.panePid)) panePids.set(p.panePid, p.paneId);
+  }
+  const psTable = readPsTable();
+  const { ppidByPid } = parsePsTable(psTable);
+
   const newPorts = new Map<string, number[]>();
   try {
-    for (const pp of detectPorts()) {
+    for (const pp of detectPorts(panePids, ppidByPid)) {
       const existing = newPorts.get(pp.paneId) ?? [];
       existing.push(pp.port);
       newPorts.set(pp.paneId, existing);
@@ -287,66 +289,69 @@ function refreshSlowCaches(panes: { paneId: string; currentPath: string }[], dir
   portCache = newPorts;
 
   // Which agent owns each pane, so the scraper picks that agent's detection
-  // manifest. Scraping runs before refreshStates derives agentType, so learn it
-  // up front from the status files. Freshness-wins on a pane-id collision across
-  // dirs — same rule as refreshStates' hookByPane.
+  // manifest. Freshness-wins on a pane-id collision across dirs — same rule as
+  // refreshStates' hookByPane.
   const paneAgent = new Map<string, { agent: string; ts: number }>();
-  for (const h of readAllStatusDirs(dirs)) {
+  for (const h of hookStatuses) {
     const prev = paneAgent.get(h.pane);
     if (!prev || h.ts > prev.ts) paneAgent.set(h.pane, { agent: h.agent, ts: h.ts });
   }
 
-  // Layer 3: pane scraping (~50ms per pane) — slow cycle only. Capture each pane
-  // ONCE and keep its lines so hook-less discovery can reuse them for the spinner
-  // check (zero extra capture-pane calls).
-  const seen = new Set<string>();
+  // Layer 3: pane scraping (~50ms per pane) — slow cycle only. Capture each
+  // pane ONCE, without classifying yet: classification needs the pane's agent
+  // identity, and hook-less panes are only named by discovery below.
   const captureCache = new Map<string, string[]>();
   for (const p of panes) {
-    seen.add(p.paneId);
-    const { status, lines } = scrapePaneCapture(p.paneId, paneAgent.get(p.paneId)?.agent ?? 'claude');
-    scrapeCache.set(p.paneId, status);
+    const lines = capturePaneLines(p.paneId);
     if (lines.length > 0) captureCache.set(p.paneId, lines);
-  }
-  for (const paneId of scrapeCache.keys()) {
-    if (!seen.has(paneId)) scrapeCache.delete(paneId);
   }
 
   // Hook-less agent discovery: map allowlisted processes with no .status file to
   // their host pane and classify working from the spinner glyph, reusing the
-  // captures above (only one ps + one list-panes call is added). A synthetic
+  // captures + pane/ps tables above (zero extra subprocess spawns). A synthetic
   // agent here fills refreshStates' no-hook branch, so a hooked agent's status
   // always wins its pane and discovery never shadows it. Failure -> empty, and
   // the pane falls back to SHELL exactly as before Phase 3.
   try {
     const now = Math.floor(Date.now() / 1000);
-    const discovered = scanDiscovered(captureCache, discoveryLastWorking, now);
+    const discovered = scanDiscovered(captureCache, panePids, psTable, discoveryLastWorking, now);
     discoveryCache = new Map(discovered.agents.map((a) => [a.paneId, a]));
     discoveryLastWorking = discovered.lastWorking;
   } catch {
     discoveryCache = new Map();
   }
 
-  // The scrape above ran before discovery could name each hook-less pane's
-  // agent, so those panes were classified with the 'claude' fallback manifest —
-  // a hook-less opencode's "△ Permission required" matched against the wrong
-  // rules and read as nothing. Re-classify each discovered pane's cached capture
-  // against its OWN agent's manifest (pure re-run over lines already captured;
-  // zero extra capture-pane calls). Hooked panes already scraped with the right
-  // manifest via paneAgent and are skipped.
-  for (const [paneId, disc] of discoveryCache) {
-    if (paneAgent.has(paneId)) continue;
-    const lines = captureCache.get(paneId);
-    if (!lines) continue;
-    scrapeCache.set(paneId, detectFromPaneContent(lines, loadDetectionManifest(disc.agentType)).status);
+  // Every pane's agent identity is now known (winning hook first, discovery
+  // second, claude as the fallback) — classify each capture exactly once
+  // against the right manifest.
+  const seen = new Set<string>();
+  for (const p of panes) {
+    seen.add(p.paneId);
+    const lines = captureCache.get(p.paneId);
+    if (!lines) {
+      scrapeCache.set(p.paneId, null);
+      continue;
+    }
+    const agent = paneAgent.get(p.paneId)?.agent ?? discoveryCache.get(p.paneId)?.agentType ?? 'claude';
+    scrapeCache.set(p.paneId, detectFromPaneContent(lines, loadDetectionManifest(agent)).status);
   }
+  for (const paneId of scrapeCache.keys()) {
+    if (!seen.has(paneId)) scrapeCache.delete(paneId);
+  }
+  scrapeCacheTs = Math.floor(Date.now() / 1000);
 
   pruneDoneTracking(discoveryDone, new Set(discoveryCache.keys()));
 }
 
-// Fast refresh: ONE tmux call + status file reads + last-line JSONL reads. No git, no lsof.
-function refreshStates(dirs: AgentDir[]): AgentState[] {
-  const hookStatuses = readAllStatusDirs(dirs);
-  const { ok: tmuxOk, panes } = listPanesResult();
+// Fast refresh: ONE tmux call + status file reads + last-line JSONL reads. No
+// git, no lsof. The full (slow) path threads its own pane list + hook statuses
+// through `pre` so they're read once per tick, not once per phase.
+function refreshStates(
+  dirs: AgentDir[],
+  pre?: { panesResult: ListPanesResult; hookStatuses: ResolvedHookStatus[] },
+): AgentState[] {
+  const hookStatuses = pre?.hookStatuses ?? readAllStatusDirs(dirs);
+  const { ok: tmuxOk, panes } = pre?.panesResult ?? listPanesResult();
   lastTmuxOk = tmuxOk;
 
   // tmux pane ids (%N) are server-global, so the same pane number can have a
@@ -372,9 +377,10 @@ function refreshStates(dirs: AgentDir[]): AgentState[] {
     if (hook) {
       // Read events from the WINNING hook's own dir (not a first-match scan
       // across all dirs, which could read the wrong agent's stream on collision).
-      const eventsFile = join(hook.statusDir, `${pane.paneNum}.events.jsonl`);
+      const eventsFile = eventsFilePath(hook.statusDir, pane.paneId);
       const recent = readLastEvents(eventsFile, 12);
       const eventStatus = recent.length > 0 ? deriveStatusFromEvents(recent) : null;
+      const eventTs = recent.at(-1)?.ts ?? null;
 
       tool = hook.tool || null;
       ts = hook.ts;
@@ -387,13 +393,19 @@ function refreshStates(dirs: AgentDir[]): AgentState[] {
       // silent.
       const titleStatus = detectFromTitle(pane.paneTitle, loadDetectionManifest(hook.agent)).status;
 
+      // The cached scrape is a snapshot from the last slow tick. A hook/event
+      // write since then means the screen has changed (a prompt was answered, a
+      // turn ended) — drop the snapshot rather than let a stale PERMIT/QUESTION
+      // mask the fresher signal until the next slow tick.
+      const scrapeFresh = Math.max(hook.ts, eventTs ?? 0) <= scrapeCacheTs;
+      const cachedScrape = scrapeFresh ? (scrapeCache.get(pane.paneId) ?? null) : null;
+
       status = fuseState({
         hookState: hook.state,
         hookTs: hook.ts,
         eventStatus,
-        scrapeStatus: titleStatus ?? scrapeCache.get(pane.paneId) ?? null,
-        currentStatus: AgentStatus.IDLE,
-        currentTs: 0,
+        eventTs,
+        scrapeStatus: titleStatus ?? cachedScrape,
       }).status;
     } else {
       // No winning hook. Before falling to SHELL, check hook-less discovery: an
@@ -437,17 +449,20 @@ function refreshStates(dirs: AgentDir[]): AgentState[] {
       ports: portCache.get(pane.paneId) ?? [],
       ts,
       agentType,
+      paneTitle: pane.paneTitle,
     });
   }
 
   return states;
 }
 
-// Full refresh: runs slow caches then fast refresh
+// Full refresh: one list-panes + one status-dir read feed both the slow caches
+// and the fast refresh.
 function fullRefreshStates(dirs: AgentDir[]): AgentState[] {
-  const panes = listPanesResult().panes;
-  refreshSlowCaches(panes, dirs);
-  return refreshStates(dirs);
+  const panesResult = listPanesResult();
+  const hookStatuses = readAllStatusDirs(dirs);
+  refreshSlowCaches(panesResult.panes, hookStatuses);
+  return refreshStates(dirs, { panesResult, hookStatuses });
 }
 
 async function handleCli(args: string[]): Promise<number | null> {
@@ -744,7 +759,7 @@ async function launchTui(): Promise<number> {
     process.stdout.write(render(app, size));
     // Advertise status in the pane title (deduped inside setPaneTitle);
     // restore() clears it on exit so automatic-rename falls back cleanly.
-    setPaneTitle(paneTitle(app.summary(), app.shellCount()));
+    setPaneTitle(paneTitle());
   };
 
   // The pane fleet itself runs in — used to suppress every toast while you're
@@ -761,7 +776,9 @@ async function launchTui(): Promise<number> {
     const { candidates, previous } = decideNotifications(states, notifyPrev);
     notifyPrev = previous;
     if (candidates.length === 0) return; // resolve the active pane only when something fires
-    const activePaneId = resolveActivePane();
+    // null when tmux can't answer, which disables per-pane suppression —
+    // better a redundant toast than a missed one.
+    const activePaneId = currentPaneId();
     for (const n of applySuppression(candidates, activePaneId, fleetPaneId)) {
       deliverDesktop(`${STATUS_DISPLAY[n.status].label}: ${n.label}`, n.agentType);
     }
@@ -794,10 +811,17 @@ async function launchTui(): Promise<number> {
 
   return await new Promise<number>((resolve) => {
     let refreshTimer: ReturnType<typeof setInterval> | null = null;
+    // Declared (not just assigned) before finish() can run: the leftover-key
+    // replay below fires synchronously before the timers are armed, and a
+    // quit key there would otherwise hit the const in its temporal dead zone.
+    let slowTimer: ReturnType<typeof setInterval> | null = null;
+    let finished = false;
 
     const finish = (code: number) => {
+      if (finished) return;
+      finished = true;
       if (refreshTimer !== null) clearInterval(refreshTimer);
-      clearInterval(slowTimer);
+      if (slowTimer !== null) clearInterval(slowTimer);
       if (watcherTimeout !== null) clearTimeout(watcherTimeout);
       stopWatching();
       process.stdin.removeAllListeners('data');
@@ -912,8 +936,15 @@ async function launchTui(): Promise<number> {
         return;
       }
 
-      const key = parseKeyEvent(buf);
+      // One read can coalesce several keystrokes (fast typing, SSH batching,
+      // paste) — dispatch every parsed key, stopping if a key quit the app.
+      for (const key of parseKeyEvents(buf)) {
+        if (finished || app.shouldQuit) break;
+        handleKey(key);
+      }
+    };
 
+    const handleKey = (key: ReturnType<typeof parseKeyEvent>) => {
       if (key.type === 'ctrl' && key.char === 'c') {
         app.shouldQuit = true;
         return;
@@ -1090,7 +1121,7 @@ async function launchTui(): Promise<number> {
     }, FAST_REFRESH_MS);
 
     // Slow timer: skip if user is actively typing
-    const slowTimer = setInterval(() => {
+    slowTimer = setInterval(() => {
       if (isTyping()) return;
       doFullRefresh();
       tick();

--- a/src/agents/config.ts
+++ b/src/agents/config.ts
@@ -32,12 +32,24 @@ export function loadAgentDirs(): AgentDir[] {
   const newConfig = join(configDir, 'fleet', 'agents.json');
   if (existsSync(newConfig)) {
     try {
-      const data = JSON.parse(readFileSync(newConfig, 'utf-8')) as { agents?: AgentDir[] };
+      const data = JSON.parse(readFileSync(newConfig, 'utf-8')) as { agents?: unknown[] };
       if (data.agents && Array.isArray(data.agents)) {
-        return data.agents.map((a) => ({
-          name: a.name,
-          statusDir: a.statusDir.replace(/^~/, HOME),
-        }));
+        if (data.agents.length === 0) return []; // deliberately empty — no fallback
+        // Per-entry validation: one malformed entry must not discard the whole
+        // file (the catch below would silently drop every valid agent).
+        const valid = data.agents
+          .filter(
+            (a): a is AgentDir =>
+              typeof a === 'object' &&
+              a !== null &&
+              typeof (a as AgentDir).name === 'string' &&
+              typeof (a as AgentDir).statusDir === 'string',
+          )
+          .map((a) => ({
+            name: a.name,
+            statusDir: a.statusDir.replace(/^~/, HOME),
+          }));
+        if (valid.length > 0) return valid;
       }
     } catch {
       // Fall through to legacy

--- a/src/agents/discovery.ts
+++ b/src/agents/discovery.ts
@@ -18,6 +18,7 @@
 import { WORKING_GLYPH_PATTERN } from '../state/detection.ts';
 import { fuseDiscoveredState } from '../state/engine.ts';
 import { AgentStatus } from '../state/types.ts';
+import { getTmuxOption } from '../tmux/ipc.ts';
 
 export interface DiscoveredAgent {
   paneId: string;
@@ -199,16 +200,12 @@ export function resolveDiscoveredStatus(
 ): AgentStatus {
   const base = fuseDiscoveredState(signals.glyphWorking, signals.title ?? signals.scrape, now);
 
-  if (base === AgentStatus.PERMIT || base === AgentStatus.QUESTION) {
+  // PERMIT/QUESTION hold wasBusy open (the turn is still in flight); BUSY arms
+  // the working→idle transition — the tracking mutation is identical.
+  if (base === AgentStatus.PERMIT || base === AgentStatus.QUESTION || base === AgentStatus.BUSY) {
     tracking.done.delete(paneId);
     tracking.wasBusy.add(paneId);
     return base;
-  }
-
-  if (base === AgentStatus.BUSY) {
-    tracking.wasBusy.add(paneId);
-    tracking.done.delete(paneId);
-    return AgentStatus.BUSY;
   }
 
   if (tracking.wasBusy.has(paneId)) {
@@ -287,54 +284,28 @@ export function parseDiscoveryConfig(raw: {
 
 // ---- I/O shell: spawn ps, call tmux, read config, delegate to the pure core ----
 
-function showOption(name: string): string | null {
-  try {
-    const p = Bun.spawnSync({ cmd: ['tmux', 'show', '-gqv', name], stdout: 'pipe', stderr: 'pipe' });
-    if (p.exitCode !== 0) return null;
-    const v = p.stdout.toString().trim();
-    return v.length > 0 ? v : null;
-  } catch {
-    return null;
-  }
-}
+// The @fleet_discover* options essentially never change mid-session, but a
+// cold read costs 3 tmux spawns — cache with a TTL so live option changes
+// still land within a minute.
+const CONFIG_TTL_MS = 60_000;
+let cachedConfig: { cfg: DiscoveryConfig; readAt: number } | null = null;
 
 export function readDiscoveryConfig(): DiscoveryConfig {
-  return parseDiscoveryConfig({
-    discover: showOption('@fleet_discover'),
-    agents: showOption('@fleet_discover_agents'),
-    idleSecs: showOption('@fleet_discover_idle_secs'),
+  const now = Date.now();
+  if (cachedConfig && now - cachedConfig.readAt < CONFIG_TTL_MS) return cachedConfig.cfg;
+  const cfg = parseDiscoveryConfig({
+    discover: getTmuxOption('@fleet_discover'),
+    agents: getTmuxOption('@fleet_discover_agents'),
+    idleSecs: getTmuxOption('@fleet_discover_idle_secs'),
   });
-}
-
-// Build the pane_pid -> paneId map from one `tmux list-panes` call (pattern:
-// ports.ts:8-22). Empty on any tmux failure.
-function readPanePids(): Map<number, string> {
-  const panePids = new Map<number, string>();
-  try {
-    const p = Bun.spawnSync({
-      cmd: ['tmux', 'list-panes', '-a', '-F', '#{pane_id}:#{pane_pid}'],
-      stdout: 'pipe',
-      stderr: 'pipe',
-    });
-    if (p.exitCode !== 0) return panePids;
-    for (const line of p.stdout.toString().split('\n')) {
-      if (line.length === 0) continue;
-      const [paneId, pidStr] = line.split(':');
-      if (paneId && pidStr) {
-        const pid = parseInt(pidStr, 10);
-        if (!Number.isNaN(pid)) panePids.set(pid, paneId);
-      }
-    }
-  } catch {
-    return panePids;
-  }
-  return panePids;
+  cachedConfig = { cfg, readAt: now };
+  return cfg;
 }
 
 // One `ps` pass over the whole process table. Empty on any failure (exotic
 // platform / different flags) so discovery degrades to no-op and fleet behaves as
 // pre-Phase-3 (the pane stays SHELL).
-function readPsTable(): string[] {
+export function readPsTable(): string[] {
   try {
     const p = Bun.spawnSync({ cmd: ['ps', '-eo', 'pid=,ppid=,comm='], stdout: 'pipe', stderr: 'pipe' });
     if (p.exitCode !== 0) return [];
@@ -345,21 +316,21 @@ function readPsTable(): string[] {
 }
 
 // Thin I/O wrapper the slow loop calls. `captures` are the per-pane lines already
-// taken for the scrape cache this tick (paneId -> captured lines), threaded in so
-// discovery adds ZERO extra capture-pane calls — only one `ps` and one
-// `list-panes`. `lastWorking` is carried across ticks by the caller. Returns the
-// discovered agents plus the pruned lastWorking to persist for the next tick.
+// taken for the scrape cache this tick (paneId -> captured lines), and `panePids`
+// + `psTable` come from the caller's single list-panes + ps pass, so discovery
+// adds ZERO extra subprocess spawns. `lastWorking` is carried across ticks by the
+// caller. Returns the discovered agents plus the pruned lastWorking to persist
+// for the next tick.
 export function scanDiscovered(
   captures: Map<string, string[]>,
+  panePids: Map<number, string>,
+  psTable: string[],
   lastWorking: Map<string, number>,
   now: number,
   config?: DiscoveryConfig,
 ): { agents: DiscoveredAgent[]; lastWorking: Map<string, number> } {
   const cfg = config ?? readDiscoveryConfig();
   if (!cfg.enabled) return { agents: [], lastWorking: new Map() };
-
-  const panePids = readPanePids();
-  const psTable = readPsTable();
 
   // Reduce each pane's captured lines to the bottom-of-pane window as one string
   // for the glyph check.

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -14,8 +14,4 @@ export class AgentRegistry {
   statusDirs(): string[] {
     return this.dirs.map((d) => d.statusDir);
   }
-
-  reload(): void {
-    this.dirs = loadAgentDirs();
-  }
 }

--- a/src/cli/explain.test.ts
+++ b/src/cli/explain.test.ts
@@ -13,7 +13,6 @@ const makeDecision = (o: Partial<StateDecision> = {}): StateDecision => ({
   winner: 'event',
   reason: 'derived from the latest JSONL event',
   workingTimeoutFired: false,
-  freshnessEvaluated: false,
   scrapeRuleId: 'idle.prompt',
   ...o,
 });
@@ -70,18 +69,6 @@ describe('renderExplain', () => {
   test('annotates that DONE never comes from the scraper', () => {
     const out = renderExplain(makeBlock(), false);
     expect(out).toContain('DONE never comes from scrape');
-  });
-
-  test('reports the dead freshness branch as not evaluated (success criterion)', () => {
-    const out = renderExplain(makeBlock({ decision: makeDecision({ freshnessEvaluated: false }) }), false);
-    expect(out).toContain('not evaluated');
-    expect(out).toContain('live refresh is stateless');
-  });
-
-  test('reports freshness evaluated when the branch actually fired', () => {
-    const out = renderExplain(makeBlock({ decision: makeDecision({ freshnessEvaluated: true }) }), false);
-    expect(out).toContain('kept in-memory state');
-    expect(out).not.toContain('not evaluated');
   });
 
   test('renders the working-timeout line (not fired)', () => {

--- a/src/cli/explain.ts
+++ b/src/cli/explain.ts
@@ -1,18 +1,17 @@
 import {
   AgentStatus,
   STATUS_DISPLAY,
+  formatAgeDelta,
   type AgentState,
   type HookStatus,
-  type EventEntry,
   type StateDecision,
 } from '../state/types.ts';
 import { fuseState } from '../state/engine.ts';
 import { loadDetectionManifest } from '../state/detection.ts';
-import { scrapePaneDetailed, type ScrapeDetail } from '../state/scraper.ts';
-import { parseStatusFile } from '../state/hooks.ts';
+import { detectFromTitle, scrapePaneDetailed, type ScrapeDetail } from '../state/scraper.ts';
+import { parseStatusFile, statusFilePath, eventsFilePath } from '../state/hooks.ts';
 import { readLastEvents, deriveStatusFromEvents } from '../state/events.ts';
 import { readFileSync, existsSync } from 'node:fs';
-import { join } from 'node:path';
 
 export interface ExplainBlock {
   session: string;
@@ -27,16 +26,9 @@ export interface ExplainBlock {
 
 const FRAME_WIDTH = 58;
 
-// Age of a delta in seconds. Pure (takes a delta, not a ts) so renderExplain
-// stays deterministic under test — it reads decision.now, never Date.now().
-function fmtAge(deltaSecs: number): string {
-  const d = Math.max(0, deltaSecs);
-  if (d < 5) return 'now';
-  if (d < 60) return `${d}s`;
-  if (d < 3600) return `${Math.floor(d / 60)}m`;
-  if (d < 86400) return `${Math.floor(d / 3600)}h`;
-  return `${Math.floor(d / 86400)}d`;
-}
+// Delta-based (never Date.now()) so renderExplain stays deterministic under
+// test — it reads decision.now.
+const fmtAge = formatAgeDelta;
 
 function candidateRow(label: string, status: string, age: string, detail: string): string {
   return `    ${label.padEnd(10)}${status.padEnd(9)}${age.padEnd(8)}${detail}`.trimEnd();
@@ -113,9 +105,6 @@ export function renderExplain(block: ExplainBlock, showSnapshot: boolean): strin
   lines.push(`    winner            ${d.winner}`);
   lines.push(`    reason            ${d.reason}`);
   lines.push(`    working-timeout   ${d.workingTimeoutFired ? 'fired (stale BUSY → idle)' : 'not fired'}`);
-  lines.push(
-    `    freshness         ${d.freshnessEvaluated ? 'evaluated — kept in-memory state' : 'not evaluated (live refresh is stateless)'}`,
-  );
 
   if (showSnapshot) {
     lines.push('');
@@ -129,30 +118,21 @@ export function renderExplain(block: ExplainBlock, showSnapshot: boolean): strin
 }
 
 // Scan statusDirs for the pane's .status file exactly as acknowledgePane does,
-// returning the parsed hook plus its resolved path (for the trace's source column).
-function findHook(paneId: string, statusDirs: string[]): { status: HookStatus; file: string } | null {
-  const paneNum = paneId.replace('%', '');
+// returning the parsed hook plus its resolved path (for the trace's source
+// column) and owning dir (so events are read from the SAME agent's stream, not
+// a first-match scan that could hit another agent's on a pane-id collision).
+function findHook(paneId: string, statusDirs: string[]): { status: HookStatus; file: string; dir: string } | null {
   for (const dir of statusDirs) {
-    const file = join(dir, `${paneNum}.status`);
+    const file = statusFilePath(dir, paneId);
     if (!existsSync(file)) continue;
     try {
       const status = parseStatusFile(readFileSync(file, 'utf-8'));
-      if (status && status.pane === paneId) return { status, file };
+      if (status && status.pane === paneId) return { status, file, dir };
     } catch {
       // Unreadable — try the next dir
     }
   }
   return null;
-}
-
-// Last 12 events for the pane, mirroring refreshStates' scan of statusDirs.
-function readRecentEvents(paneId: string, statusDirs: string[]): EventEntry[] {
-  const paneNum = paneId.replace('%', '');
-  for (const dir of statusDirs) {
-    const recent = readLastEvents(join(dir, `${paneNum}.events.jsonl`), 12);
-    if (recent.length > 0) return recent;
-  }
-  return [];
 }
 
 function toBlock(
@@ -201,23 +181,26 @@ export function runExplain(session: string, states: AgentState[], statusDirs: st
     // not the cache the dashboard warmed on its last slow tick — and with the
     // pane's OWN agent manifest, so a discovered (hook-less) agent's trace shows
     // the rules that actually classify it, not claude's.
-    const detail = scrapePaneDetailed(state.paneId, loadDetectionManifest(state.agentType || 'claude'));
+    const manifest = loadDetectionManifest(state.agentType || 'claude');
+    const detail = scrapePaneDetailed(state.paneId, manifest);
     const hook = findHook(state.paneId, statusDirs);
     if (!hook) {
       out.push(renderExplain(shellBlock(state, detail, showSnapshot), showSnapshot));
       continue;
     }
-    const events = readRecentEvents(state.paneId, statusDirs);
+    const events = readLastEvents(eventsFilePath(hook.dir, state.paneId), 12);
     const eventStatus = events.length > 0 ? deriveStatusFromEvents(events) : null;
+    // Mirror the live wiring: a title-rule match takes the scrape slot (it's
+    // the fresher signal), the screen scrape covers the rest.
+    const title = state.paneTitle !== undefined ? detectFromTitle(state.paneTitle, manifest) : null;
+    const scrape = title?.status != null ? title : (detail?.result ?? null);
     const { status, decision } = fuseState({
       hookState: hook.status.state,
       hookTs: hook.status.ts,
       eventStatus,
       eventTs: events.at(-1)?.ts ?? null,
-      scrapeStatus: detail?.result.status ?? null,
-      scrapeRuleId: detail?.result.ruleId ?? null,
-      currentStatus: AgentStatus.IDLE, // mirror the live wiring exactly (index.ts:282-283)
-      currentTs: 0,
+      scrapeStatus: scrape?.status ?? null,
+      scrapeRuleId: scrape?.ruleId ?? null,
     });
     out.push(renderExplain(toBlock(state, hook.file, status, decision, detail, showSnapshot), showSnapshot));
   }

--- a/src/cli/install-codex.ts
+++ b/src/cli/install-codex.ts
@@ -199,6 +199,18 @@ export function removeAgentEntry(path: string, name: string): void {
   writeFileSync(path, JSON.stringify({ agents: kept }, null, 2) + '\n');
 }
 
+// Agents present before an install, guaranteed to include a claude entry even
+// when ~/.cache/claude-status doesn't exist yet: agents.json PREEMPTS the
+// fallback once written, so an agent-first user who later runs Claude would
+// otherwise find it hidden. Shared by the codex and pi installers.
+export function seededAgentDirs(): AgentDir[] {
+  const seed = loadAgentDirs();
+  if (!seed.some((a) => a.name === 'claude')) {
+    seed.unshift({ name: 'claude', statusDir: '~/.cache/claude-status' });
+  }
+  return seed;
+}
+
 // --- top-level commands --------------------------------------------------------
 export function runInstallCodex(): number {
   const fleetDir = fleetPluginDir();
@@ -213,13 +225,8 @@ export function runInstallCodex(): number {
 
   // Snapshot the agents that exist BEFORE this install (so the mkdir below doesn't
   // pull a half-formed codex into the fallback) — this seeds a fresh agents.json
-  // without dropping them. Guarantee a claude entry even when ~/.cache/claude-status
-  // doesn't exist yet: agents.json PREEMPTS the fallback once written, so a
-  // Codex-first user who later runs Claude would otherwise find it hidden.
-  const seed = loadAgentDirs();
-  if (!seed.some((a) => a.name === 'claude')) {
-    seed.unshift({ name: 'claude', statusDir: '~/.cache/claude-status' });
-  }
+  // without dropping them.
+  const seed = seededAgentDirs();
 
   // Stable, upgrade-safe path for Codex to reference (no $CLAUDE_PLUGIN_ROOT, and
   // a Homebrew keg path changes on upgrade). Re-pointed on every install.

--- a/src/cli/install-pi.ts
+++ b/src/cli/install-pi.ts
@@ -2,8 +2,8 @@ import { existsSync, lstatSync, mkdirSync, rmSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fleetPluginDir, linkPluginDir } from './install.ts';
-import { agentsJsonPath, removeAgentEntry, upsertAgentEntry, withTilde } from './install-codex.ts';
-import { loadAgentDirs, PI_STATUS_DIR } from '../agents/config.ts';
+import { agentsJsonPath, removeAgentEntry, seededAgentDirs, upsertAgentEntry, withTilde } from './install-codex.ts';
+import { PI_STATUS_DIR } from '../agents/config.ts';
 
 // pi (npm: @mariozechner/pi-coding-agent) has no shell-hook config; it loads
 // TypeScript extensions auto-discovered from ~/.pi/agent/extensions/*.ts (see
@@ -46,13 +46,8 @@ export function runInstallPi(): number {
   }
 
   // Snapshot agents present BEFORE the mkdir below so a fresh agents.json is
-  // seeded without dropping claude/codex; guarantee a claude entry even when its
-  // status dir doesn't exist yet (agents.json preempts the fallback once written,
-  // same reasoning as install-codex).
-  const seed = loadAgentDirs();
-  if (!seed.some((a) => a.name === 'claude')) {
-    seed.unshift({ name: 'claude', statusDir: '~/.cache/claude-status' });
-  }
+  // seeded without dropping claude/codex (see seededAgentDirs).
+  const seed = seededAgentDirs();
 
   mkdirSync(PI_EXTENSIONS_DIR, { recursive: true });
   linkPluginDir(extensionSrc, PI_EXTENSION_LINK); // rm + symlink; replaces a stale/dangling link

--- a/src/cli/next.ts
+++ b/src/cli/next.ts
@@ -1,13 +1,9 @@
-import { AgentStatus, compareStatus, type AgentState } from '../state/types.ts';
+import { compareStatus, needsAttention, type AgentState } from '../state/types.ts';
 import { switchClient, displayMessage, currentPaneId } from '../tmux/sessions.ts';
 
 export function runNext(states: AgentState[]): number {
   const currentPane = currentPaneId();
-  const waiting = states
-    .filter(
-      (s) => s.status === AgentStatus.PERMIT || s.status === AgentStatus.QUESTION || s.status === AgentStatus.DONE,
-    )
-    .sort((a, b) => compareStatus(a.status, b.status));
+  const waiting = states.filter((s) => needsAttention(s.status)).sort((a, b) => compareStatus(a.status, b.status));
 
   if (waiting.length === 0) {
     displayMessage('No waiting agents');

--- a/src/cli/send.ts
+++ b/src/cli/send.ts
@@ -1,4 +1,5 @@
-import { AgentStatus, type AgentState } from '../state/types.ts';
+import { AgentStatus, compareStatus, type AgentState } from '../state/types.ts';
+import { canSendTo } from '../tui/send.ts';
 import { sendKeys } from '../tmux/send.ts';
 
 export function runSend(session: string, prompt: string, states: AgentState[], force: boolean): number {
@@ -8,28 +9,24 @@ export function runSend(session: string, prompt: string, states: AgentState[], f
     return 1;
   }
 
-  const target = sessionStates[0]!;
+  // Target the session's AGENT, never a bare shell — typing a prompt into a
+  // shell pane and pressing Enter would execute it as a shell command. Among
+  // agents, prefer the most urgent (tmux pane order is arbitrary).
+  const agents = sessionStates
+    .filter((s) => s.status !== AgentStatus.SHELL && s.status !== AgentStatus.DOWN)
+    .sort((a, b) => compareStatus(a.status, b.status));
+  const target = agents[0];
+  if (!target) {
+    process.stderr.write(`No agent panes in session '${session}' (only shells)\n`);
+    return 1;
+  }
 
-  switch (target.status) {
-    case AgentStatus.PERMIT:
-      process.stderr.write(`Session '${session}' has a permission prompt — refusing to send\n`);
-      return 1;
-    case AgentStatus.QUESTION:
-      process.stderr.write(`Session '${session}' is asking a question — refusing to send\n`);
-      return 1;
-    case AgentStatus.BUSY:
-      if (!force) {
-        process.stderr.write(`Session '${session}' is busy — use --force to override\n`);
-        return 1;
-      }
-      break;
-    case AgentStatus.DONE:
-    case AgentStatus.IDLE:
-    case AgentStatus.SHELL:
-      break;
-    case AgentStatus.DOWN:
-      process.stderr.write(`Session '${session}' has no live process\n`);
-      return 1;
+  // Same gating policy as the TUI's send mode; --force overrides BUSY only.
+  const check = canSendTo(target);
+  if (!check.ok && !(force && target.status === AgentStatus.BUSY)) {
+    const hint = target.status === AgentStatus.BUSY ? ' — use --force to override' : '';
+    process.stderr.write(`Session '${session}': ${check.reason}${hint}\n`);
+    return 1;
   }
 
   try {

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -2,19 +2,15 @@ import {
   AgentStatus,
   ACK_ALL_RANGE,
   compareStatus,
+  formatAgeDelta,
+  needsAttention,
   STATUS_DISPLAY,
   windowLabel,
   type AgentState,
 } from '../state/types.ts';
 
 export function formatAge(ts: number): string {
-  const now = Math.floor(Date.now() / 1000);
-  const delta = Math.max(0, now - ts);
-  if (delta < 5) return 'now';
-  if (delta < 60) return `${delta}s`;
-  if (delta < 3600) return `${Math.floor(delta / 60)}m`;
-  if (delta < 86400) return `${Math.floor(delta / 3600)}h`;
-  return `${Math.floor(delta / 86400)}d`;
+  return formatAgeDelta(Math.floor(Date.now() / 1000) - ts);
 }
 
 export function formatStatusLine(states: AgentState[]): string {
@@ -22,15 +18,17 @@ export function formatStatusLine(states: AgentState[]): string {
   // a permission prompt (PERMIT), asking a question (QUESTION), or finished and
   // waiting on your next move (DONE/ready). Working and idle agents don't need
   // you, so they stay out of the bar.
-  const visible: AgentStatus[] = [AgentStatus.PERMIT, AgentStatus.QUESTION, AgentStatus.DONE];
-  const filtered = states.filter((s) => visible.includes(s.status));
+  const filtered = states.filter((s) => needsAttention(s.status));
   if (filtered.length === 0) return '';
 
   filtered.sort((a, b) => compareStatus(a.status, b.status));
 
   const entries = filtered.map((s) => {
     const display = STATUS_DISPLAY[s.status];
-    return `#[range=user|${s.paneId}]#[fg=${display.color}]${display.icon} #[bold]${windowLabel(s)}#[nobold] ${formatAge(s.ts)}#[norange]`;
+    // tmux re-expands format directives in #() output, so a window/session
+    // name containing '#' must be escaped ('##') or it corrupts the row.
+    const label = windowLabel(s).replace(/#/g, '##');
+    return `#[range=user|${s.paneId}]#[fg=${display.color}]${display.icon} #[bold]${label}#[nobold] ${formatAge(s.ts)}#[norange]`;
   });
 
   // A "clear all" chip dismisses every ready agent at once. Only ready (DONE)
@@ -48,9 +46,7 @@ export function formatPlainStatus(states: AgentState[], session: string): string
 
   sessionStates.sort((a, b) => compareStatus(a.status, b.status));
   const mostUrgent = sessionStates[0]!.status;
-  const needsYouCount = sessionStates.filter(
-    (s) => s.status === AgentStatus.PERMIT || s.status === AgentStatus.QUESTION || s.status === AgentStatus.DONE,
-  ).length;
+  const needsYouCount = sessionStates.filter((s) => needsAttention(s.status)).length;
 
   return `${mostUrgent} ${needsYouCount}`;
 }
@@ -62,8 +58,7 @@ export function formatTmuxStatus(states: AgentState[], session: string): string 
   sessionStates.sort((a, b) => compareStatus(a.status, b.status));
   const mostUrgent = sessionStates[0]!.status;
 
-  const needsAttention: AgentStatus[] = [AgentStatus.PERMIT, AgentStatus.QUESTION, AgentStatus.DONE];
-  if (!needsAttention.includes(mostUrgent)) return '';
+  if (!needsAttention(mostUrgent)) return '';
 
   const display = STATUS_DISPLAY[mostUrgent];
   return `#[fg=${display.color}] ${display.icon} `;
@@ -83,12 +78,11 @@ export function windowColorArgs(states: AgentState[]): string[][] {
     byWindow.set(s.windowId, list);
   }
 
-  const attention: AgentStatus[] = [AgentStatus.PERMIT, AgentStatus.QUESTION, AgentStatus.DONE];
   const args: string[][] = [];
   for (const [windowId, group] of byWindow) {
     group.sort((a, b) => compareStatus(a.status, b.status));
     const worst = group[0]!.status;
-    if (attention.includes(worst)) {
+    if (needsAttention(worst)) {
       args.push(['set', '-w', '-t', windowId, '@fleet_state', STATUS_DISPLAY[worst].color]);
     } else {
       // Data shadow: a window whose agent just went idle/working MUST be unset

--- a/src/cli/statusline.ts
+++ b/src/cli/statusline.ts
@@ -7,6 +7,7 @@
  */
 
 import { windowColorArgs } from './status.ts';
+import { getTmuxOption, tmux } from '../tmux/ipc.ts';
 import type { AgentState } from '../state/types.ts';
 
 // Fire only on row 1 (the fleet row) and only when the click landed on a named
@@ -114,20 +115,16 @@ function runCommands(commands: string[][]): number {
   return 0;
 }
 
-// Gate: only emit window colors when the user opted in. Mirrors the
-// `tmux show -gqv @fleet-theme` read in src/terminal/theme.ts. Cheap (~2ms) and
+// Gate: only emit window colors when the user opted in. Cheap (~2ms) and
 // only paid by users who have the statusline installed at all.
 export function rollupEnabled(): boolean {
-  try {
-    const p = Bun.spawnSync({ cmd: ['tmux', 'show', '-gqv', '@fleet_rollup'], stdout: 'pipe', stderr: 'pipe' });
-    return p.stdout.toString().trim() === '1';
-  } catch {
-    return false;
-  }
+  return getTmuxOption('@fleet_rollup') === '1';
 }
 
 // One batched tmux call for all windows: `tmux set ... ; set -w -u ... ; ...`.
 // tmux treats a lone ";" arg as a command separator, so N windows = 1 spawn.
+// Failures (not in tmux, window closed mid-batch) are non-critical — the next
+// redraw retries.
 export function emitWindowColors(states: AgentState[]): void {
   const groups = windowColorArgs(states);
   if (groups.length === 0) return;
@@ -136,34 +133,22 @@ export function emitWindowColors(states: AgentState[]): void {
     if (i > 0) flat.push(';');
     flat.push(...groups[i]!);
   }
-  try {
-    Bun.spawnSync({ cmd: ['tmux', ...flat], stdout: 'ignore', stderr: 'ignore' });
-  } catch {
-    // Not in tmux, or a window closed mid-batch — non-critical, next redraw retries.
-  }
+  tmux(flat);
 }
 
 // Sweep every window's @fleet_state so no stale tint lingers after uninstall —
 // including windows that have no fleet pane. Dynamic (lists live windows), so it
 // lives outside the static buildRemoveCommands array.
 export function clearAllWindowStates(): void {
-  try {
-    const p = Bun.spawnSync({
-      cmd: ['tmux', 'list-windows', '-a', '-F', '#{window_id}'],
-      stdout: 'pipe',
-      stderr: 'pipe',
-    });
-    if (p.exitCode !== 0) return;
-    const flat: string[] = [];
-    for (const id of p.stdout.toString().split('\n')) {
-      if (id.length === 0) continue;
-      if (flat.length > 0) flat.push(';');
-      flat.push('set', '-w', '-u', '-t', id, '@fleet_state');
-    }
-    if (flat.length > 0) Bun.spawnSync({ cmd: ['tmux', ...flat], stdout: 'ignore', stderr: 'ignore' });
-  } catch {
-    // Not in tmux — nothing to sweep.
+  const p = tmux(['list-windows', '-a', '-F', '#{window_id}']);
+  if (p.exitCode !== 0) return;
+  const flat: string[] = [];
+  for (const id of p.stdout.split('\n')) {
+    if (id.length === 0) continue;
+    if (flat.length > 0) flat.push(';');
+    flat.push('set', '-w', '-u', '-t', id, '@fleet_state');
   }
+  if (flat.length > 0) tmux(flat);
 }
 
 export function runStatusLineInject(): number {

--- a/src/state/engine.test.ts
+++ b/src/state/engine.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { fuseDiscoveredState, fuseState } from './engine.ts';
+import { fuseDiscoveredState, fuseState, hookStateForStatus } from './engine.ts';
 import { AgentStatus } from './types.ts';
 
 describe('fuseDiscoveredState', () => {
@@ -31,6 +31,18 @@ describe('fuseDiscoveredState', () => {
   });
 });
 
+describe('hookStateForStatus', () => {
+  test('round-trips every status the write path persists', () => {
+    // The inverse of mapHookState for the states verifyPaneState writes.
+    expect(hookStateForStatus(AgentStatus.PERMIT)).toBe('permit');
+    expect(hookStateForStatus(AgentStatus.QUESTION)).toBe('question');
+    expect(hookStateForStatus(AgentStatus.DONE)).toBe('done');
+    expect(hookStateForStatus(AgentStatus.BUSY)).toBe('working');
+    expect(hookStateForStatus(AgentStatus.IDLE)).toBe('idle');
+    expect(hookStateForStatus(AgentStatus.SHELL)).toBe('idle');
+  });
+});
+
 describe('fuseState', () => {
   const now = Math.floor(Date.now() / 1000);
 
@@ -40,26 +52,9 @@ describe('fuseState', () => {
       hookTs: now,
       eventStatus: null,
       scrapeStatus: null,
-      currentStatus: AgentStatus.IDLE,
-      currentTs: now - 10,
     });
     expect(result.status).toBe(AgentStatus.BUSY);
     expect(result.decision.winner).toBe('hook');
-  });
-
-  test('freshness invariant rejects stale hook data', () => {
-    const result = fuseState({
-      hookState: 'working',
-      hookTs: now - 100,
-      eventStatus: null,
-      scrapeStatus: null,
-      currentStatus: AgentStatus.DONE,
-      currentTs: now - 5,
-    });
-    expect(result.status).toBe(AgentStatus.DONE);
-    // Only the stale-hook shape reaches the freshness branch.
-    expect(result.decision.freshnessEvaluated).toBe(true);
-    expect(result.decision.winner).toBe('default');
   });
 
   test('event layer overrides hook when more specific', () => {
@@ -68,8 +63,6 @@ describe('fuseState', () => {
       hookTs: now,
       eventStatus: AgentStatus.BUSY,
       scrapeStatus: null,
-      currentStatus: AgentStatus.IDLE,
-      currentTs: now - 10,
     });
     expect(result.status).toBe(AgentStatus.BUSY);
     expect(result.decision.winner).toBe('event');
@@ -82,8 +75,6 @@ describe('fuseState', () => {
       eventStatus: AgentStatus.BUSY,
       scrapeStatus: AgentStatus.PERMIT,
       scrapeRuleId: 'permit.yn',
-      currentStatus: AgentStatus.BUSY,
-      currentTs: now - 5,
     });
     expect(result.status).toBe(AgentStatus.PERMIT);
     expect(result.decision.winner).toBe('scrape');
@@ -97,8 +88,6 @@ describe('fuseState', () => {
       hookTs: now,
       eventStatus: null,
       scrapeStatus: AgentStatus.PERMIT,
-      currentStatus: AgentStatus.IDLE,
-      currentTs: now - 10,
     });
     expect(result.status).toBe(AgentStatus.PERMIT);
     expect(result.decision.winner).toBe('scrape');
@@ -112,13 +101,8 @@ describe('fuseState', () => {
       hookTs: now - 3600,
       eventStatus: null,
       scrapeStatus: null,
-      currentStatus: AgentStatus.IDLE,
-      currentTs: 0,
     });
     expect(result.status).toBe(AgentStatus.DONE);
-    // Live wiring (currentStatus: IDLE, currentTs: 0) never reaches the freshness
-    // branch — this is the invariant fleet explain reports as "not evaluated".
-    expect(result.decision.freshnessEvaluated).toBe(false);
   });
 
   test('maps waiting to PERMIT', () => {
@@ -127,8 +111,6 @@ describe('fuseState', () => {
       hookTs: now,
       eventStatus: null,
       scrapeStatus: null,
-      currentStatus: AgentStatus.IDLE,
-      currentTs: now - 10,
     });
     expect(result.status).toBe(AgentStatus.PERMIT);
   });
@@ -141,8 +123,6 @@ describe('fuseState', () => {
       hookTs: now,
       eventStatus: null,
       scrapeStatus: AgentStatus.IDLE,
-      currentStatus: AgentStatus.IDLE,
-      currentTs: 0,
     });
     expect(result.status).toBe(AgentStatus.BUSY);
   });
@@ -155,8 +135,6 @@ describe('fuseState', () => {
       hookTs: now - 5,
       eventStatus: null,
       scrapeStatus: AgentStatus.IDLE,
-      currentStatus: AgentStatus.IDLE,
-      currentTs: 0,
     });
     expect(result.status).toBe(AgentStatus.IDLE);
     expect(result.decision.winner).toBe('scrape');
@@ -168,8 +146,6 @@ describe('fuseState', () => {
       hookTs: now,
       eventStatus: null,
       scrapeStatus: AgentStatus.BUSY,
-      currentStatus: AgentStatus.IDLE,
-      currentTs: 0,
     });
     expect(result.status).toBe(AgentStatus.BUSY);
     expect(result.decision.winner).toBe('scrape');
@@ -185,8 +161,6 @@ describe('fuseState', () => {
       hookTs: now,
       eventStatus: null,
       scrapeStatus: AgentStatus.IDLE,
-      currentStatus: AgentStatus.IDLE,
-      currentTs: 0,
     });
     expect(result.status).toBe(AgentStatus.DONE);
   });
@@ -197,11 +171,35 @@ describe('fuseState', () => {
       hookTs: now - 200,
       eventStatus: null,
       scrapeStatus: null,
-      currentStatus: AgentStatus.IDLE,
-      currentTs: 0,
     });
     expect(result.status).toBe(AgentStatus.IDLE);
     expect(result.decision.workingTimeoutFired).toBe(true);
     expect(result.decision.winner).toBe('default');
+  });
+
+  test('a fresh event BUSY is not decayed by a stale hook ts', () => {
+    // Decay anchors to the freshest activity signal: a long single tool run
+    // keeps the event ts fresh even when the status file has gone stale.
+    const result = fuseState({
+      hookState: 'working',
+      hookTs: now - 200,
+      eventStatus: AgentStatus.BUSY,
+      eventTs: now - 10,
+      scrapeStatus: null,
+    });
+    expect(result.status).toBe(AgentStatus.BUSY);
+    expect(result.decision.workingTimeoutFired).toBe(false);
+  });
+
+  test('event BUSY with a stale event ts still decays', () => {
+    const result = fuseState({
+      hookState: 'working',
+      hookTs: now - 300,
+      eventStatus: AgentStatus.BUSY,
+      eventTs: now - 200,
+      scrapeStatus: null,
+    });
+    expect(result.status).toBe(AgentStatus.IDLE);
+    expect(result.decision.workingTimeoutFired).toBe(true);
   });
 });

--- a/src/state/engine.ts
+++ b/src/state/engine.ts
@@ -6,11 +6,9 @@ export interface FuseInput {
   hookState: string;
   hookTs: number;
   eventStatus: AgentStatus | null;
-  eventTs?: number | null; // NEW (optional): last event ts, for the trace only
+  eventTs?: number | null; // last event ts — anchors BUSY decay and the trace
   scrapeStatus: AgentStatus | null;
-  scrapeRuleId?: string | null; // NEW (optional): matched scraper rule, for the trace only
-  currentStatus: AgentStatus;
-  currentTs: number;
+  scrapeRuleId?: string | null; // matched scraper rule, for the trace only
 }
 
 export interface FuseResult {
@@ -36,6 +34,24 @@ function mapHookState(state: string): AgentStatus {
   }
 }
 
+// Inverse of mapHookState for the write path (verifyPaneState persists a
+// scraped correction as a hook state). Kept next to its twin so the wire
+// vocabulary can't drift between the read and write sides.
+export function hookStateForStatus(status: AgentStatus): string {
+  switch (status) {
+    case AgentStatus.PERMIT:
+      return 'permit';
+    case AgentStatus.QUESTION:
+      return 'question';
+    case AgentStatus.DONE:
+      return 'done';
+    case AgentStatus.BUSY:
+      return 'working';
+    default:
+      return 'idle';
+  }
+}
+
 // Status for a hook-less discovered agent — the same fusion as the hook path
 // with the hook layer silenced. The scraper's positive reads (an on-screen
 // permission prompt, question dialog, or live token counter) outrank the
@@ -48,8 +64,6 @@ export function fuseDiscoveredState(working: boolean, scrapeStatus: AgentStatus 
     hookTs: now, // anchors the BUSY decay window at "fresh" so it can't fire here
     eventStatus: working ? AgentStatus.BUSY : null,
     scrapeStatus,
-    currentStatus: AgentStatus.IDLE,
-    currentTs: 0,
   }).status;
 }
 
@@ -65,7 +79,6 @@ export function fuseState(input: FuseInput): FuseResult {
     winner: 'hook',
     reason: '',
     workingTimeoutFired: false,
-    freshnessEvaluated: false,
     scrapeRuleId: input.scrapeRuleId ?? null,
   };
   const finish = (status: AgentStatus, winner: StateDecision['winner'], reason: string): FuseResult => {
@@ -74,28 +87,6 @@ export function fuseState(input: FuseInput): FuseResult {
     decision.reason = reason;
     return { status, decision };
   };
-
-  // Freshness invariant: a newer in-memory state beats a staler hook write.
-  // DEAD in live — index.ts passes currentTs=0, currentStatus=IDLE, so the second
-  // clause is always false and this branch never fires outside engine.test.ts.
-  if (input.hookTs <= input.currentTs && input.currentStatus !== AgentStatus.IDLE) {
-    decision.freshnessEvaluated = true;
-    const age = now - input.currentTs;
-    // A stuck "working" eventually retires — a crashed turn shouldn't spin
-    // forever. But DONE never auto-decays: a finished turn is waiting on you and
-    // stays "ready" until you actually act on it (switch to it, send, or it
-    // starts working again). Timing out a pending hand-off into "idle" is what
-    // made questions silently disappear.
-    if (input.currentStatus === AgentStatus.BUSY && age >= WORKING_TIMEOUT_SECS) {
-      decision.workingTimeoutFired = true;
-      return finish(AgentStatus.IDLE, 'default', `stale in-memory BUSY aged ${age}s ≥ ${WORKING_TIMEOUT_SECS}s`);
-    }
-    return finish(
-      input.currentStatus,
-      'default',
-      'freshness invariant: newer in-memory state kept over a staler hook write',
-    );
-  }
 
   // The scraper reliably reads permission prompts ([y/n], "Do you want to…") and
   // question dialogs ("Enter to select") — fixed on-screen strings the hook layer
@@ -110,10 +101,12 @@ export function fuseState(input: FuseInput): FuseResult {
 
   // Derive the hook/event activity status — the reliable BUSY/DONE signal.
   // PreToolUse fires the instant a tool runs; Stop fires when a turn ends.
+  // Decay anchors to the freshest activity signal (hook write OR event), so a
+  // fresh event-derived BUSY can't be retired by a stale hook ts.
   let derived = input.eventStatus ?? hookCandidate;
   const fromEvent = input.eventStatus !== null;
-  const hookAge = now - input.hookTs;
-  if (derived === AgentStatus.BUSY && hookAge >= WORKING_TIMEOUT_SECS) {
+  const activityAge = now - Math.max(input.hookTs, input.eventTs ?? 0);
+  if (derived === AgentStatus.BUSY && activityAge >= WORKING_TIMEOUT_SECS) {
     derived = AgentStatus.IDLE;
     decision.workingTimeoutFired = true;
   }
@@ -137,7 +130,7 @@ export function fuseState(input: FuseInput): FuseResult {
   // scrape null falls here too).
   const winner: StateDecision['winner'] = decision.workingTimeoutFired ? 'default' : fromEvent ? 'event' : 'hook';
   const reason = decision.workingTimeoutFired
-    ? `hook BUSY aged ${hookAge}s ≥ ${WORKING_TIMEOUT_SECS}s — decayed to idle`
+    ? `BUSY aged ${activityAge}s ≥ ${WORKING_TIMEOUT_SECS}s — decayed to idle`
     : fromEvent
       ? 'derived from the latest JSONL event'
       : 'derived from the hook status file';

--- a/src/state/events.ts
+++ b/src/state/events.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, openSync, readSync, fstatSync, closeSync } from 'node:fs';
+import { existsSync, openSync, readSync, fstatSync, closeSync } from 'node:fs';
 import { AgentStatus, type EventEntry } from './types.ts';
 
 const TAIL_BYTES = 8192;
@@ -22,42 +22,6 @@ export function parseEventLog(content: string): EventEntry[] {
     }
   }
   return entries;
-}
-
-export function readEventLog(path: string): EventEntry[] {
-  if (!existsSync(path)) return [];
-  try {
-    const content = readFileSync(path, 'utf-8');
-    return parseEventLog(content);
-  } catch {
-    return [];
-  }
-}
-
-export function readLastEvent(path: string): EventEntry | null {
-  if (!existsSync(path)) return null;
-  try {
-    const buf = readFileSync(path, 'utf-8');
-    let end = buf.length;
-    while (end > 0 && buf[end - 1] === '\n') end--;
-    if (end === 0) return null;
-    let start = buf.lastIndexOf('\n', end - 1);
-    if (start === -1) start = 0;
-    else start++;
-    const line = buf.slice(start, end);
-    if (line.length === 0) return null;
-    const data = JSON.parse(line) as Record<string, unknown>;
-    return {
-      event: String(data.event ?? ''),
-      ts: Number(data.ts ?? 0),
-      tool: data.tool != null ? String(data.tool) : undefined,
-      stop_reason: data.stop_reason != null ? String(data.stop_reason) : undefined,
-      background_tasks: data.background_tasks === true ? true : undefined,
-      notification_type: data.notification_type != null ? String(data.notification_type) : undefined,
-    };
-  } catch {
-    return null;
-  }
 }
 
 // Read just the last `maxLines` events without parsing the whole file — reads a
@@ -84,11 +48,6 @@ export function readLastEvents(path: string, maxLines: number): EventEntry[] {
   } catch {
     return [];
   }
-}
-
-export function deriveStatusFromLastEvent(event: EventEntry | null): AgentStatus | null {
-  if (!event) return null;
-  return deriveStatusFromEvents([event]);
 }
 
 export function deriveStatusFromEvents(events: EventEntry[]): AgentStatus | null {

--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -1,7 +1,29 @@
-import { readdirSync, readFileSync, existsSync, watch } from 'node:fs';
+import { readdirSync, readFileSync, existsSync, watch, writeFileSync, renameSync } from 'node:fs';
 import { join } from 'node:path';
 import type { HookStatus, ResolvedHookStatus } from './types.ts';
 import type { AgentDir } from '../agents/config.ts';
+
+// The `.status` / `.events.jsonl` filename convention, named once. Keyed by the
+// pane number (`%12` -> `12`), matching what hooks/lib.sh writes.
+export function paneNum(paneId: string): string {
+  return paneId.replace('%', '');
+}
+
+export function statusFilePath(dir: string, paneId: string): string {
+  return join(dir, `${paneNum(paneId)}.status`);
+}
+
+export function eventsFilePath(dir: string, paneId: string): string {
+  return join(dir, `${paneNum(paneId)}.events.jsonl`);
+}
+
+// Write-then-rename so a concurrent reader never sees a truncated file —
+// rename is atomic within a filesystem.
+export function writeFileAtomic(path: string, content: string): void {
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, content);
+  renameSync(tmp, path);
+}
 
 export function parseStatusFile(content: string): HookStatus | null {
   try {

--- a/src/state/scraper.ts
+++ b/src/state/scraper.ts
@@ -63,25 +63,25 @@ export function detectFromTitle(title: string, manifest: DetectionManifest): Det
   return { status: null, ruleId: null };
 }
 
-// Capture a pane ONCE and return both its classified status and the raw captured
-// lines. A caller that also needs the capture (hook-less discovery's spinner-glyph
-// check) reuses these lines instead of capturing the same pane a second time.
-// scrapePane is exactly this minus the lines.
-export function scrapePaneCapture(paneId: string, agent: string): { status: AgentStatus | null; lines: string[] } {
-  let lines: string[];
+// Capture a pane's bottom window WITHOUT classifying — the slow tick captures
+// every pane once, resolves each pane's agent identity (hook or discovery),
+// then classifies each capture exactly once with the right manifest. Empty on
+// capture failure so callers degrade to "no scrape read".
+export function capturePaneLines(paneId: string): string[] {
   try {
-    lines = capturePane(paneId, SCRAPE_LINES);
+    return capturePane(paneId, SCRAPE_LINES);
   } catch {
-    return { status: null, lines: [] };
+    return [];
   }
-  // Phase 3: the agent is real (was hardcoded 'claude'). Resolve its manifest
-  // (built-in, or a user override) so each agent's prompts classify against its
-  // own rules; an unknown agent degrades to an empty manifest (detects nothing).
-  return { status: detectFromPaneContent(lines, loadDetectionManifest(agent)).status, lines };
 }
 
 export function scrapePane(paneId: string, agent: string): AgentStatus | null {
-  return scrapePaneCapture(paneId, agent).status;
+  const lines = capturePaneLines(paneId);
+  if (lines.length === 0) return null;
+  // Resolve the agent's manifest (built-in, or a user override) so each agent's
+  // prompts classify against its own rules; an unknown agent degrades to an
+  // empty manifest (detects nothing).
+  return detectFromPaneContent(lines, loadDetectionManifest(agent)).status;
 }
 
 export interface ScrapeDetail {

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -36,6 +36,31 @@ export function compareStatus(a: AgentStatus, b: AgentStatus): number {
   return PRIORITY[a] - PRIORITY[b];
 }
 
+// Statuses where it's the user's turn to act: blocked on a permission prompt,
+// asking a question, or finished and waiting on the next move. The single
+// source of truth for "needs you" — the status line, window tints, and
+// `fleet next` all consume this set.
+export const ATTENTION_STATES: ReadonlySet<AgentStatus> = new Set([
+  AgentStatus.PERMIT,
+  AgentStatus.QUESTION,
+  AgentStatus.DONE,
+]);
+
+export function needsAttention(status: AgentStatus): boolean {
+  return ATTENTION_STATES.has(status);
+}
+
+// Compact age string shared by the TUI, status line, and explain trace.
+// Takes a delta (not a ts) so callers under test stay deterministic.
+export function formatAgeDelta(deltaSecs: number): string {
+  const d = Math.max(0, deltaSecs);
+  if (d < 5) return 'now';
+  if (d < 60) return `${d}s`;
+  if (d < 3600) return `${Math.floor(d / 60)}m`;
+  if (d < 86400) return `${Math.floor(d / 3600)}h`;
+  return `${Math.floor(d / 86400)}d`;
+}
+
 // `color` is a tmux color name (not a hex value): it is consumed only by the
 // tmux status line via `#[fg=...]`, where named colors resolve against the
 // terminal's own palette so they stay readable on light and dark themes alike.
@@ -66,6 +91,9 @@ export interface AgentState {
   ports: number[];
   ts: number;
   agentType: string;
+  // Raw #{pane_title} (optional — populated by refreshStates so explain can
+  // trace the same title rules the live fusion used).
+  paneTitle?: string;
 }
 
 export function extractClaudeName(paneTitle: string): string | null {
@@ -86,6 +114,13 @@ export const FLEET_PANE_TITLE = 'fleet';
 export function sessionLabel(state: AgentState): string {
   const label = windowLabel(state);
   return label === state.session ? state.session : `${state.session}:${label}`;
+}
+
+// Bracketed variant for modal headers (preview, kill confirm): the window
+// label with the session in brackets when they differ.
+export function whereLabel(state: AgentState): string {
+  const label = windowLabel(state);
+  return label === state.session ? state.session : `${label} [${state.session}]`;
 }
 
 // Window-first label: the window name is what distinguishes agents; the
@@ -161,6 +196,5 @@ export interface StateDecision {
   winner: 'hook' | 'event' | 'scrape' | 'default';
   reason: string; // human-readable why
   workingTimeoutFired: boolean;
-  freshnessEvaluated: boolean; // MUST be false under live wiring — see engine notes
   scrapeRuleId: string | null;
 }

--- a/src/terminal/ansi.ts
+++ b/src/terminal/ansi.ts
@@ -1,5 +1,7 @@
+// CSI sequences, plus OSC strings (hyperlinks, titles) terminated by BEL/ST —
+// an unterminated OSC (truncated capture) strips to end of string.
 // oxlint-disable-next-line no-control-regex
-const ANSI_PATTERN = /\x1b\[[0-9;:]*[@-~]/g;
+const ANSI_PATTERN = /\x1b(?:\[[0-9;:]*[@-~]|\][^\x07\x1b]*(?:\x07|\x1b\\)?)/g;
 
 export function stripAnsi(value: string): string {
   return value.replace(ANSI_PATTERN, '');
@@ -17,11 +19,20 @@ export function oscTitle(title: string): string {
 
 function charWidth(codePoint: number): number {
   if (codePoint < 0x20 || codePoint === 0x7f) return 0;
-  // Zero-width joiners, variation selectors.
+  // Zero-width: joiners, variation selectors (incl. the supplement plane),
+  // and combining marks (diacriticals, kana voicing, half marks) — these
+  // attach to the previous glyph and occupy no column of their own.
   if (
     codePoint === 0xfe0f ||
     (codePoint >= 0x200d && codePoint <= 0x200f) ||
-    (codePoint >= 0xfe00 && codePoint <= 0xfe0e)
+    (codePoint >= 0xfe00 && codePoint <= 0xfe0e) ||
+    (codePoint >= 0x0300 && codePoint <= 0x036f) ||
+    (codePoint >= 0x1ab0 && codePoint <= 0x1aff) ||
+    (codePoint >= 0x1dc0 && codePoint <= 0x1dff) ||
+    (codePoint >= 0x20d0 && codePoint <= 0x20ff) ||
+    (codePoint >= 0x3099 && codePoint <= 0x309a) ||
+    (codePoint >= 0xfe20 && codePoint <= 0xfe2f) ||
+    (codePoint >= 0xe0100 && codePoint <= 0xe01ef)
   )
     return 0;
   // Wide: CJK, emoji, fullwidth forms.
@@ -34,8 +45,7 @@ function charWidth(codePoint: number): number {
     (codePoint >= 0xff01 && codePoint <= 0xff60) ||
     (codePoint >= 0xffe0 && codePoint <= 0xffe6) ||
     (codePoint >= 0x1f000 && codePoint <= 0x1fbff) ||
-    (codePoint >= 0x20000 && codePoint <= 0x3ffff) ||
-    (codePoint >= 0xe0100 && codePoint <= 0xe01ef)
+    (codePoint >= 0x20000 && codePoint <= 0x3ffff)
   )
     return 2;
   return 1;
@@ -93,6 +103,25 @@ export function truncateAnsi(value: string, maxWidth: number): string {
         i += 1;
         const code = next.charCodeAt(0);
         if (code >= 0x40 && code <= 0x7e) {
+          break;
+        }
+      }
+      continue;
+    }
+    // OSC string (hyperlink, title): copy through to BEL / ST so truncation
+    // can't split it mid-sequence; its bytes are zero-width.
+    if (ch === '\x1b' && value[i + 1] === ']') {
+      output += ch;
+      output += value[i + 1]!;
+      i += 2;
+      while (i < value.length) {
+        const next = value[i]!;
+        output += next;
+        i += 1;
+        if (next === '\x07') break;
+        if (next === '\x1b' && value[i] === '\\') {
+          output += value[i]!;
+          i += 1;
           break;
         }
       }

--- a/src/terminal/input.ts
+++ b/src/terminal/input.ts
@@ -8,53 +8,80 @@ export type KeyEvent =
   | { type: 'ctrl'; char: string }
   | { type: 'unknown' };
 
-export function parseKeyEvent(data: Buffer): KeyEvent {
-  if (data.length === 0) return { type: 'unknown' };
+// Parse one key event starting at `offset`, returning the event and the offset
+// just past its bytes — so a read that coalesced several keystrokes (fast
+// typing, SSH batching, paste) yields every key instead of only the first.
+function parseOneKey(data: Buffer, offset: number): { event: KeyEvent; next: number } {
+  const first = data[offset]!;
 
-  const first = data[0]!;
-
-  // Escape sequence (arrows, etc.)
+  // Escape sequence (arrows, other CSI)
   if (first === 0x1b) {
-    if (data.length === 1) return { type: 'escape' };
-    if (data.length >= 3 && data[1] === 0x5b /* '[' */) {
-      const final = data[2];
-      switch (final) {
-        case 0x41 /* A */:
-          return { type: 'arrow', direction: 'up' };
-        case 0x42 /* B */:
-          return { type: 'arrow', direction: 'down' };
-        case 0x43 /* C */:
-          return { type: 'arrow', direction: 'right' };
-        case 0x44 /* D */:
-          return { type: 'arrow', direction: 'left' };
-        default:
-          return { type: 'unknown' };
+    if (data[offset + 1] === 0x5b /* '[' */) {
+      // Consume the full CSI sequence: parameters, then a final byte @-~.
+      let i = offset + 2;
+      while (i < data.length) {
+        const b = data[i]!;
+        i++;
+        if (b >= 0x40 && b <= 0x7e) {
+          if (i - offset === 3) {
+            switch (b) {
+              case 0x41 /* A */:
+                return { event: { type: 'arrow', direction: 'up' }, next: i };
+              case 0x42 /* B */:
+                return { event: { type: 'arrow', direction: 'down' }, next: i };
+              case 0x43 /* C */:
+                return { event: { type: 'arrow', direction: 'right' }, next: i };
+              case 0x44 /* D */:
+                return { event: { type: 'arrow', direction: 'left' }, next: i };
+            }
+          }
+          return { event: { type: 'unknown' }, next: i };
+        }
       }
+      // Incomplete CSI at end of buffer — treat as escape, drop the tail.
+      return { event: { type: 'escape' }, next: data.length };
     }
-    return { type: 'escape' };
+    return { event: { type: 'escape' }, next: offset + 1 };
   }
 
   // Enter (CR only — 0x0A/LF is Ctrl-J, handled below)
-  if (first === 0x0d) return { type: 'enter' };
+  if (first === 0x0d) return { event: { type: 'enter' }, next: offset + 1 };
   // Backspace (DEL only — 0x08/BS is Ctrl-H, handled below)
-  if (first === 0x7f) return { type: 'backspace' };
-  if (first === 0x09) return { type: 'tab' };
+  if (first === 0x7f) return { event: { type: 'backspace' }, next: offset + 1 };
+  if (first === 0x09) return { event: { type: 'tab' }, next: offset + 1 };
 
-  // Control characters (Ctrl-A..Ctrl-Z except CR/LF/Tab/BS handled above)
+  // Control characters (Ctrl-A..Ctrl-Z except CR/Tab handled above)
   if (first >= 0x01 && first <= 0x1a) {
-    const char = String.fromCharCode(first + 0x60);
-    return { type: 'ctrl', char };
+    return { event: { type: 'ctrl', char: String.fromCharCode(first + 0x60) }, next: offset + 1 };
   }
 
-  // Printable ASCII + extended (multi-byte UTF-8 first byte)
+  // Printable ASCII
   if (first >= 0x20 && first <= 0x7e) {
-    return { type: 'char', char: String.fromCharCode(first) };
+    return { event: { type: 'char', char: String.fromCharCode(first) }, next: offset + 1 };
   }
 
-  // UTF-8 multi-byte
+  // UTF-8 multi-byte lead — length from the lead byte, clamped to the buffer.
   if (first >= 0xc0) {
-    return { type: 'char', char: data.toString('utf8') };
+    const len = first >= 0xf0 ? 4 : first >= 0xe0 ? 3 : 2;
+    const end = Math.min(offset + len, data.length);
+    return { event: { type: 'char', char: data.subarray(offset, end).toString('utf8') }, next: end };
   }
 
-  return { type: 'unknown' };
+  return { event: { type: 'unknown' }, next: offset + 1 };
+}
+
+export function parseKeyEvents(data: Buffer): KeyEvent[] {
+  const events: KeyEvent[] = [];
+  let offset = 0;
+  while (offset < data.length) {
+    const { event, next } = parseOneKey(data, offset);
+    events.push(event);
+    offset = next;
+  }
+  return events;
+}
+
+export function parseKeyEvent(data: Buffer): KeyEvent {
+  if (data.length === 0) return { type: 'unknown' };
+  return parseOneKey(data, 0).event;
 }

--- a/src/terminal/terminal.ts
+++ b/src/terminal/terminal.ts
@@ -9,7 +9,6 @@ const ENTER_ALT_SCREEN = '\x1b[?1049h';
 const LEAVE_ALT_SCREEN = '\x1b[?1049l';
 const HIDE_CURSOR = '\x1b[?25l';
 const SHOW_CURSOR = '\x1b[?25h';
-const CLEAR_SCREEN = '\x1b[2J\x1b[H';
 const ENABLE_MOUSE = '\x1b[?1002h\x1b[?1003h\x1b[?1006h';
 const DISABLE_MOUSE = '\x1b[?1002l\x1b[?1003l\x1b[?1006l';
 
@@ -87,14 +86,6 @@ export function clearPaneTitle(): void {
   process.stdout.write(oscTitle(''));
 }
 
-export function moveCursor(row: number, col: number): string {
-  return `\x1b[${row};${col}H`;
-}
-
-export function clearScreen(): void {
-  process.stdout.write(CLEAR_SCREEN);
-}
-
 export function getTerminalSize(): TerminalSize {
   return {
     rows: process.stdout.rows ?? 24,
@@ -137,15 +128,4 @@ function registerCleanup(): void {
     console.error(reason);
     process.exit(1);
   });
-}
-
-export async function withTerminal<T>(fn: () => Promise<T> | T): Promise<T> {
-  enterAlternateScreen();
-  hideCursor();
-  enterRawMode();
-  try {
-    return await fn();
-  } finally {
-    restore();
-  }
 }

--- a/src/terminal/theme.ts
+++ b/src/terminal/theme.ts
@@ -1,4 +1,6 @@
 // src/terminal/theme.ts
+import { getTmuxOption } from '../tmux/ipc.ts';
+
 export type ThemeMode = 'light' | 'dark';
 
 export interface Rgb {
@@ -77,14 +79,7 @@ export function shouldQueryOsc(env: { TMUX?: string; FLEET_THEME?: string }, tmu
 // ---- I/O section: reads env/tmux/OS and performs the OSC 11 round-trip ----
 
 export function readTmuxThemeOption(): string | null {
-  try {
-    const p = Bun.spawnSync({ cmd: ['tmux', 'show', '-gqv', '@fleet-theme'], stdout: 'pipe', stderr: 'pipe' });
-    if (p.exitCode !== 0) return null;
-    const v = p.stdout.toString().trim();
-    return v.length > 0 ? v : null;
-  } catch {
-    return null;
-  }
+  return getTmuxOption('@fleet-theme');
 }
 
 export function readMacAppearance(): 'Dark' | 'Light' | null {

--- a/src/tmux/ipc.ts
+++ b/src/tmux/ipc.ts
@@ -5,16 +5,21 @@ export interface TmuxResult {
 }
 
 export function tmux(args: string[]): TmuxResult {
-  const proc = Bun.spawnSync({
-    cmd: ['tmux', ...args],
-    stdout: 'pipe',
-    stderr: 'pipe',
-  });
-  return {
-    exitCode: proc.exitCode ?? -1,
-    stdout: proc.stdout.toString(),
-    stderr: proc.stderr.toString(),
-  };
+  try {
+    const proc = Bun.spawnSync({
+      cmd: ['tmux', ...args],
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    return {
+      exitCode: proc.exitCode ?? -1,
+      stdout: proc.stdout.toString(),
+      stderr: proc.stderr.toString(),
+    };
+  } catch (err) {
+    // tmux binary missing / spawn failure — same shape as a failed command.
+    return { exitCode: -1, stdout: '', stderr: err instanceof Error ? err.message : String(err) };
+  }
 }
 
 export function tmuxOrNull(args: string[]): string | null {
@@ -22,6 +27,12 @@ export function tmuxOrNull(args: string[]): string | null {
   if (result.exitCode !== 0) return null;
   const out = result.stdout.trim();
   return out.length > 0 ? out : null;
+}
+
+// `show -gqv` exits 0 with empty output for an unset option — normalized to
+// null here so every option read shares one copy of that semantic.
+export function getTmuxOption(name: string): string | null {
+  return tmuxOrNull(['show', '-gqv', name]);
 }
 
 export function tmuxOrThrow(args: string[], label: string): string {

--- a/src/tmux/ports.ts
+++ b/src/tmux/ports.ts
@@ -1,24 +1,14 @@
-import { tmux } from './ipc.ts';
+import { walkToPane } from '../agents/discovery.ts';
 
 export interface PanePort {
   paneId: string;
   port: number;
 }
 
-export function detectPorts(): PanePort[] {
-  const paneResult = tmux(['list-panes', '-a', '-F', '#{pane_id}:#{pane_pid}']);
-  if (paneResult.exitCode !== 0) return [];
-
-  const panePids = new Map<number, string>();
-  for (const line of paneResult.stdout.split('\n')) {
-    if (line.length === 0) continue;
-    const [paneId, pidStr] = line.split(':');
-    if (paneId && pidStr) {
-      const pid = parseInt(pidStr, 10);
-      if (!Number.isNaN(pid)) panePids.set(pid, paneId);
-    }
-  }
-
+// Map listening TCP ports to the tmux pane hosting the listener. `panePids`
+// (pane_pid -> paneId) and `ppidByPid` come from the caller's single
+// list-panes + ps pass, so this adds only the one `lsof` spawn.
+export function detectPorts(panePids: Map<number, string>, ppidByPid: Map<number, number>): PanePort[] {
   if (panePids.size === 0) return [];
 
   const proc = Bun.spawnSync({
@@ -39,7 +29,7 @@ export function detectPorts(): PanePort[] {
       if (match) {
         const port = parseInt(match[1]!, 10);
         if (port >= 1024) {
-          const paneId = findPaneForPid(currentPid, panePids);
+          const paneId = walkToPane(currentPid, ppidByPid, panePids);
           if (paneId) {
             results.push({ paneId, port });
           }
@@ -49,24 +39,4 @@ export function detectPorts(): PanePort[] {
   }
 
   return results;
-}
-
-function findPaneForPid(pid: number, panePids: Map<number, string>): string | null {
-  let checkPid = pid;
-  const visited = new Set<number>();
-  while (checkPid > 1 && !visited.has(checkPid)) {
-    visited.add(checkPid);
-    const paneId = panePids.get(checkPid);
-    if (paneId) return paneId;
-    const proc = Bun.spawnSync({
-      cmd: ['ps', '-o', 'ppid=', '-p', String(checkPid)],
-      stdout: 'pipe',
-      stderr: 'pipe',
-    });
-    if (proc.exitCode !== 0) break;
-    const ppid = parseInt(proc.stdout.toString().trim(), 10);
-    if (Number.isNaN(ppid) || ppid <= 1) break;
-    checkPid = ppid;
-  }
-  return null;
 }

--- a/src/tmux/send.ts
+++ b/src/tmux/send.ts
@@ -7,7 +7,9 @@ export function sendKeys(paneId: string, text: string): void {
     if (i > 0) {
       tmuxOrThrow(['send-keys', '-t', paneId, 'M-Enter'], 'send-keys M-Enter failed');
     }
-    tmuxOrThrow(['send-keys', '-t', paneId, '-l', line], 'send-keys failed');
+    // `--` ends option parsing: a line starting with `-` (markdown bullet,
+    // CLI flag) would otherwise be read as a send-keys option and fail.
+    tmuxOrThrow(['send-keys', '-t', paneId, '-l', '--', line], 'send-keys failed');
   }
   tmuxOrThrow(['send-keys', '-t', paneId, 'Enter'], 'send-keys Enter failed');
 }
@@ -49,5 +51,5 @@ export function sendRawKey(paneId: string, data: Buffer): void {
     return;
   }
 
-  tmuxOrThrow(['send-keys', '-t', paneId, '-l', data.toString('utf8')], 'send-keys literal failed');
+  tmuxOrThrow(['send-keys', '-t', paneId, '-l', '--', data.toString('utf8')], 'send-keys literal failed');
 }

--- a/src/tmux/sessions.ts
+++ b/src/tmux/sessions.ts
@@ -46,7 +46,9 @@ export function parsePanesOutput(stdout: string): PaneInfo[] {
       panePid: parseInt(parts[6]!, 10),
       // pane_active/window_active are 1/0; session_attached counts clients.
       focused: parts[7] === '1' && parts[8] === '1' && parseInt(parts[9]!, 10) > 0,
-      paneTitle: parts[10]!,
+      // Title is the last field, so a tab inside it split into extra parts —
+      // rejoin them instead of silently truncating at the first tab.
+      paneTitle: parts.slice(10).join('\t'),
     });
   }
   return panes;

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -54,10 +54,21 @@ export class TuiApp {
   pulsePhase: boolean = false;
   private lastClickPaneId: string | null = null;
   private lastClickTs: number = 0;
+  // visibleStates()/dashboardRows() are pure over (states, filter) but consumed
+  // several times per frame (render, selection, hit-testing) — memoized here
+  // and invalidated by the only mutations that change them.
+  private visibleCache: AgentState[] | null = null;
+  private rowsCache: DashboardRow[] | null = null;
+
+  private invalidateViews(): void {
+    this.visibleCache = null;
+    this.rowsCache = null;
+  }
 
   updateStates(newStates: AgentState[]): void {
     const selectedPaneId = this.selectedState()?.paneId ?? null;
     this.states = newStates;
+    this.invalidateViews();
 
     if (this.hoverPaneId && !newStates.some((s) => s.paneId === this.hoverPaneId)) {
       this.hoverPaneId = null;
@@ -88,6 +99,7 @@ export class TuiApp {
   // group, rows sort by urgency then window name. dashboardRows() derives from
   // this, so selection indices stay valid against this list.
   visibleStates(): AgentState[] {
+    if (this.visibleCache) return this.visibleCache;
     const sorted = this.sortedStates();
     const noShell = sorted.filter((s) => s.status !== AgentStatus.SHELL && s.status !== AgentStatus.DOWN);
     const filtered = this.applyFilter(noShell);
@@ -108,10 +120,12 @@ export class TuiApp {
       });
       out.push(...members);
     }
+    this.visibleCache = out;
     return out;
   }
 
   dashboardRows(): DashboardRow[] {
+    if (this.rowsCache) return this.rowsCache;
     const states = this.visibleStates();
     const rows: DashboardRow[] = [];
     let i = 0;
@@ -134,6 +148,7 @@ export class TuiApp {
       }
       i = j;
     }
+    this.rowsCache = rows;
     return rows;
   }
 
@@ -173,6 +188,7 @@ export class TuiApp {
     this.filter = text;
     this.filtering = true;
     this.selectedIndex = 0;
+    this.invalidateViews();
   }
 
   getFilter(): string {
@@ -187,6 +203,7 @@ export class TuiApp {
     this.filter = '';
     this.filtering = false;
     this.selectedIndex = 0;
+    this.invalidateViews();
   }
 
   enterSend(): void {

--- a/src/tui/dashboard.test.ts
+++ b/src/tui/dashboard.test.ts
@@ -4,7 +4,7 @@ import { disableColors } from '../terminal/colors.ts';
 disableColors();
 
 import { computeColumnWidths, paneTitle, renderHeader, renderSessionList, stateAtLine } from './dashboard.ts';
-import { TuiApp, type Summary } from './app.ts';
+import { TuiApp } from './app.ts';
 import { stripAnsi, visibleLength } from '../terminal/ansi.ts';
 import { AgentStatus, type AgentState } from '../state/types.ts';
 
@@ -270,24 +270,15 @@ describe('header summary strip', () => {
 });
 
 describe('paneTitle', () => {
-  const summary = (extra: Partial<Summary> = {}): Summary => ({
-    total: 0,
-    permit: 0,
-    question: 0,
-    done: 0,
-    busy: 0,
-    ...extra,
-  });
-
-  test('identifies the app when the fleet is quiet', () => {
-    expect(paneTitle(summary(), 0)).toBe('fleet');
+  test('identifies the app', () => {
+    expect(paneTitle()).toBe('fleet');
   });
 
   test('never starts with the Claude title marker', () => {
     // extractClaudeName treats a leading ✳ as "this pane is a Claude agent";
     // fleet's own title must never be mistaken for one.
-    const busy = paneTitle(summary({ total: 5, busy: 2, permit: 1, question: 1, done: 1 }), 0);
-    expect(busy.startsWith('✳')).toBe(false);
-    expect(busy.length).toBeGreaterThan(0);
+    const title = paneTitle();
+    expect(title.startsWith('✳')).toBe(false);
+    expect(title.length).toBeGreaterThan(0);
   });
 });

--- a/src/tui/dashboard.ts
+++ b/src/tui/dashboard.ts
@@ -1,11 +1,11 @@
 import { C } from '../terminal/colors.ts';
 import { truncateAnsi } from '../terminal/ansi.ts';
 import { AgentStatus, FLEET_PANE_TITLE, type AgentState } from '../state/types.ts';
-import { TuiMode, type TuiApp, type Summary } from './app.ts';
+import { TuiMode, type TuiApp } from './app.ts';
 import { buildTableLines } from './layouts/table.ts';
 import { buildCardLines } from './layouts/cards.ts';
 import { pickLayout } from './layouts/index.ts';
-import { windowLines, type LayoutLines } from './layouts/shared.ts';
+import { chip, windowLines, type LayoutLines } from './layouts/shared.ts';
 
 const BOX_H = '─';
 
@@ -38,11 +38,10 @@ function logo(): string {
 // which extractClaudeName treats as a Claude agent marker.
 //
 // TODO(nicknisi): decide what the window name says in each state — e.g.
-// all quiet vs. "fleet ◉2" (busy) vs. "fleet ⚠1" (needs you). Inputs:
-// s.busy / s.permit / s.question / s.done, and shellCount to derive the
-// agent count like renderHeader does. Keep it short — it lives in the
-// tmux status bar next to your other window names.
-export function paneTitle(_s: Summary, _shellCount: number): string {
+// all quiet vs. "fleet ◉2" (busy) vs. "fleet ⚠1" (needs you). Inputs would
+// be app.summary() / app.shellCount() (add parameters back then). Keep it
+// short — it lives in the tmux status bar next to your other window names.
+export function paneTitle(): string {
   return FLEET_PANE_TITLE;
 }
 
@@ -67,11 +66,11 @@ function buildLines(app: TuiApp, cols: number): LayoutLines {
   return pickLayout(cols) === 'cards' ? buildCardLines(app, cols) : buildTableLines(app, cols);
 }
 
-// Line index (chrome lines included) of the selected agent within built lines.
-function selectedLineIndex(app: TuiApp, cols: number): number {
+// Line index (chrome lines included) of the selected agent within `built` —
+// takes the already-built lines so callers never build the layout twice.
+function selectedLineIndex(app: TuiApp, built: LayoutLines): number {
   const selected = app.selectedState();
   if (!selected) return 0;
-  const built = buildLines(app, cols);
   return Math.max(
     0,
     built.states.findIndex((s) => s?.paneId === selected.paneId),
@@ -106,14 +105,16 @@ export function renderSessionList(app: TuiApp, maxRows: number, cols: number): s
     return lines;
   }
 
-  return windowLines(buildLines(app, cols), selectedLineIndex(app, cols), maxRows).lines;
+  const built = buildLines(app, cols);
+  return windowLines(built, selectedLineIndex(app, built), maxRows).lines;
 }
 
 // Map a clicked session-list line (0 = first rendered line) back to the agent
 // on that line, accounting for scroll, header rows, and scroll indicators.
 // Chrome lines (headers, indicators) map to null.
 export function stateAtLine(app: TuiApp, lineIdx: number, maxRows: number, cols: number): AgentState | null {
-  const windowed = windowLines(buildLines(app, cols), selectedLineIndex(app, cols), maxRows);
+  const built = buildLines(app, cols);
+  const windowed = windowLines(built, selectedLineIndex(app, built), maxRows);
   return windowed.states[lineIdx] ?? null;
 }
 
@@ -180,10 +181,6 @@ export function renderFooter(app: TuiApp, cols: number): string[] {
   }
 
   return lines;
-}
-
-function chip(key: string): string {
-  return `${C.dim}[${C.reset}${C.bold}${key}${C.reset}${C.dim}]${C.reset}`;
 }
 
 export { computeColumnWidths, type ColumnWidths } from './layouts/table.ts';

--- a/src/tui/kill.ts
+++ b/src/tui/kill.ts
@@ -1,5 +1,5 @@
 import { C } from '../terminal/colors.ts';
-import { AgentStatus, windowLabel, type AgentState } from '../state/types.ts';
+import { AgentStatus, whereLabel, type AgentState } from '../state/types.ts';
 
 // Killing is destructive, so it gets the same state gating as send: refuse the
 // states where the agent is mid-thought or blocked on you. You can still reap
@@ -23,8 +23,7 @@ export function canKillSession(state: AgentState): { ok: boolean; reason: string
 export function renderKillConfirm(state: AgentState): string[] {
   const lines: string[] = [];
   const check = canKillSession(state);
-  const windowName = windowLabel(state);
-  const where = windowName === state.session ? state.session : `${windowName} [${state.session}]`;
+  const where = whereLabel(state);
   const label = state.claudeName ? `${where} (${state.claudeName})` : where;
 
   lines.push(`${C.bold}Kill ${label}?${C.reset}`);

--- a/src/tui/layouts/shared.ts
+++ b/src/tui/layouts/shared.ts
@@ -1,6 +1,18 @@
 import { C } from '../../terminal/colors.ts';
-import { AgentStatus, STATUS_DISPLAY, sessionDisplay, windowLabel, type AgentState } from '../../state/types.ts';
+import {
+  AgentStatus,
+  STATUS_DISPLAY,
+  formatAgeDelta,
+  sessionDisplay,
+  windowLabel,
+  type AgentState,
+} from '../../state/types.ts';
 import type { DashboardRow } from '../app.ts';
+
+// Bracketed key hint (e.g. `[q]`), shared by the footer and preview chrome.
+export function chip(key: string): string {
+  return `${C.dim}[${C.reset}${C.bold}${key}${C.reset}${C.dim}]${C.reset}`;
+}
 
 // One entry per rendered line: states[i] is the agent on lines[i], or null for
 // chrome lines (headers, separators, indicators). Render and hit-testing both
@@ -57,12 +69,7 @@ export function getAgeColor(ts: number): string {
 }
 
 export function formatAge(ts: number): string {
-  const secs = Math.max(0, Math.floor(Date.now() / 1000) - ts);
-  if (secs < 5) return 'now';
-  if (secs < 60) return `${secs}s`;
-  if (secs < 3600) return `${Math.floor(secs / 60)}m`;
-  if (secs < 86400) return `${Math.floor(secs / 3600)}h`;
-  return `${Math.floor(secs / 86400)}d`;
+  return formatAgeDelta(Math.floor(Date.now() / 1000) - ts);
 }
 
 export function calculateScroll(selected: number, viewHeight: number, total: number): number {

--- a/src/tui/preview.ts
+++ b/src/tui/preview.ts
@@ -1,7 +1,8 @@
 import { C } from '../terminal/colors.ts';
 import { truncateAnsi } from '../terminal/ansi.ts';
-import { AgentStatus, STATUS_DISPLAY, windowLabel, type AgentState } from '../state/types.ts';
+import { AgentStatus, STATUS_DISPLAY, whereLabel, type AgentState } from '../state/types.ts';
 import { capturePane } from '../tmux/sessions.ts';
+import { chip } from './layouts/shared.ts';
 
 export function previewActions(state: AgentState): string {
   switch (state.status) {
@@ -19,10 +20,6 @@ export function previewActions(state: AgentState): string {
   }
 }
 
-function chip(key: string): string {
-  return `${C.dim}[${C.reset}${C.bold}${key}${C.reset}${C.dim}]${C.reset}`;
-}
-
 export function renderPreview(
   state: AgentState,
   width: number,
@@ -34,9 +31,7 @@ export function renderPreview(
 
   const modeTag = passthrough ? ` ${C.cyan}● LIVE${C.reset}` : '';
   const claudeInfo = state.claudeName ? ` · ${state.claudeName}` : '';
-  const label = windowLabel(state);
-  const where = label === state.session ? state.session : `${label} [${state.session}]`;
-  const title = `${display.icon} ${where} · ${display.label.toUpperCase()}${claudeInfo}${modeTag}`;
+  const title = `${display.icon} ${whereLabel(state)} · ${display.label.toUpperCase()}${claudeInfo}${modeTag}`;
   const toolInfo = state.tool ? ` · ${state.tool}` : '';
   const portInfo = state.ports.length > 0 ? ` · ⌁${state.ports.join(',')}` : '';
   lines.push(truncateAnsi(`${C.bold}${title}${C.reset}${C.gray}${toolInfo}${portInfo}${C.reset}`, width));

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -28,8 +28,27 @@ export function render(app: TuiApp, size: TerminalSize): string {
   }
 
   const footerLines = renderFooter(app, cols);
-  const contentRows = rows - headerLines.length - footerLines.length - 1;
+  // Every row between header and footer — all of them are written each frame
+  // (the fill loop below), so no row can carry a stale previous frame.
+  const contentRows = rows - headerLines.length - footerLines.length;
   let linesWritten = 0;
+
+  // SEND/RENAME/CONFIRM_KILL share one modal shape: a spacer, then the modal's
+  // lines. null = not a modal mode (or nothing selected — fill loop blanks it).
+  const modalLines = ((): string[] | null => {
+    const selected = app.selectedState();
+    if (!selected) return null;
+    switch (app.mode) {
+      case TuiMode.SEND:
+        return renderSendMode(selected, app.sendBuffer, cols);
+      case TuiMode.RENAME:
+        return renderRenameMode(selected, app.renameBuffer, cols);
+      case TuiMode.CONFIRM_KILL:
+        return renderKillConfirm(selected);
+      default:
+        return null;
+    }
+  })();
 
   if (app.mode === TuiMode.HELP) {
     const helpLines = renderHelp();
@@ -37,38 +56,12 @@ export function render(app: TuiApp, size: TerminalSize): string {
       out.push((helpLines[i] ?? '') + '\x1b[K\r\n');
       linesWritten++;
     }
-  } else if (app.mode === TuiMode.SEND) {
-    const selected = app.selectedState();
-    if (selected) {
-      out.push('\x1b[K\r\n');
+  } else if (modalLines) {
+    out.push('\x1b[K\r\n');
+    linesWritten++;
+    for (let i = 0; i < contentRows - 1 && i < modalLines.length; i++) {
+      out.push(modalLines[i]! + '\x1b[K\r\n');
       linesWritten++;
-      const sendLines = renderSendMode(selected, app.sendBuffer, cols);
-      for (let i = 0; i < contentRows - 1 && i < sendLines.length; i++) {
-        out.push(sendLines[i]! + '\x1b[K\r\n');
-        linesWritten++;
-      }
-    }
-  } else if (app.mode === TuiMode.RENAME) {
-    const selected = app.selectedState();
-    if (selected) {
-      out.push('\x1b[K\r\n');
-      linesWritten++;
-      const renameLines = renderRenameMode(selected, app.renameBuffer, cols);
-      for (let i = 0; i < contentRows - 1 && i < renameLines.length; i++) {
-        out.push(renameLines[i]! + '\x1b[K\r\n');
-        linesWritten++;
-      }
-    }
-  } else if (app.mode === TuiMode.CONFIRM_KILL) {
-    const selected = app.selectedState();
-    if (selected) {
-      out.push('\x1b[K\r\n');
-      linesWritten++;
-      const killLines = renderKillConfirm(selected);
-      for (let i = 0; i < contentRows - 1 && i < killLines.length; i++) {
-        out.push(killLines[i]! + '\x1b[K\r\n');
-        linesWritten++;
-      }
     }
   } else if (app.mode === TuiMode.PREVIEW || app.mode === TuiMode.PASSTHROUGH) {
     const selected = app.selectedState();
@@ -78,8 +71,9 @@ export function render(app: TuiApp, size: TerminalSize): string {
 
     out.push('\x1b[K\r\n');
     linesWritten++;
-    const sessionLines = renderSessionList(app, contentRows, listWidth);
-    const previewLines = selected ? renderPreview(selected, previewWidth, contentRows, isPassthrough) : [];
+    // contentRows - 1: the spacer above consumed one content row.
+    const sessionLines = renderSessionList(app, contentRows - 1, listWidth);
+    const previewLines = selected ? renderPreview(selected, previewWidth, contentRows - 1, isPassthrough) : [];
 
     for (let row = 0; row < contentRows - 1; row++) {
       const sessionLine = sessionLines[row] ?? '';
@@ -102,10 +96,10 @@ export function render(app: TuiApp, size: TerminalSize): string {
       linesWritten++;
     }
   } else {
-    // Dashboard mode
+    // Dashboard mode — contentRows - 1 list rows after the spacer.
     out.push('\x1b[K\r\n');
     linesWritten++;
-    const sessionLines = renderSessionList(app, contentRows, cols);
+    const sessionLines = renderSessionList(app, contentRows - 1, cols);
     for (const line of sessionLines) {
       out.push(line + '\x1b[K\r\n');
       linesWritten++;


### PR DESCRIPTION
## Summary

Whole-codebase review pass (4 quality lenses + 2 bug hunts, findings verified against source before fixing). Net **−17 lines** across 36 files. All 533 tests pass; lint/typecheck/format clean; smoke-tested `status`, `--statusline`, and `explain` against a live tmux server.

## Bugs fixed

- **`send-keys` breaks on prompts starting with `-`** (verified live on tmux 3.7b): a markdown bullet or flag as any line failed the send — silently in the TUI. Fixed with `--` before the literal operand.
- **Preview/passthrough rendered one content row short**: the row above the footer kept stale pixels from the previous frame, the bottom list/preview row was clipped, and a click on the stale row switched to a hidden agent. Content geometry now writes every row between header and footer each frame.
- **Dropped keystrokes**: only the first key per stdin read was processed — pasting "hello" into send/rename inserted "h". `parseKeyEvents` now consumes the whole buffer.
- **Startup crash window**: a quit key pressed during the ~150ms OSC-11 theme detection window (outside tmux) hit `slowTimer`'s temporal dead zone → `ReferenceError`. `finish()` is also idempotent now.
- **Torn status-file reads**: hooks truncated-then-wrote `.status`, so a refresh could read partial JSON and flicker that pane's state for a tick. Writes are atomic (tmp + `mv`) on both the bash and TS sides, and events append before status writes.
- **Stale scrape masking fresh state**: a cached PERMIT from the last slow-tick scrape could mask a fresh DONE for up to 5s after answering a prompt. The scrape cache is timestamped and ignored once a newer hook/event write exists.
- **`fleet send` could type a prompt into a bare shell pane** and press Enter — executing it as a shell command. Now targets only agent panes and shares the TUI's `canSendTo` policy.
- **Statusline format injection**: `#` in window names is escaped (`##`) — tmux re-expands directives in `#()` output.
- **`fleet explain` could disagree with the dashboard**: it ignored title rules and could read another agent's event stream on a pane-id collision. It now mirrors the live fusion (title takes the scrape slot) and reads events from the winning hook's own dir.
- Smaller: BUSY decay anchors to the freshest of hook/event ts; one malformed `agents.json` entry no longer discards all valid entries; pane titles with tabs no longer truncate; combining marks / variation-selector supplement are zero-width in `charWidth` (VS17-256 previously counted as width 2); OSC sequences are stripped and never split by truncation.

## Perf

- **Slow tick + every `fleet status --statusline` redraw: ~8 fixed subprocess spawns → ~3.** One `list-panes` (was 4), one shared `ps` table for ports + discovery (ports previously spawned `ps` per ppid hop), discovery config cached 60s (was 3 `tmux show`/tick), status dirs read once per tick (was twice). Statusline redraws are the user-visible win (~30–80ms less per redraw). `capture-pane` cost is unchanged and still dominates the slow tick.
- **Render: ~6 sort/filter/group passes per frame → 1.** `visibleStates()`/`dashboardRows()` memoized (invalidated only by state/filter changes); the layout is built once per frame instead of twice, and no longer rebuilt per mouse-motion event just to hit-test.
- **Single-pass scrape**: capture → resolve pane identity (hook or discovery) → classify once with the right manifest, replacing the classify-wrong-then-reclassify flow.

## Cleanup

- ~90 lines of verified-dead code deleted, including the engine's freshness branch that could never fire under live wiring (and its `FuseInput.currentStatus/currentTs` + `StateDecision.freshnessEvaluated` fields).
- Single sources of truth extracted: `ATTENTION_STATES`/`needsAttention` (was 5 inline copies), `formatAgeDelta` (3 copies), `getTmuxOption` in ipc.ts (3 copies), `hookStateForStatus` colocated with `mapHookState`, `statusFilePath`/`eventsFilePath`/`paneNum`, shared `chip`/`whereLabel`, `seededAgentDirs`. All raw tmux spawns route through `ipc.ts`, which no longer throws if the tmux binary is missing.

## Known follow-up (not in this PR)

Agent identity is still scattered across three hand-synced lists (hook dirs, detection manifests, discovery allowlist): aider/cursor/gemini/amp/droid are allowlisted for discovery but have no manifests, so they only ever show BUSY/IDLE. The right fix is a unified agent registry plus real manifests per agent — its own project.

## Test plan

- `bun test` — 533 pass, includes new coverage for `hookStateForStatus` round-trip and event-ts-anchored BUSY decay
- `bun run typecheck` / `lint` / `format` clean
- `bun run build` + live smoke test: `fleet --version`, `fleet status`, `fleet status --statusline`, `fleet explain` (explain now shows `rule: busy.title-spinner` via the new title parity)