### PR TITLE
feat: track pi questions and install as a package

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ fleet uninstall codex
 
 ### pi
 
-Fleet also tracks [pi](https://www.npmjs.com/package/@mariozechner/pi-coding-agent) sessions. pi has no shell hooks — it loads TypeScript extensions auto-discovered from `~/.pi/agent/extensions/` — so `fleet install pi` drops fleet's extension there:
+Fleet also tracks [pi](https://www.npmjs.com/package/@earendil-works/pi-coding-agent) sessions. pi has no shell hooks, but it loads extensions from installed packages. `fleet install pi` registers fleet's `hooks/pi` directory as a local pi package:
 
 ```bash
 fleet install pi
@@ -77,11 +77,11 @@ fleet install pi
 
 This:
 
-1. Creates the pi status dir (`~/.cache/pi-status`)
-2. Symlinks the `fleet-pi` extension into `~/.pi/agent/extensions/` (your own pi extensions are untouched)
+1. Adds `hooks/pi` to `packages` in `~/.pi/agent/settings.json` (your own pi extensions and packages are untouched)
+2. Creates the pi status dir (`~/.cache/pi-status`)
 3. Registers `pi` in `~/.config/fleet/agents.json`
 
-The extension publishes fleet status from pi's `agent_start` / `tool_execution_start` / `agent_end` lifecycle events, so pi panes appear on the dashboard labeled `pi` (working / idle / done). pi auto-runs its tools, so there is no permission-prompt (PERMIT/QUESTION) state to surface — working/done is the full picture. Re-run after a `brew upgrade` to re-point the extension; in an already-running pi session, `/reload` picks it up. To reverse it (leaving your own pi extensions intact):
+The extension publishes fleet status from pi's lifecycle events, so pi panes appear on the dashboard labeled `pi` (working / idle / done). pi auto-runs its tools, so there is no permission-prompt state to surface. When `@juicesharp/rpiv-ask-user-question` is installed, its stable blocked event also surfaces the QUESTION state while it awaits input. Homebrew upgrades update the registered package in place; in an already-running pi session, `/reload` picks it up. To reverse it (leaving your own pi extensions and packages intact):
 
 ```bash
 fleet uninstall pi
@@ -257,7 +257,7 @@ Fleet also works as a non-interactive CLI for scripting and tmux integration.
 | `fleet reconcile [--dry-run] [--verbose]` | Remove orphan status files for dead panes, fix stale working states.               |
 | `fleet install`                           | Register Fleet as a Claude Code plugin + add second tmux status row.               |
 | `fleet install codex`                     | Wire fleet into Codex's `hooks.json` + `config.toml` (preserves your own hooks).   |
-| `fleet install pi`                        | Wire fleet into pi via an auto-discovered extension (preserves your own).          |
+| `fleet install pi`                        | Wire fleet into pi as a package extension (preserves your own packages).           |
 | `fleet uninstall`                         | Remove plugin registration + tmux status row.                                      |
 | `fleet uninstall codex`                   | Remove fleet's Codex hooks + config (leaves your own Codex hooks intact).          |
 | `fleet uninstall pi`                      | Remove fleet's pi extension + registration.                                        |

--- a/hooks/pi/fleet-pi.test.ts
+++ b/hooks/pi/fleet-pi.test.ts
@@ -87,6 +87,11 @@ describe('extension event wiring', () => {
       on(event: string, handler: (e?: unknown) => void): void {
         handlers[event] = handler;
       },
+      events: {
+        on(event: string, handler: (e?: unknown) => void): void {
+          handlers[event] = handler;
+        },
+      },
     };
     piDefault(mockPi as unknown as Parameters<typeof piDefault>[0]);
     return handlers;
@@ -110,6 +115,21 @@ describe('extension event wiring', () => {
     h.agent_end?.();
     s = readStatus('42');
     expect(s?.state).toBe('done');
+  });
+
+  test('rpiv ask-user blocked event writes question until the wait ends', () => {
+    const h = loadWithTmux('%8');
+    h.agent_start?.();
+    h.tool_execution_start?.({ toolName: 'ask_user_question', args: {} });
+
+    h['rpiv:ask-user:blocked']?.({ active: true });
+    let s = readStatus('8');
+    expect(s?.state).toBe('question');
+    expect(s?.tool).toBe('Ask User Question');
+
+    h['rpiv:ask-user:blocked']?.({ active: false });
+    s = readStatus('8');
+    expect(s?.state).toBe('working');
   });
 
   test('session_shutdown removes the status file', () => {

--- a/hooks/pi/fleet-pi.ts
+++ b/hooks/pi/fleet-pi.ts
@@ -3,19 +3,22 @@
  * lifecycle events, so a pi session shows up on the fleet dashboard (working /
  * idle / done) alongside claude and codex.
  *
- * pi has no shell-hook config like Claude Code or Codex; it loads TypeScript
- * extensions auto-discovered from ~/.pi/agent/extensions/*.ts. `fleet install pi`
- * symlinks this file there. It subscribes to pi's lifecycle events and writes the
+ * pi has no shell-hook config like Claude Code or Codex; `fleet install pi`
+ * registers this directory as a local pi package (see package.json next to this
+ * file). It subscribes to pi's lifecycle events and writes the
  * same status-file schema fleet's shell hooks write (see hooks/lib.sh):
  *
- *   agent_start          -> { state: "working" }
- *   tool_execution_start -> { state: "working", tool: "Bash: …" | "Edit: …" }
- *   agent_end            -> { state: "done" }        (fleet ages done -> idle)
- *   session_shutdown     -> remove the status file   (pi exited; no stale state)
+ *   agent_start                    -> { state: "working" }
+ *   tool_execution_start           -> { state: "working", tool: "Bash: …" | "Edit: …" }
+ *   rpiv:ask-user:blocked (active)  -> { state: "question" }
+ *   rpiv:ask-user:blocked (cleared) -> { state: "working" }
+ *   agent_end                      -> { state: "done" }      (fleet ages done -> idle)
+ *   session_shutdown               -> remove the status file (pi exited; no stale state)
  *
- * pi auto-runs its tools (no interactive permission prompt), so there is no
- * PERMIT/QUESTION state to source — working/done is complete coverage. State
- * goes to $FLEET_PI_STATUS_DIR or ~/.cache/pi-status (must match config.ts's
+ * pi auto-runs its tools, so it has no interactive permission prompt. Question
+ * tools can still block on user input; @juicesharp/rpiv-ask-user-question
+ * publishes that interval on pi's shared event bus. State goes to
+ * $FLEET_PI_STATUS_DIR or ~/.cache/pi-status (must match config.ts's
  * PI_STATUS_DIR). It is a no-op outside tmux, since fleet keys every agent on a
  * tmux pane. Every write is wrapped so a status-file error can never break pi.
  *
@@ -42,6 +45,9 @@ interface PiToolExecutionStartEvent {
 interface PiExtensionAPI {
   on(event: 'session_start' | 'agent_start' | 'agent_end' | 'session_shutdown', handler: () => void): void;
   on(event: 'tool_execution_start', handler: (event: PiToolExecutionStartEvent) => void): void;
+  events?: {
+    on(event: 'rpiv:ask-user:blocked', handler: (payload: { active: boolean }) => void): void;
+  };
 }
 
 // --- pure helpers (exported for unit tests) -----------------------------------
@@ -124,6 +130,9 @@ export default function (pi: PiExtensionAPI): void {
   pi.on('tool_execution_start', (event) => {
     currentTool = fleetPiLabel(event.toolName, event.args);
     write('working', currentTool);
+  });
+  pi.events?.on('rpiv:ask-user:blocked', (payload) => {
+    write(payload.active ? 'question' : 'working', payload.active ? 'Ask User Question' : currentTool);
   });
   pi.on('agent_end', () => {
     currentTool = '';

--- a/hooks/pi/package.json
+++ b/hooks/pi/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "fleet-pi",
+  "private": true,
+  "keywords": [
+    "pi-package"
+  ],
+  "pi": {
+    "extensions": [
+      "./fleet-pi.ts"
+    ]
+  }
+}

--- a/index.ts
+++ b/index.ts
@@ -114,7 +114,7 @@ function printHelp(): number {
       `  ${C.bold}Plugin${C.reset}`,
       `    ${C.idle}fleet install${C.reset}                    ${C.gray}Register as Claude Code plugin${C.reset}`,
       `    ${C.idle}fleet install codex${C.reset}              ${C.gray}Wire fleet into Codex's hooks + config${C.reset}`,
-      `    ${C.idle}fleet install pi${C.reset}                 ${C.gray}Wire fleet into pi via an extension${C.reset}`,
+      `    ${C.idle}fleet install pi${C.reset}                 ${C.gray}Wire fleet into pi as a package extension${C.reset}`,
       `    ${C.idle}fleet uninstall${C.reset}                  ${C.gray}Remove plugin registration${C.reset}`,
       `    ${C.idle}fleet uninstall codex${C.reset}            ${C.gray}Remove fleet's Codex hooks + config${C.reset}`,
       `    ${C.idle}fleet uninstall pi${C.reset}               ${C.gray}Remove fleet's pi extension${C.reset}`,

--- a/src/cli/install-pi.test.ts
+++ b/src/cli/install-pi.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'bun:test';
+import { piPackageEntryMatches } from './install-pi.ts';
+
+describe('piPackageEntryMatches', () => {
+  const dir = '/opt/homebrew/opt/fleet/hooks/pi';
+
+  test('matches a string local-package entry', () => {
+    expect(piPackageEntryMatches(dir, dir)).toBe(true);
+    expect(piPackageEntryMatches('/other/package', dir)).toBe(false);
+  });
+
+  test('matches an object entry by source', () => {
+    expect(piPackageEntryMatches({ source: dir, extensions: ['./fleet-pi.ts'] }, dir)).toBe(true);
+    expect(piPackageEntryMatches({ source: '/other/package' }, dir)).toBe(false);
+  });
+
+  test("matches pi's normalized relative local-package source", () => {
+    const devDir = '/Users/nicknisi/Developer/fleet/hooks/pi';
+    expect(piPackageEntryMatches('../../Developer/fleet/hooks/pi', devDir)).toBe(true);
+    expect(piPackageEntryMatches({ source: '../../Developer/fleet/hooks/pi' }, devDir)).toBe(true);
+  });
+
+  test('ignores non-source shapes and substring matches', () => {
+    expect(piPackageEntryMatches(`${dir}/fleet-pi.ts`, dir)).toBe(false);
+    expect(piPackageEntryMatches({ path: dir }, dir)).toBe(false);
+    expect(piPackageEntryMatches([dir], dir)).toBe(false);
+    expect(piPackageEntryMatches(null, dir)).toBe(false);
+  });
+});

--- a/src/cli/install-pi.ts
+++ b/src/cli/install-pi.ts
@@ -1,17 +1,17 @@
-import { existsSync, lstatSync, mkdirSync, rmSync } from 'node:fs';
+import { existsSync, lstatSync, mkdirSync, readFileSync, readlinkSync, rmSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
-import { dirname, join } from 'node:path';
-import { fleetPluginDir, linkPluginDir } from './install.ts';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fleetPluginDir } from './install.ts';
 import { agentsJsonPath, removeAgentEntry, seededAgentDirs, upsertAgentEntry, withTilde } from './install-codex.ts';
 import { PI_STATUS_DIR } from '../agents/config.ts';
 
-// pi (npm: @mariozechner/pi-coding-agent) has no shell-hook config; it loads
-// TypeScript extensions auto-discovered from ~/.pi/agent/extensions/*.ts (see
-// pi's docs/extensions.md). `fleet install pi` symlinks fleet's extension there
-// — a symlink into the plugin dir so a fleet upgrade is picked up without a
-// re-copy; re-running install after a Homebrew upgrade re-points it (linkPluginDir
-// replaces even a dangling link). Everything is idempotent and reversible; the
-// user's own pi extensions and config are never touched.
+// pi (npm: @earendil-works/pi-coding-agent) has no shell-hook config; it loads
+// package extensions from `packages` in ~/.pi/agent/settings.json (see pi's
+// docs/packages.md). `fleet install pi` registers hooks/pi as a local package so
+// pi owns loading. The source directory itself is never copied or symlinked:
+// Homebrew's opt path survives upgrades, while a dev checkout tracks the repo.
+// Everything is idempotent and reversible; the user's own pi extensions,
+// packages, and config are never touched.
 
 const PI_EXTENSIONS_DIR = join(homedir(), '.pi', 'agent', 'extensions');
 const PI_EXTENSION_LINK = join(PI_EXTENSIONS_DIR, 'fleet-pi.ts');
@@ -19,8 +19,77 @@ const PI_EXTENSION_LINK = join(PI_EXTENSIONS_DIR, 'fleet-pi.ts');
 // expands the leading ~ back to PI_STATUS_DIR when it reads this.
 const PI_STATUS_DIR_CONFIG = '~/.cache/pi-status';
 
-// lstat (does not follow the link) so a dangling symlink still reports present.
-function linkPresent(path: string): boolean {
+interface PiSettingsDoc {
+  packages?: unknown[];
+  [key: string]: unknown;
+}
+
+function piSettingsPath(): string {
+  return join(homedir(), '.pi', 'agent', 'settings.json');
+}
+
+// Pi's own installer persists local packages relative to the directory that
+// owns settings.json (~/.pi/agent), e.g. `../../Developer/fleet/hooks/pi`.
+// Matching both forms keeps fleet's direct settings edit byte-compatible with
+// a later `pi remove`.
+function canonicalPiPackageSource(packageDir: string): string {
+  return relative(dirname(piSettingsPath()), packageDir) || '.';
+}
+
+function readPiSettings(path: string): PiSettingsDoc | null {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, 'utf8')) as PiSettingsDoc;
+  } catch {
+    return null; // malformed — leave the user's settings untouched
+  }
+}
+
+function writePiSettings(path: string, doc: PiSettingsDoc): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(doc, null, 2) + '\n');
+}
+
+// --- pure settings helpers (exported for unit tests) -------------------------
+
+// A settings entry points at this fleet checkout when its source string is
+// exactly `packageDir` or pi's normalized relative form. A legacy entry
+// pointing at a symlinked source is repaired by packageDirsToRemove below
+// rather than by string surgery.
+export function piPackageEntryMatches(entry: unknown, packageDir: string): boolean {
+  const relativeDir = canonicalPiPackageSource(packageDir);
+  const matches = (source: string): boolean => source === packageDir || source === relativeDir;
+  if (typeof entry === 'string') return matches(entry);
+  if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) return false;
+  const source = (entry as { source?: unknown }).source;
+  return typeof source === 'string' && matches(source);
+}
+
+function upsertPiPackageEntry(packages: unknown[], packageDir: string): unknown[] {
+  if (packages.some((entry) => piPackageEntryMatches(entry, packageDir))) return packages;
+  return [...packages, packageDir];
+}
+
+function removePiPackageEntry(packages: unknown[], packageDir: string): unknown[] {
+  return packages.filter((entry) => !piPackageEntryMatches(entry, packageDir));
+}
+
+// The old installer linked fleet-pi.ts into ~/.pi/agent/extensions. Read the
+// link itself (not the extension content) so uninstall can also remove a
+// settings entry that pointed at the symlinked source instead of the realpath.
+function legacyPiPackageDir(): string | null {
+  try {
+    const target = readlinkSync(PI_EXTENSION_LINK);
+    const resolvedTarget = target.startsWith('/') ? target : resolve(dirname(PI_EXTENSION_LINK), target);
+    return dirname(resolvedTarget);
+  } catch {
+    return null;
+  }
+}
+
+// lstat (does not follow the link) so a dangling legacy link still reports
+// present and gets removed.
+function legacyEntryPresent(path: string): boolean {
   try {
     lstatSync(path);
     return true;
@@ -29,29 +98,44 @@ function linkPresent(path: string): boolean {
   }
 }
 
+function packageDirsToRemove(packageDir: string | null): string[] {
+  return Array.from(new Set([packageDir, legacyPiPackageDir()].filter((p): p is string => p !== null)));
+}
+
 export function runInstallPi(): number {
   const fleetDir = fleetPluginDir();
   if (fleetDir === null) {
     process.stderr.write(
       'fleet install pi failed: could not find a plugin directory containing hooks/hooks.json.\n' +
-        'Without it there is no fleet-pi extension to link into pi.\n' +
+        'Without it there is no fleet-pi extension to register with pi.\n' +
         'If fleet was installed via Homebrew, the package may be missing the hooks/ directory — try upgrading.\n',
     );
     return 1;
   }
-  const extensionSrc = join(fleetDir, 'hooks', 'pi', 'fleet-pi.ts');
-  if (!existsSync(extensionSrc)) {
-    process.stderr.write(`fleet install pi failed: fleet-pi extension not found at ${extensionSrc}\n`);
+  const packageDir = join(fleetDir, 'hooks', 'pi');
+  const extensionSrc = join(packageDir, 'fleet-pi.ts');
+  const manifestSrc = join(packageDir, 'package.json');
+  if (!existsSync(extensionSrc) || !existsSync(manifestSrc)) {
+    process.stderr.write(`fleet install pi failed: fleet-pi package not found at ${packageDir}\n`);
     return 1;
   }
 
   // Snapshot agents present BEFORE the mkdir below so a fresh agents.json is
   // seeded without dropping claude/codex (see seededAgentDirs).
   const seed = seededAgentDirs();
+  const settingsPath = piSettingsPath();
+  const doc = readPiSettings(settingsPath) ?? {};
+  const packages = Array.isArray(doc.packages) ? doc.packages : [];
+  doc.packages = upsertPiPackageEntry(packages, canonicalPiPackageSource(packageDir));
+  writePiSettings(settingsPath, doc);
 
-  mkdirSync(PI_EXTENSIONS_DIR, { recursive: true });
-  linkPluginDir(extensionSrc, PI_EXTENSION_LINK); // rm + symlink; replaces a stale/dangling link
-  process.stdout.write(`Linked ${withTilde(PI_EXTENSION_LINK)} -> ${extensionSrc}\n`);
+  // Migrate away from the old ~/.pi/agent/extensions/fleet-pi.ts symlink so pi
+  // does not load both the package and the legacy auto-discovered extension.
+  const hadLegacyEntry = legacyEntryPresent(PI_EXTENSION_LINK);
+  if (hadLegacyEntry) rmSync(PI_EXTENSION_LINK, { force: true });
+
+  process.stdout.write(`Registered ${withTilde(packageDir)} in ${withTilde(settingsPath)}\n`);
+  if (hadLegacyEntry) process.stdout.write(`Removed legacy ${withTilde(PI_EXTENSION_LINK)}\n`);
 
   mkdirSync(PI_STATUS_DIR, { recursive: true });
   process.stdout.write(`Created ${withTilde(PI_STATUS_DIR)}\n`);
@@ -62,15 +146,33 @@ export function runInstallPi(): number {
   process.stdout.write(`Registered pi in ${withTilde(agentsPath)}\n`);
 
   process.stdout.write('\nfleet is now wired into pi. Start pi in a tmux pane to see it on the dashboard.\n');
-  process.stdout.write('(In an already-running pi session, run /reload to pick up the extension.)\n');
+  process.stdout.write('(In an already-running pi session, run /reload to pick up the package.)\n');
   return 0;
 }
 
 export function runUninstallPi(): number {
-  // Remove only fleet's extension symlink; the user's own pi extensions stay.
-  if (linkPresent(PI_EXTENSION_LINK)) {
+  const fleetDir = fleetPluginDir();
+  const packageDir = fleetDir === null ? null : join(fleetDir, 'hooks', 'pi');
+  const settingsPath = piSettingsPath();
+  const doc = readPiSettings(settingsPath);
+  if (doc && Array.isArray(doc.packages)) {
+    let packages = doc.packages;
+    for (const dir of packageDirsToRemove(packageDir)) {
+      packages = removePiPackageEntry(packages, dir);
+    }
+    if (packages.length !== doc.packages.length) {
+      doc.packages = packages;
+      writePiSettings(settingsPath, doc);
+      process.stdout.write(`Removed fleet package from ${withTilde(settingsPath)}\n`);
+    }
+  }
+
+  // Remove the old installer path as a legacy migration. A non-fleet file by
+  // this exact name is still fleet-owned install territory; the user's other pi
+  // extensions are untouched.
+  if (legacyEntryPresent(PI_EXTENSION_LINK)) {
     rmSync(PI_EXTENSION_LINK, { force: true });
-    process.stdout.write(`Removed ${withTilde(PI_EXTENSION_LINK)}\n`);
+    process.stdout.write(`Removed legacy ${withTilde(PI_EXTENSION_LINK)}\n`);
   }
 
   const agentsPath = agentsJsonPath();

--- a/src/state/detection.ts
+++ b/src/state/detection.ts
@@ -216,16 +216,14 @@ export const OPENCODE_MANIFEST: DetectionManifest = {
 
 // --- the embedded built-in `pi` manifest ---
 // pi (npm: @mariozechner/pi-coding-agent) is wired via a fleet extension, not
-// scraping:
-// the fleet-pi extension subscribes to pi's agent_start / tool_execution_start /
-// agent_end lifecycle events and writes working/done to ~/.cache/pi-status, so
-// BUSY/DONE/IDLE are hook-sourced and authoritative. pi auto-runs its tools —
-// there is no interactive "[y/n]" permission prompt or selection dialog on the
-// screen to match — so there are no PERMIT/QUESTION scrape rules (a documented
-// limitation, mirroring Codex's absent QUESTION). The manifest is intentionally
-// empty; it exists so `pi` resolves to a built-in (no "no manifest" warning) and
-// is a registered, known agent. A user can still drop a ~/.config/fleet/detection/
-// pi.json override to add scrape rules.
+// scraping. The fleet-pi extension subscribes to pi's lifecycle events for
+// BUSY/DONE/IDLE and to rpiv-ask-user-question's stable blocked event for
+// QUESTION, writing each state to ~/.cache/pi-status. pi auto-runs its tools, so
+// there is no interactive "[y/n]" permission prompt to scrape. The manifest is
+// intentionally empty; it exists so `pi` resolves to a built-in (no "no
+// manifest" warning) and is a registered, known agent. A user can still drop a
+// ~/.config/fleet/detection/pi.json override to add scrape rules for another
+// question UI that does not publish a blocked event.
 export const PI_MANIFEST: DetectionManifest = {
   agent: 'pi',
   linesFromBottom: 15,


### PR DESCRIPTION
## Summary
- Subscribe Fleet's Pi extension to `rpiv:ask-user:blocked` so an awaiting `ask_user_question` surfaces as `question` in Fleet.
- Install the Pi integration as a native local Pi package from `hooks/pi/package.json` instead of symlinking into `~/.pi/agent/extensions`.
- Preserve unrelated Pi settings, handle Pi's relative package-source normalization, and migrate away the legacy auto-discovered symlink.
- Document the package installation flow and the new question-state source.

## Test plan
- `bun test` — 551 passed
- `bun run typecheck`
- `bun run lint`
- `bunx oxfmt --check hooks/pi/package.json src/cli/install-pi.ts src/cli/install-pi.test.ts hooks/pi/fleet-pi.ts README.md index.ts`
- `git diff --check`
- Live install cycle: `fleet install pi` registered one canonical package entry, second install stayed idempotent, `fleet uninstall pi` removed it, and reinstall restored it.