### PR TITLE
fix: drop the divider after the ☰ button and move its space to the right

### DIFF
--- a/src/cli/status.test.ts
+++ b/src/cli/status.test.ts
@@ -90,12 +90,20 @@ describe('formatStatusLine', () => {
   });
 
   test('renders the sidebar button for no states', () => {
-    expect(formatStatusLine([])).toBe(`#[range=user|${SIDEBAR_RANGE}]#[fg=cyan] ☰#[norange]`);
+    expect(formatStatusLine([])).toBe(`#[range=user|${SIDEBAR_RANGE}]#[fg=cyan]☰ #[norange]`);
   });
 
-  test('keeps the button’s leading space inside the clickable range', () => {
-    // The gutter doubles as click area — a bare ☰ is a 1-cell target.
-    expect(formatStatusLine([])).toContain(`${SIDEBAR_RANGE}]#[fg=cyan] ☰`);
+  test('keeps the button’s trailing space inside the clickable range', () => {
+    // The space doubles as click area — a bare ☰ is a 1-cell target.
+    expect(formatStatusLine([])).toContain(`${SIDEBAR_RANGE}]#[fg=cyan]☰ #[norange]`);
+  });
+
+  test('runs the button straight into the first chip, with no divider', () => {
+    const states = [makeState({ status: AgentStatus.PERMIT, window: 'permit-w' })];
+    const result = formatStatusLine(states);
+    expect(result.startsWith(`#[range=user|${SIDEBAR_RANGE}]#[fg=cyan]☰ #[norange]#[range=user|`)).toBe(true);
+    // The divider is for telling agents apart, so a single agent means none.
+    expect(result).not.toContain('│');
   });
 
   test('anchors the sidebar button leftmost, ahead of every agent chip', () => {

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -19,14 +19,16 @@ export function formatAge(ts: number): string {
 // that moves is a click target you miss — and it doubles as the only visible
 // signal that the row is clickable at all.
 //
-// The leading space sits INSIDE the range, so it's both the gutter that keeps ☰
-// off the terminal edge and a second clickable column. A bare glyph is a 1-cell
-// target; two cells is meaningfully easier to hit.
+// The button is prepended rather than joined, so no `│` separates it from the
+// first agent chip: the divider is for telling agents apart, and the glyph is
+// already visually distinct from them. Its trailing space sits INSIDE the range
+// so it doubles as click area — a bare glyph is a 1-cell target, and two cells
+// is meaningfully easier to hit.
 //
 // Deliberately static: showing sidebar open/closed state would mean a list-panes
 // call on every status redraw, and one fleet process per redraw is the budget
 // this whole path is built around.
-const SIDEBAR_BUTTON = `#[range=user|${SIDEBAR_RANGE}]#[fg=cyan] ☰#[norange]`;
+const SIDEBAR_BUTTON = `#[range=user|${SIDEBAR_RANGE}]#[fg=cyan]☰ #[norange]`;
 
 // These chips must keep reaching tmux as #() job output, never inlined into
 // status-format as a literal: tmux strftime-expands the format string itself, so
@@ -40,7 +42,7 @@ export function formatStatusLine(states: AgentState[]): string {
   const filtered = states.filter((s) => needsAttention(s.status));
   filtered.sort((a, b) => compareStatus(a.status, b.status));
 
-  const entries = [SIDEBAR_BUTTON];
+  const entries: string[] = [];
 
   for (const s of filtered) {
     const display = STATUS_DISPLAY[s.status];
@@ -58,7 +60,7 @@ export function formatStatusLine(states: AgentState[]): string {
     entries.push(`#[range=user|${ACK_ALL_RANGE}]#[fg=brightblack]✕ clear#[norange]`);
   }
 
-  return entries.join(' #[fg=brightblack]│ ');
+  return SIDEBAR_BUTTON + entries.join(' #[fg=brightblack]│ ');
 }
 
 export function formatPlainStatus(states: AgentState[], session: string): string {


### PR DESCRIPTION
The ☰ button was joined into the chip list, so it picked up a `│` separator and rendered ` ☰ │ ⚠ horizon 9m`. The divider is there to tell agents apart, and the glyph is already visually distinct from them — the pipe directly after it was just noise.

Prepends the button instead of joining it, and moves its space from the left of the glyph to the right:

```
☰
☰ ⚠ horizon 9m
☰ ⚠ horizon 9m │ ? authkit 9m │ ● fleet 9m │ ✕ clear
```

The space stays **inside** the range, so the button is still a two-cell click target rather than a bare one-cell glyph. Verified previously in a nested tmux that the padding column toggles the sidebar just like the glyph does.

Three tests cover the shape: the exact button string, the space being inside the range, and the button running straight into the first chip with no divider.