### PR TITLE
feat: ☰ fleet button on the status line toggles the sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,9 @@ fleet statusline --inject
 
 Each entry is clickable (tmux 3.2+). **Left-click** an agent name to switch to that session; **right-click** to mark it read in place without switching. When any agent is ready, a `✕ clear` chip appears at the end of the row — click it to dismiss every ready agent at once. Only agents whose turn it is for you appear: PERMIT (tool approval), QUESTION (a question to answer), and DONE/ready (finished, waiting on your next move). Working and idle sessions stay out of the bar — they don't need you to act, so they'd just be noise. Watch those in the dashboard instead.
 
-(After upgrading Fleet, re-run `fleet statusline --inject` to pick up the right-click binding, clear chip, and focus-to-clear hook.)
+**The `☰ fleet` button** sits at the far left of the row and is always there, even when no agent needs you. Click it (either mouse button) to open the dashboard in a 34-column sidebar split; click again to close it. It toggles the window you're looking at, so it does the right thing with several clients attached to different windows. Same thing as `prefix+f`, minus the keyboard — and the same as `fleet sidebar`, which you can bind however you like.
+
+(After upgrading Fleet, re-run `fleet statusline --inject` to pick up the right-click binding, clear chip, focus-to-clear hook, and `☰ fleet` button.)
 
 **Status-right icon (lightweight):** A single icon in your existing status bar:
 

--- a/index.ts
+++ b/index.ts
@@ -33,6 +33,7 @@ import { loadRenames, saveRename } from './src/state/rename.ts';
 import {
   AgentStatus,
   ACK_ALL_RANGE,
+  SIDEBAR_RANGE,
   STATUS_DISPLAY,
   extractClaudeName,
   type AgentState,
@@ -64,6 +65,7 @@ import { tmux, tmuxOrNull } from './src/tmux/ipc.ts';
 import { detectPorts } from './src/tmux/ports.ts';
 import { sendKeys, sendRawKey } from './src/tmux/send.ts';
 import { runStatus } from './src/cli/status.ts';
+import { runSidebar } from './src/cli/sidebar.ts';
 import { runNext } from './src/cli/next.ts';
 import { runSend } from './src/cli/send.ts';
 import { runInstall, runUninstall } from './src/cli/install.ts';
@@ -103,6 +105,7 @@ function printHelp(): number {
       `    ${C.idle}fleet status${C.reset} [--tmux] <session>  ${C.gray}Query agent state${C.reset}`,
       `    ${C.idle}fleet status${C.reset} --statusline        ${C.gray}Render multi-agent tmux status line${C.reset}`,
       `    ${C.idle}fleet next${C.reset}                       ${C.gray}Jump to next waiting agent${C.reset}`,
+      `    ${C.idle}fleet sidebar${C.reset}                    ${C.gray}Toggle the ☰ fleet sidebar split${C.reset}`,
       `    ${C.idle}fleet send${C.reset} <session> <prompt>    ${C.gray}Send prompt to session${C.reset}`,
       `    ${C.idle}fleet wait${C.reset} <session> --state <s> ${C.gray}Block until agent reaches state${C.reset}`,
       `    ${C.idle}fleet explain${C.reset} <session>          ${C.gray}Trace how a session's state was decided${C.reset}`,
@@ -495,11 +498,16 @@ async function handleCli(args: string[]): Promise<number | null> {
     case 'ack': {
       // Acknowledge a ready agent without switching to it (clears it from the
       // attention tier in place). Bound to right-click on the status line, and
-      // handy for scripting. The ACK_ALL_RANGE sentinel clears every ready agent.
+      // handy for scripting. The ACK_ALL_RANGE sentinel clears every ready agent;
+      // the SIDEBAR_RANGE button toggles either way it's clicked, so a stray
+      // right-click on it isn't a dead spot.
       const target = args[1];
       if (!target) {
         process.stderr.write('Usage: fleet ack <pane-id>\n');
         return 1;
+      }
+      if (target === SIDEBAR_RANGE) {
+        return runSidebar(args.slice(2));
       }
       if (target === ACK_ALL_RANGE) {
         acknowledgeAllReady(dirs);
@@ -511,13 +519,17 @@ async function handleCli(args: string[]): Promise<number | null> {
     }
     case 'switch': {
       // Invoked by the statusline left-click binding. The ACK_ALL_RANGE sentinel
-      // (the "clear all" chip) clears every ready agent without switching.
-      // Otherwise acknowledge the target (so a click counts the same as Enter in
-      // the dashboard) and switch to it.
+      // (the "clear all" chip) clears every ready agent without switching, and
+      // SIDEBAR_RANGE (the "☰ fleet" button) toggles the sidebar. Otherwise
+      // acknowledge the target (so a click counts the same as Enter in the
+      // dashboard) and switch to it.
       const target = args[1];
       if (!target) {
         process.stderr.write('Usage: fleet switch <pane-id>\n');
         return 1;
+      }
+      if (target === SIDEBAR_RANGE) {
+        return runSidebar(args.slice(2));
       }
       if (target === ACK_ALL_RANGE) {
         acknowledgeAllReady(dirs);
@@ -531,6 +543,11 @@ async function handleCli(args: string[]): Promise<number | null> {
         // Pane may have closed
       }
       return 0;
+    }
+    case 'sidebar': {
+      // Open the fleet sidebar split, or close it if it's already up. Same entry
+      // point the status-line button routes to.
+      return runSidebar(args.slice(1));
     }
     case 'send': {
       const session = args[1];

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -7,10 +7,12 @@ import {
   WINDOW_STATUS_FORMAT,
   WINDOW_STATUS_CURRENT_FORMAT,
 } from './statusline.ts';
+import { SIDEBAR_WIDTH } from './sidebar.ts';
 
 const FLEET_MANAGED_MARKER = '# fleet-managed';
 const FLEET_TMUX_LINE = `run-shell "fleet statusline --inject" ${FLEET_MANAGED_MARKER}`;
-const FLEET_KEYBIND_SIDEBAR = `bind-key f split-window -hbf -l 34 fleet ${FLEET_MANAGED_MARKER}`;
+// Same width the ☰ fleet button's toggle uses, from one constant.
+const FLEET_KEYBIND_SIDEBAR = `bind-key f split-window -hbf -l ${SIDEBAR_WIDTH} fleet ${FLEET_MANAGED_MARKER}`;
 const FLEET_KEYBIND_POPUP = `bind-key F display-popup -E -w 80% -h 60% fleet ${FLEET_MANAGED_MARKER}`;
 
 // Window state rollup opt-in: gate option + both window-status format overrides,

--- a/src/cli/sidebar.test.ts
+++ b/src/cli/sidebar.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'bun:test';
+import { buildCloseArgs, buildFindArgs, buildMarkArgs, buildOpenArgs, SIDEBAR_WIDTH } from './sidebar.ts';
+
+describe('buildFindArgs', () => {
+  test('filters panes by the fleet marker option', () => {
+    const args = buildFindArgs(null);
+    expect(args).toEqual(['list-panes', '-f', '#{@fleet_sidebar}', '-F', '#{pane_id}']);
+  });
+
+  test('scopes the search to the target pane’s window', () => {
+    expect(buildFindArgs('%7')).toEqual(['list-panes', '-f', '#{@fleet_sidebar}', '-F', '#{pane_id}', '-t', '%7']);
+  });
+});
+
+describe('buildOpenArgs', () => {
+  test('splits full-height on the left and prints the new pane id', () => {
+    const args = buildOpenArgs(null);
+    expect(args).toEqual(['split-window', '-hbf', '-l', String(SIDEBAR_WIDTH), '-P', '-F', '#{pane_id}', 'fleet']);
+  });
+
+  test('targets the clicking pane’s window, with the command last', () => {
+    const args = buildOpenArgs('%7');
+    expect(args.slice(-3)).toEqual(['-t', '%7', 'fleet']);
+  });
+});
+
+describe('buildMarkArgs', () => {
+  test('sets the marker pane-scoped so list-panes -f can find it', () => {
+    // -p is what makes this a pane option; -g or -w here would leak the marker
+    // to every pane and make the toggle think a sidebar is always open.
+    expect(buildMarkArgs('%9')).toEqual(['set', '-p', '-t', '%9', '@fleet_sidebar', '1']);
+  });
+});
+
+describe('buildCloseArgs', () => {
+  test('kills the marked pane by id', () => {
+    expect(buildCloseArgs('%9')).toEqual(['kill-pane', '-t', '%9']);
+  });
+});

--- a/src/cli/sidebar.ts
+++ b/src/cli/sidebar.ts
@@ -1,0 +1,77 @@
+/**
+ * The `☰ fleet` button on the status line: toggle a fleet sidebar split in the
+ * window the click came from.
+ *
+ * The sidebar pane is identified by a pane-scoped marker option, not by matching
+ * `pane_current_command` — under `bun run dev` the pane reports as `bun`, and any
+ * shell that merely *ran* fleet once would false-positive.
+ */
+
+import { tmux, tmuxOrNull } from '../tmux/ipc.ts';
+
+// Shared with the prefix+f conf line install.ts persists, so a click and the
+// keybind can never drift to different widths.
+export const SIDEBAR_WIDTH = 34;
+
+// Pane-scoped marker set on the split we create; `list-panes -f` filters on it.
+const SIDEBAR_OPTION = '@fleet_sidebar';
+
+// `-t <pane>` scopes list-panes to that pane's *window*, which is what makes the
+// toggle land where the click came from. A null target falls back to whatever
+// tmux considers current — right for `fleet sidebar` typed in a shell, but wrong
+// with two clients on different windows, so the status-line binding always
+// passes `#{pane_id}` (verified to expand to the clicking client's active pane;
+// $TMUX_PANE does NOT — it carries the tmux server's inherited environment).
+export function buildFindArgs(target: string | null): string[] {
+  const args = ['list-panes', '-f', `#{${SIDEBAR_OPTION}}`, '-F', '#{pane_id}'];
+  if (target !== null) args.push('-t', target);
+  return args;
+}
+
+// -h vertical divider, -b before (left of) the target, -f full window height.
+// -P -F prints the new pane id so we can mark it in the very next call.
+export function buildOpenArgs(target: string | null): string[] {
+  const args = ['split-window', '-hbf', '-l', String(SIDEBAR_WIDTH), '-P', '-F', '#{pane_id}'];
+  if (target !== null) args.push('-t', target);
+  args.push('fleet');
+  return args;
+}
+
+export function buildMarkArgs(paneId: string): string[] {
+  return ['set', '-p', '-t', paneId, SIDEBAR_OPTION, '1'];
+}
+
+export function buildCloseArgs(paneId: string): string[] {
+  return ['kill-pane', '-t', paneId];
+}
+
+// Open when absent, close when present. Both halves are best-effort: a pane that
+// vanished between the list and the kill just leaves the toggle in the state the
+// user wanted anyway.
+export function toggleSidebar(target: string | null): number {
+  const found = tmuxOrNull(buildFindArgs(target));
+  if (found !== null) {
+    // Normally one id. Kill every marked pane so a hand-marked stray can't wedge
+    // the toggle into permanently reporting "already open".
+    for (const paneId of found.split('\n')) {
+      if (paneId.length > 0) tmux(buildCloseArgs(paneId));
+    }
+    return 0;
+  }
+
+  const created = tmuxOrNull(buildOpenArgs(target));
+  if (created === null) {
+    process.stderr.write('fleet sidebar: split-window failed (not inside tmux?)\n');
+    return 1;
+  }
+  tmux(buildMarkArgs(created));
+  return 0;
+}
+
+// `fleet sidebar [--from <pane>]`. The flag exists for the status-line binding;
+// typed by hand the bare form is correct.
+export function runSidebar(args: string[]): number {
+  const fromIndex = args.indexOf('--from');
+  const target = fromIndex !== -1 ? (args[fromIndex + 1] ?? null) : null;
+  return toggleSidebar(target);
+}

--- a/src/cli/status.test.ts
+++ b/src/cli/status.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { formatTmuxStatus, formatPlainStatus, formatStatusLine, formatAge, windowColorArgs } from './status.ts';
-import { AgentStatus, ACK_ALL_RANGE, type AgentState } from '../state/types.ts';
+import { AgentStatus, ACK_ALL_RANGE, SIDEBAR_RANGE, type AgentState } from '../state/types.ts';
 
 const makeState = (overrides: Partial<AgentState>): AgentState => ({
   paneId: '%42',
@@ -77,17 +77,35 @@ describe('formatAge', () => {
 });
 
 describe('formatStatusLine', () => {
-  test('returns empty string when all idle/shell/down', () => {
+  test('renders only the sidebar button when all idle/shell/down', () => {
     const states = [
       makeState({ status: AgentStatus.IDLE, session: 'a' }),
       makeState({ status: AgentStatus.SHELL, session: 'b', paneId: '%2' }),
       makeState({ status: AgentStatus.DOWN, session: 'c', paneId: '%3' }),
     ];
-    expect(formatStatusLine(states)).toBe('');
+    const result = formatStatusLine(states);
+    expect(result).toContain(SIDEBAR_RANGE);
+    // No agent chips, so no divider — the button stands alone.
+    expect(result).not.toContain('│');
   });
 
-  test('returns empty string for no states', () => {
-    expect(formatStatusLine([])).toBe('');
+  test('renders the sidebar button for no states', () => {
+    expect(formatStatusLine([])).toBe(`#[range=user|${SIDEBAR_RANGE}]#[fg=cyan]☰ fleet#[norange]`);
+  });
+
+  test('anchors the sidebar button leftmost, ahead of every agent chip', () => {
+    const states = [
+      makeState({ status: AgentStatus.PERMIT, window: 'permit-w' }),
+      makeState({ status: AgentStatus.DONE, window: 'done-w', paneId: '%2' }),
+    ];
+    const result = formatStatusLine(states);
+    expect(result.indexOf(SIDEBAR_RANGE)).toBe(0 + '#[range=user|'.length);
+    expect(result.indexOf(SIDEBAR_RANGE)).toBeLessThan(result.indexOf('permit-w'));
+    expect(result.indexOf(SIDEBAR_RANGE)).toBeLessThan(result.indexOf(ACK_ALL_RANGE));
+  });
+
+  test('sidebar sentinel fits tmux’s 15-byte range=user limit', () => {
+    expect(Buffer.byteLength(SIDEBAR_RANGE)).toBeLessThanOrEqual(15);
   });
 
   test('includes PERMIT/QUESTION/DONE, excludes BUSY/IDLE/SHELL/DOWN', () => {
@@ -164,9 +182,9 @@ describe('formatStatusLine', () => {
     expect(result).toContain('#[range=user|%42]');
     expect(result).toContain('#[range=user|%7]');
     expect(result).toContain('#[norange]');
-    // Two entries -> two range openings and two norange closings
-    expect(result.match(/#\[range=user\|/g)?.length).toBe(2);
-    expect(result.match(/#\[norange\]/g)?.length).toBe(2);
+    // Two entries plus the always-present sidebar button -> three ranges
+    expect(result.match(/#\[range=user\|/g)?.length).toBe(3);
+    expect(result.match(/#\[norange\]/g)?.length).toBe(3);
   });
 
   test('joins multiple entries with the dim separator', () => {

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -1,6 +1,7 @@
 import {
   AgentStatus,
   ACK_ALL_RANGE,
+  SIDEBAR_RANGE,
   compareStatus,
   formatAgeDelta,
   needsAttention,
@@ -13,23 +14,39 @@ export function formatAge(ts: number): string {
   return formatAgeDelta(Math.floor(Date.now() / 1000) - ts);
 }
 
+// Leftmost chip, always rendered: toggles the fleet sidebar. Anchoring it at the
+// left keeps it in one fixed spot as agent chips come and go — a click target
+// that moves is a click target you miss — and it doubles as the only visible
+// signal that the row is clickable at all.
+//
+// Deliberately static: showing sidebar open/closed state would mean a list-panes
+// call on every status redraw, and one fleet process per redraw is the budget
+// this whole path is built around.
+const SIDEBAR_BUTTON = `#[range=user|${SIDEBAR_RANGE}]#[fg=cyan]☰ fleet#[norange]`;
+
+// These chips must keep reaching tmux as #() job output, never inlined into
+// status-format as a literal: tmux strftime-expands the format string itself, so
+// a literal `range=user|%42` registers as `42` (%4 is an unknown conversion) and
+// every click resolves to the wrong target. Job output skips that pass.
 export function formatStatusLine(states: AgentState[]): string {
   // The status line is for agents whose turn it is for you to act on: waiting on
   // a permission prompt (PERMIT), asking a question (QUESTION), or finished and
   // waiting on your next move (DONE/ready). Working and idle agents don't need
   // you, so they stay out of the bar.
   const filtered = states.filter((s) => needsAttention(s.status));
-  if (filtered.length === 0) return '';
-
   filtered.sort((a, b) => compareStatus(a.status, b.status));
 
-  const entries = filtered.map((s) => {
+  const entries = [SIDEBAR_BUTTON];
+
+  for (const s of filtered) {
     const display = STATUS_DISPLAY[s.status];
     // tmux re-expands format directives in #() output, so a window/session
     // name containing '#' must be escaped ('##') or it corrupts the row.
     const label = windowLabel(s).replace(/#/g, '##');
-    return `#[range=user|${s.paneId}]#[fg=${display.color}]${display.icon} #[bold]${label}#[nobold] ${formatAge(s.ts)}#[norange]`;
-  });
+    entries.push(
+      `#[range=user|${s.paneId}]#[fg=${display.color}]${display.icon} #[bold]${label}#[nobold] ${formatAge(s.ts)}#[norange]`,
+    );
+  }
 
   // A "clear all" chip dismisses every ready agent at once. Only ready (DONE)
   // agents are dismissible, so the chip only appears when one is present.

--- a/src/cli/statusline.ts
+++ b/src/cli/statusline.ts
@@ -15,6 +15,15 @@ import type { AgentState } from '../state/types.ts';
 // through fleet, which decides what to do based on the range value.
 const ROW1_RANGE_GUARD = '#{&&:#{==:#{mouse_status_line},1},#{!=:#{mouse_status_range},}}';
 
+// Which window the click came from. A status-line click carries no pane target
+// of its own, so `#{pane_id}` here resolves to the active pane of the clicking
+// client's current window — exactly what the sidebar toggle needs to split the
+// right window when two clients are attached to different ones. ($TMUX_PANE is
+// NOT a substitute: in a run-shell child it carries the tmux server's inherited
+// environment, which points at whatever pane happened to start the server.)
+// Only the sidebar sentinel reads it; switch/ack on an agent chip ignore it.
+const FROM_PANE_ARG = '--from \\"#{pane_id}\\"';
+
 // Clearing a notification by *reaching* the pane, not just by clicking its Fleet
 // chip. A pane-focus-in hook acks whatever pane just gained focus, so switching
 // to a ready agent by any route (prefix keys, clicking the pane, choose-tree)
@@ -38,8 +47,8 @@ export function buildInjectCommands(): string[][] {
   return [
     ['tmux', 'set', '-g', 'status', '2'],
     ['tmux', 'set', '-g', 'status-format[1]', '#[align=left]#(fleet status --statusline)'],
-    // Left-click: switch to the agent (acknowledging it on the way), or clear all
-    // ready agents when the sentinel chip is clicked.
+    // Left-click: switch to the agent (acknowledging it on the way), clear all
+    // ready agents on the ✕ chip, or toggle the sidebar on the ☰ fleet button.
     [
       'tmux',
       'bind',
@@ -49,7 +58,7 @@ export function buildInjectCommands(): string[][] {
       'if-shell',
       '-F',
       ROW1_RANGE_GUARD,
-      'run-shell "fleet switch \\"#{mouse_status_range}\\""',
+      `run-shell "fleet switch \\"#{mouse_status_range}\\" ${FROM_PANE_ARG}"`,
       'select-window -t=',
     ],
     // Right-click: acknowledge in place without switching (or clear all on the chip).
@@ -62,7 +71,7 @@ export function buildInjectCommands(): string[][] {
       'if-shell',
       '-F',
       ROW1_RANGE_GUARD,
-      'run-shell "fleet ack \\"#{mouse_status_range}\\""',
+      `run-shell "fleet ack \\"#{mouse_status_range}\\" ${FROM_PANE_ARG}"`,
     ],
     // pane-focus-in requires focus-events; switching to a pane then acks it.
     ['tmux', 'set', '-g', 'focus-events', 'on'],

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -10,10 +10,14 @@ export const AgentStatus = {
 
 export type AgentStatus = (typeof AgentStatus)[keyof typeof AgentStatus];
 
-// Sentinel range name for the status-line "clear all" chip. Not a pane id — the
-// CLI router (fleet switch / fleet ack) detects it and acknowledges every ready
-// agent instead of acting on a single pane.
+// Sentinel range names for the status-line chips that aren't agents. Not pane
+// ids — the CLI router (fleet switch / fleet ack) detects them and runs a bar
+// action instead of acting on a single pane.
+//
+// tmux caps a `range=user|X` argument at 15 bytes and silently truncates past
+// that, so every sentinel here must stay short.
 export const ACK_ALL_RANGE = '__ack_all__';
+export const SIDEBAR_RANGE = '__sidebar__';
 
 // Dashboard sort order, most-urgent first: a blocked tool (PERMIT) and a
 // question (QUESTION) need you now; working agents come next so live work stays


### PR DESCRIPTION
Adds an always-present chip at the far left of the fleet status row. Click it (either mouse button) to open the dashboard in a 34-column sidebar split; click again to close. Also exposed as `fleet sidebar` for custom bindings.

The row previously rendered empty whenever no agent needed attention, so nothing signalled that any of it was clickable. Anchoring the button leftmost keeps it in one fixed spot as agent chips come and go — a click target that moves is a click target you miss.

## Design notes

**Marker option, not process matching.** The sidebar pane is found via a pane-scoped `@fleet_sidebar` option and `list-panes -f`. Matching `pane_current_command` would report `bun` under `bun run dev` and false-positive on any shell that merely ran fleet once.

**Both bindings now pass `--from "#{pane_id}"`.** A status-line click carries no pane target of its own, so `#{pane_id}` resolves to the clicking client's current window. This is load-bearing: with two clients attached to different sessions, tmux's own notion of the "current" session points at the most recently active client, which is not necessarily the one that was clicked. `$TMUX_PANE` is **not** a substitute — in a `run-shell` child it carries the tmux server's inherited environment, which points at whatever pane happened to start the server.

**The button is deliberately static.** Rendering open/closed state would mean a `list-panes` call on every status redraw, and one fleet process per redraw is the budget this whole path is built around.

**`prefix+f` is untouched.** Converting it to a toggle would change the conf line text, `addTmuxKeybindLines` would stop recognizing existing installs, and users would end up with two `bind-key f` lines. It now just draws its width from the same `SIDEBAR_WIDTH` constant, producing a byte-identical string.

**No new tmux version floor.** `range=user` already required 3.2+; `set -p` and `list-panes -f` are older.

## Verification

Unit tests cover the arg builders and the button's position, but the interesting part was tested for real: a nested tmux running the built binary, driven by raw SGR mouse escape sequences injected at the button's coordinates.

- click → 34-col pane appears, `marker=[1]`, running fleet
- click again → gone; again → back
- right-click → toggles too
- two clients on **different sessions**: clicking from the non-most-recent one landed the split in that client's window (`inner:second`) while tmux considered `other` current

## Incidental

Added a comment at `src/cli/status.ts` warning that these chips must keep reaching tmux as `#()` job output. tmux strftime-expands `status-format` itself, so a literal `range=user|%42` inlined there registers as `42` (`%4` being an unknown conversion) and every click resolves to the wrong target. Job output skips that pass. Current code is correct; the comment exists so it stays that way.

Not included: popup-on-right-click. `run-shell` without `-b` blocks tmux's command queue, and opening a modal popup from there risks wedging the server.