### PR TITLE
fix: toggle the sidebar on prefix+f, and quiet a repeated statusline inject

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -122,6 +122,7 @@ function printHelp(): number {
       '',
       `  ${C.bold}Tmux${C.reset}`,
       `    ${C.idle}fleet statusline${C.reset} --inject        ${C.gray}Add fleet status to tmux row 2${C.reset}`,
+      `    ${C.idle}fleet statusline${C.reset} --inject --force ${C.gray}Re-apply even if already injected${C.reset}`,
       `    ${C.idle}fleet statusline${C.reset} --remove        ${C.gray}Remove fleet status from tmux${C.reset}`,
       '',
       `  ${C.permit}⚠ waiting${C.reset}  ${C.question}? asking${C.reset}  ${C.done}✓ done${C.reset}  ${C.busy}◉ working${C.reset}  ${C.idle}● idle${C.reset}`,
@@ -590,12 +591,14 @@ async function handleCli(args: string[]): Promise<number | null> {
     }
     case 'statusline': {
       if (args.includes('--inject') || args.includes('--install')) {
-        return runStatusLineInject();
+        // Silent no-op when already applied — the conf line re-runs this on
+        // every tmux source-file. --force re-applies regardless.
+        return runStatusLineInject(args.includes('--force'));
       }
       if (args.includes('--remove') || args.includes('--uninstall')) {
         return runStatusLineRemove();
       }
-      process.stderr.write('Usage: fleet statusline --inject | --remove\n');
+      process.stderr.write('Usage: fleet statusline --inject [--force] | --remove\n');
       return 1;
     }
     case 'wait': {

--- a/src/cli/install.test.ts
+++ b/src/cli/install.test.ts
@@ -261,9 +261,26 @@ describe('addTmuxKeybindLines', () => {
     const added = addTmuxKeybindLines(path, () => true);
     expect(added).toHaveLength(2);
     const conf = readFileSync(path, 'utf8');
-    expect(conf).toContain('bind-key f split-window -hbf');
+    expect(conf).toContain('bind-key f run-shell "fleet sidebar --from \'#{pane_id}\'"');
     expect(conf).toContain('bind-key F display-popup');
     expect(conf.match(/# fleet-managed/g)?.length).toBe(2);
+  });
+
+  test('rewrites a pre-toggle split-window binding instead of duplicating it', () => {
+    const path = confWith('set -g mouse on\nbind-key f split-window -hbf -l 34 fleet # fleet-managed\n');
+    addTmuxKeybindLines(path, () => false);
+    const conf = readFileSync(path, 'utf8');
+    expect(conf).not.toContain('split-window');
+    expect(conf).toContain('bind-key f run-shell "fleet sidebar --from \'#{pane_id}\'"');
+    // One prefix+f bind, not the old and new fighting each other.
+    expect(conf.match(/^bind-key f /gm)?.length).toBe(1);
+  });
+
+  test('leaves a hand-rolled prefix+f binding alone', () => {
+    const own = 'bind-key f resize-pane -Z\n';
+    const path = confWith(own);
+    addTmuxKeybindLines(path, () => false);
+    expect(readFileSync(path, 'utf8')).toBe(own);
   });
 
   test('declining adds nothing and leaves the file untouched', () => {

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -11,8 +11,12 @@ import { SIDEBAR_WIDTH } from './sidebar.ts';
 
 const FLEET_MANAGED_MARKER = '# fleet-managed';
 const FLEET_TMUX_LINE = `run-shell "fleet statusline --inject" ${FLEET_MANAGED_MARKER}`;
-// Same width the ☰ button's toggle uses, from one constant.
-const FLEET_KEYBIND_SIDEBAR = `bind-key f split-window -hbf -l ${SIDEBAR_WIDTH} fleet ${FLEET_MANAGED_MARKER}`;
+// Routes through `fleet sidebar` so the key toggles instead of stacking another
+// split on every press. `--from` is load-bearing, not decorative: a run-shell
+// child inherits the tmux *server's* TMUX_PANE, so with no explicit target the
+// toggle lands in whichever window happened to start the server. `#{pane_id}`
+// expands against the invoking client, same as the ☰ button's binding.
+const FLEET_KEYBIND_SIDEBAR = `bind-key f run-shell "fleet sidebar --from '#{pane_id}'" ${FLEET_MANAGED_MARKER}`;
 const FLEET_KEYBIND_POPUP = `bind-key F display-popup -E -w 80% -h 60% fleet ${FLEET_MANAGED_MARKER}`;
 
 // Window state rollup opt-in: gate option + both window-status format overrides,
@@ -94,14 +98,28 @@ export function removeTmuxConfLine(path: string = tmuxConfPath()): boolean {
 // Offer the sidebar/popup bindings one at a time. `ask` is injected so tests
 // don't touch a TTY. Declined bindings are printed for manual adoption.
 // Uninstall needs no changes: removeTmuxConfLine strips every marker line.
+// Rewrite a fleet-managed prefix+f line that isn't the current one. Versions
+// before the toggle bound it straight to `split-window`; appending the new line
+// beside it would leave two conflicting binds, so replace in place. Scoped to
+// our own marker — a hand-rolled prefix+f binding is left alone.
+export function migrateSidebarKeybind(contents: string): string {
+  return contents
+    .split('\n')
+    .map((line) =>
+      line.includes(FLEET_MANAGED_MARKER) && line.startsWith('bind-key f ') ? FLEET_KEYBIND_SIDEBAR : line,
+    )
+    .join('\n');
+}
+
 export function addTmuxKeybindLines(path: string, ask: (question: string) => boolean): string[] {
   if (!existsSync(path)) return [];
-  let contents = readFileSync(path, 'utf8');
+  const original = readFileSync(path, 'utf8');
+  let contents = migrateSidebarKeybind(original);
   const added: string[] = [];
   const candidates = [
     {
       line: FLEET_KEYBIND_SIDEBAR,
-      question: 'Add tmux binding — prefix+f: fleet in a 34-col sidebar split? [y/N] ',
+      question: `Add tmux binding — prefix+f: toggle fleet in a ${SIDEBAR_WIDTH}-col sidebar split? [y/N] `,
     },
     {
       line: FLEET_KEYBIND_POPUP,
@@ -117,7 +135,7 @@ export function addTmuxKeybindLines(path: string, ask: (question: string) => boo
       process.stdout.write(`  skipped — add it yourself anytime:\n    ${cand.line}\n`);
     }
   }
-  if (added.length > 0) writeFileSync(path, contents);
+  if (contents !== original) writeFileSync(path, contents);
   return added;
 }
 

--- a/src/cli/statusline.test.ts
+++ b/src/cli/statusline.test.ts
@@ -3,9 +3,20 @@ import {
   buildInjectCommands,
   buildRemoveCommands,
   buildRollupEnableCommands,
+  STATUS_ROW1_FORMAT,
   WINDOW_STATUS_FORMAT,
   WINDOW_STATUS_CURRENT_FORMAT,
 } from './statusline.ts';
+
+describe('STATUS_ROW1_FORMAT', () => {
+  // isStatusLineInjected compares a live `show -gqv status-format[1]` against
+  // this constant, so the value inject writes has to come from the same place.
+  test('is the exact value buildInjectCommands writes to status-format[1]', () => {
+    const row1 = buildInjectCommands().find((c) => c[3] === 'status-format[1]');
+    expect(row1).toBeDefined();
+    expect(row1![4]).toBe(STATUS_ROW1_FORMAT);
+  });
+});
 
 describe('buildInjectCommands', () => {
   test('returns status-2, status-format[1], both mouse binds, and the focus hook', () => {

--- a/src/cli/statusline.ts
+++ b/src/cli/statusline.ts
@@ -43,10 +43,14 @@ const FOCUS_HOOK_ACTION = 'run-shell -b "fleet ack \\"#{pane_id}\\""';
 export const WINDOW_STATUS_FORMAT = '#{?#{@fleet_state},#[fg=#{@fleet_state}],}#I:#W#F';
 export const WINDOW_STATUS_CURRENT_FORMAT = '#{?#{@fleet_state},#[fg=#{@fleet_state}],}#[bold]#I:#W#F#[nobold]';
 
+// Row 1's content. Named so the idempotence check can compare against the exact
+// value inject writes, rather than a second copy that could drift.
+export const STATUS_ROW1_FORMAT = '#[align=left]#(fleet status --statusline)';
+
 export function buildInjectCommands(): string[][] {
   return [
     ['tmux', 'set', '-g', 'status', '2'],
-    ['tmux', 'set', '-g', 'status-format[1]', '#[align=left]#(fleet status --statusline)'],
+    ['tmux', 'set', '-g', 'status-format[1]', STATUS_ROW1_FORMAT],
     // Left-click: switch to the agent (acknowledging it on the way), clear all
     // ready agents on the ✕ chip, or toggle the sidebar on the ☰ button.
     [
@@ -160,7 +164,25 @@ export function clearAllWindowStates(): void {
   if (flat.length > 0) tmux(flat);
 }
 
-export function runStatusLineInject(): number {
+// Whether the live server already carries everything inject would set. Hooks are
+// options in tmux 3.x, so `show -gqv` reads all three the same way. Deliberately
+// compares values rather than just presence: a fleet upgrade that changes a
+// format must still re-apply over the stale one.
+export function isStatusLineInjected(): boolean {
+  return (
+    getTmuxOption('status') === '2' &&
+    getTmuxOption('status-format[1]') === STATUS_ROW1_FORMAT &&
+    getTmuxOption(FOCUS_HOOK_INDEX) === FOCUS_HOOK_ACTION
+  );
+}
+
+// install.ts persists a `run-shell "fleet statusline --inject"` line so a fresh
+// tmux server gets row 2 — which also means this runs on every `source-file`,
+// where it is nearly always a no-op that only announced itself. Skip the work
+// and the message when the server already matches; --force re-applies anyway.
+export function runStatusLineInject(force = false): number {
+  if (!force && isStatusLineInjected()) return 0;
+
   const code = runCommands(buildInjectCommands());
   if (code === 0) {
     process.stdout.write('Fleet status line injected. tmux will now render `fleet status --statusline` on row 2.\n');


### PR DESCRIPTION
Two fixes to how fleet wires itself into tmux, both surfaced while debugging why `prefix+f` kept stacking sidebars.

## `prefix+f` stacked splits instead of toggling

`install.ts` bound the key straight to `split-window`, so every press opened another sidebar. It now routes through `fleet sidebar`, which has toggled since the ☰ button landed.

The subtle part is `--from`. A `run-shell` child inherits the tmux **server's** environment, so its `TMUX_PANE` points at whatever pane started the server — often a different session — and the bare `fleet sidebar` form toggles a sidebar the user can't see. It exits 0 while appearing to do nothing. `#{pane_id}` expands against the invoking client instead, the same way the ☰ button's binding already targets its window. `sidebar.ts` documented this; the keybinding just wasn't using it.

Existing configs carry the old line, and appending the new one beside it would leave two `prefix+f` binds fighting. `migrateSidebarKeybind` rewrites a fleet-managed `prefix+f` line in place, scoped to the `# fleet-managed` marker so a hand-rolled binding of the same key is untouched.

## `statusline --inject` announced itself on every config reload

The persisted `run-shell "fleet statusline --inject"` line exists so a fresh server gets row 2, but it also runs on every `source-file` — re-setting six already-correct options and printing "Fleet status line injected" each time.

`isStatusLineInjected()` compares the live values of `status`, `status-format[1]`, and the `pane-focus-in[99]` hook against the constants inject writes, and `runStatusLineInject` returns early when they match. Comparing **values** rather than presence keeps self-healing intact: an upgrade that changes a format still re-applies over the stale one, which is precisely when re-applying matters. `--force` covers the rest.

## Verification

- 546 tests pass (4 new); typecheck, lint, and format clean.
- Against a live server: repeated `source-file` is silent, clearing `status-format[1]` still triggers one re-apply, and `prefix+f` toggles 2→1→2→1 in the correct session with no stray marked panes elsewhere.

`CHANGELOG.md` is untouched — release-please generates it from these conventional commits.