### PR TITLE
fix: mask fleet sidebar window renames

### DIFF
--- a/src/state/types.test.ts
+++ b/src/state/types.test.ts
@@ -125,6 +125,11 @@ describe('windowLabel', () => {
     expect(windowLabel({ ...base, window: 'fleet', project: null })).toBe('dotfiles');
   });
 
+  test('window renamed after fleet’s sidebar icon falls back to the project basename', () => {
+    expect(windowLabel({ ...base, window: '☰ nicknisi', project: '~/Developer/sessions' })).toBe('sessions');
+    expect(windowLabel({ ...base, window: '☰ nicknisi', project: null })).toBe('dotfiles');
+  });
+
   test('fleet-titled window in the fleet repo still reads fleet', () => {
     expect(windowLabel({ ...base, window: 'fleet', project: '~/Developer/fleet' })).toBe('fleet');
   });

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -129,13 +129,15 @@ export function whereLabel(state: AgentState): string {
 
 // Window-first label: the window name is what distinguishes agents; the
 // session is the fallback when the window adds no information. A window named
-// exactly after fleet's advertised pane title was named by a title-aware
-// renamer reading the fleet pane, not this agent — the agent's project
-// directory is the honest label there (and when the agent really is working
-// in a repo named fleet, the basename shows "fleet" anyway).
+// after fleet's advertised pane title or sidebar icon was named by a
+// title-aware renamer reading the fleet pane, not this agent — the agent's
+// project directory is the honest label there (and when the agent really is
+// working in a repo named fleet, the basename shows "fleet" anyway).
+const FLEET_WINDOW_RENAME_PATTERN = /^☰\s*/;
+
 export function windowLabel(state: AgentState): string {
   if (state.window.length === 0 || state.window === state.session) return state.session;
-  if (state.window === FLEET_PANE_TITLE) {
+  if (state.window === FLEET_PANE_TITLE || FLEET_WINDOW_RENAME_PATTERN.test(state.window)) {
     const project = state.project?.split('/').pop();
     return project && project.length > 0 ? project : state.session;
   }


### PR DESCRIPTION
## Summary
- Treat `☰ ...` window names as Fleet-owned renames, matching the existing literal `fleet` pane-title masking.
- Fall back to the agent project basename when a Fleet sidebar in `$HOME` causes a title-aware tmux renamer to rename the window to something like `☰ nicknisi`.
- Add regression coverage for the sidebar-icon rename case.

## Test plan
- `bun test` — 552 passed
- `bun run typecheck`
- `bun run lint`
- `bunx oxfmt --check src/state/types.ts src/state/types.test.ts`
- `git diff --check`
