### PR TITLE
fix: detect shimmed pi question tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ This:
 2. Creates the pi status dir (`~/.cache/pi-status`)
 3. Registers `pi` in `~/.config/fleet/agents.json`
 
-The extension publishes fleet status from pi's lifecycle events, so pi panes appear on the dashboard labeled `pi` (working / idle / done). pi auto-runs its tools, so there is no permission-prompt state to surface. When `@juicesharp/rpiv-ask-user-question` is installed, its stable blocked event also surfaces the QUESTION state while it awaits input. Homebrew upgrades update the registered package in place; in an already-running pi session, `/reload` picks it up. To reverse it (leaving your own pi extensions and packages intact):
+The extension publishes fleet status from pi's lifecycle events, so pi panes appear on the dashboard labeled `pi` (working / idle / done). pi auto-runs its tools, so there is no permission-prompt state to surface. Question tools do surface QUESTION while awaiting input: `@juicesharp/rpiv-ask-user-question` via its stable blocked event, and compatibility-shimmed `AskUserQuestion` tools via pi's `tool_call` lifecycle. Homebrew upgrades update the registered package in place; in an already-running pi session, `/reload` picks it up. To reverse it (leaving your own pi extensions and packages intact):
 
 ```bash
 fleet uninstall pi

--- a/hooks/pi/fleet-pi.test.ts
+++ b/hooks/pi/fleet-pi.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import piDefault, { buildPiStatusLine, fleetPiLabel } from './fleet-pi.ts';
+import piDefault, { buildPiStatusLine, fleetPiLabel, isPiQuestionTool } from './fleet-pi.ts';
 import { parseStatusFile } from '../../src/state/hooks.ts';
 
 describe('fleetPiLabel', () => {
@@ -32,6 +32,15 @@ describe('fleetPiLabel', () => {
     expect(fleetPiLabel('bash', undefined)).toBe('Bash');
     expect(fleetPiLabel('edit', null)).toBe('Edit');
     expect(fleetPiLabel('', {})).toBe('');
+  });
+});
+
+describe('isPiQuestionTool', () => {
+  test('recognizes native and compatibility-shim question tools case-insensitively', () => {
+    expect(isPiQuestionTool('AskUserQuestion')).toBe(true);
+    expect(isPiQuestionTool('ask_user_question')).toBe(true);
+    expect(isPiQuestionTool('ASK_USER_QUESTION')).toBe(true);
+    expect(isPiQuestionTool('bash')).toBe(false);
   });
 });
 
@@ -130,6 +139,24 @@ describe('extension event wiring', () => {
     h['rpiv:ask-user:blocked']?.({ active: false });
     s = readStatus('8');
     expect(s?.state).toBe('working');
+  });
+
+  test('compatibility AskUserQuestion writes question from tool_call until execution ends', () => {
+    const h = loadWithTmux('%9');
+    h.agent_start?.();
+    h.tool_execution_start?.({ toolName: 'AskUserQuestion', args: {} });
+
+    // Another extension may also write working on tool_execution_start; the
+    // question write deliberately happens on the later tool_call event.
+    h.tool_call?.({ toolName: 'AskUserQuestion' });
+    let s = readStatus('9');
+    expect(s?.state).toBe('question');
+    expect(s?.tool).toBe('Ask User Question');
+
+    h.tool_execution_end?.({ toolName: 'AskUserQuestion' });
+    s = readStatus('9');
+    expect(s?.state).toBe('working');
+    expect(s?.tool).toBe('AskUserQuestion');
   });
 
   test('session_shutdown removes the status file', () => {

--- a/hooks/pi/fleet-pi.ts
+++ b/hooks/pi/fleet-pi.ts
@@ -10,6 +10,8 @@
  *
  *   agent_start                    -> { state: "working" }
  *   tool_execution_start           -> { state: "working", tool: "Bash: …" | "Edit: …" }
+ *   tool_call (question tool)      -> { state: "question" }
+ *   tool_execution_end (question)  -> { state: "working" }
  *   rpiv:ask-user:blocked (active)  -> { state: "question" }
  *   rpiv:ask-user:blocked (cleared) -> { state: "working" }
  *   agent_end                      -> { state: "done" }      (fleet ages done -> idle)
@@ -17,7 +19,8 @@
  *
  * pi auto-runs its tools, so it has no interactive permission prompt. Question
  * tools can still block on user input; @juicesharp/rpiv-ask-user-question
- * publishes that interval on pi's shared event bus. State goes to
+ * publishes that interval on pi's shared event bus, and compatibility-shimmed
+ * AskUserQuestion tools are recognized from their tool_call lifecycle. State goes to
  * $FLEET_PI_STATUS_DIR or ~/.cache/pi-status (must match config.ts's
  * PI_STATUS_DIR). It is a no-op outside tmux, since fleet keys every agent on a
  * tmux pane. Every write is wrapped so a status-file error can never break pi.
@@ -42,9 +45,13 @@ interface PiToolExecutionStartEvent {
   toolName: string;
   args: unknown;
 }
+interface PiToolEvent {
+  toolName: string;
+}
 interface PiExtensionAPI {
   on(event: 'session_start' | 'agent_start' | 'agent_end' | 'session_shutdown', handler: () => void): void;
   on(event: 'tool_execution_start', handler: (event: PiToolExecutionStartEvent) => void): void;
+  on(event: 'tool_call' | 'tool_execution_end', handler: (event: PiToolEvent) => void): void;
   events?: {
     on(event: 'rpiv:ask-user:blocked', handler: (payload: { active: boolean }) => void): void;
   };
@@ -56,6 +63,16 @@ interface PiExtensionAPI {
 // convention: "Bash: <cmd>", "Edit: <file>". pi's built-in tool names are
 // lowercase (bash, edit, write, read, …) with `command` (bash) or `path`
 // (edit/write/read) inputs; anything else falls back to the capitalized name.
+const QUESTION_TOOL_LABEL = 'Ask User Question';
+
+// Claude Code compatibility shims expose `AskUserQuestion`; the native pi
+// package exposes `ask_user_question`. The RPIV package also emits a precise
+// blocked event, but this lifecycle fallback covers shims that emit nothing.
+export function isPiQuestionTool(toolName: string): boolean {
+  const normalized = toolName.toLowerCase();
+  return normalized === 'askuserquestion' || normalized === 'ask_user_question';
+}
+
 export function fleetPiLabel(toolName: string, args: unknown): string {
   const a = (args ?? {}) as Record<string, unknown>;
   const str = (v: unknown): string => (typeof v === 'string' ? v : '');
@@ -130,6 +147,14 @@ export default function (pi: PiExtensionAPI): void {
   pi.on('tool_execution_start', (event) => {
     currentTool = fleetPiLabel(event.toolName, event.args);
     write('working', currentTool);
+  });
+  pi.on('tool_call', (event) => {
+    // tool_call fires after every extension's tool_execution_start handler, so
+    // another status extension cannot overwrite this with its own working write.
+    if (isPiQuestionTool(event.toolName)) write('question', QUESTION_TOOL_LABEL);
+  });
+  pi.on('tool_execution_end', (event) => {
+    if (isPiQuestionTool(event.toolName)) write('working', currentTool);
   });
   pi.events?.on('rpiv:ask-user:blocked', (payload) => {
     write(payload.active ? 'question' : 'working', payload.active ? 'Ask User Question' : currentTool);


### PR DESCRIPTION
## Summary
- Recognize both native `ask_user_question` and compatibility-shimmed `AskUserQuestion` tools as question tools.
- Write Fleet's `question` state on pi's later `tool_call` event so other status extensions cannot overwrite it during `tool_execution_start`.
- Restore `working` on `tool_execution_end`, while preserving the precise RPIV blocked-event path.
- Document the compatibility-shim behavior.

## Test plan
- `bun test` — 553 passed
- `bun run typecheck`
- `bun run lint`
- `bunx oxfmt --check hooks/pi/fleet-pi.ts hooks/pi/fleet-pi.test.ts README.md`
- `git diff --check`
- Live verification in a fresh tmux Pi: invoked the real `AskUserQuestion` shim, status file changed to `question`, and `fleet status --statusline` rendered the magenta `?` chip.