### PR TITLE
feat: support custom state palettes

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,15 +217,44 @@ The in-tmux status-line flash still fires as before. The terminal **bell**, thou
 
 ## Theming
 
-Fleet ships two palettes — Catppuccin Mocha for dark terminals, Catppuccin Latte for light ones — and picks between them automatically. Detection walks a chain and stops at the first hit:
+Fleet ships two state palettes — Catppuccin Mocha for dark terminals, Catppuccin Latte for light ones — and picks between them automatically. You can customize the seven agent-state colors with `${XDG_CONFIG_HOME:-$HOME/.config}/fleet/theme.toml`:
+
+```toml
+[colors]
+permit = "yellow"
+question = "magenta"
+done = "green"
+busy = "bright-red"
+idle = "blue"
+shell = "bright-black"
+down = "white"
+```
+
+Each role is required and accepts one of the 16 ANSI foreground names (`black` through `white`, plus their `bright-` variants) or a six-digit `#rrggbb` value. ANSI colors follow your terminal palette; RGB colors remain fixed, and the two forms can be mixed:
+
+```toml
+[colors]
+permit = "yellow"
+question = "#cba6f7"
+done = "green"
+busy = "#fab387"
+idle = "blue"
+shell = "bright-black"
+down = "#45475a"
+```
+
+This is state-palette customization, not complete UI theming: chrome, style modifiers, pane previews, glyphs, and the tmux status line are unchanged. A missing file is normal. An invalid or unreadable file prints one warning and falls back to automatic selection.
+
+Selection walks this chain and stops at the first hit:
 
 1. **`FLEET_THEME`** — `FLEET_THEME=light` or `FLEET_THEME=dark` forces the theme outright.
 2. **tmux option** — `tmux set -g @fleet-theme light` (or `dark`) pins it for every Fleet launched in that tmux server.
-3. **Terminal background** — outside tmux, Fleet asks the terminal for its background color (OSC 11), falling back to `COLORFGBG` if the terminal exports it. Current tmux doesn't forward the OSC 11 query, so this rung only fires when you run Fleet directly, not through tmux.
-4. **macOS appearance** — inside tmux on a Mac, Fleet follows the system Light/Dark setting. This is the rung that makes auto-switching work in a normal tmux session.
-5. Otherwise it defaults to dark (Mocha).
+3. **Custom state palette** — a valid XDG `theme.toml` selects its ANSI/RGB colors.
+4. **Terminal background** — outside tmux, Fleet asks the terminal for its background color (OSC 11), falling back to `COLORFGBG` if the terminal exports it. Current tmux doesn't forward the OSC 11 query, so this rung only fires when you run Fleet directly, not through tmux.
+5. **macOS appearance** — inside tmux on a Mac, Fleet follows the system Light/Dark setting. This is the rung that makes auto-switching work in a normal tmux session.
+6. Otherwise it defaults to dark (Mocha).
 
-`NO_COLOR` is always honored: set it and Fleet renders monochrome, whatever the theme would have been.
+`NO_COLOR` is always honored: set it and Fleet emits no color or styling escape sequences, whatever the theme would have been. It produces plain terminal text; it is not an ANSI-color fallback.
 
 ## Configuration
 

--- a/index.ts
+++ b/index.ts
@@ -15,8 +15,8 @@ import {
   setPaneTitle,
   getTerminalSize,
 } from './src/terminal/terminal.ts';
-import { setThemeMode, C } from './src/terminal/colors.ts';
-import { detectThemeMode } from './src/terminal/theme.ts';
+import { setStatePalette, setThemeMode, C } from './src/terminal/colors.ts';
+import { detectTheme, prepareTheme } from './src/terminal/theme.ts';
 import { fuseState, hookStateForStatus } from './src/state/engine.ts';
 import {
   readAllStatusDirs,
@@ -761,13 +761,16 @@ async function launchTui(): Promise<number> {
     app.mode = TuiMode.PREVIEW;
   }
 
-  // Raw mode first so the OSC 11 theme reply is readable from stdin, then the
-  // rest of the terminal setup. Detection is instant inside tmux or with an
+  // Read and validate the optional palette before raw mode so warnings are
+  // ordinary stderr output. Raw mode then makes the OSC 11 reply readable from
+  // stdin. Detection is instant inside tmux or with an
   // explicit FLEET_THEME/@fleet-theme override; only a direct terminal query
   // (outside tmux, no override) costs up to 150ms.
+  const themeStartup = prepareTheme();
   enterRawMode();
-  const detectedTheme = await detectThemeMode();
-  setThemeMode(detectedTheme.mode);
+  const detectedTheme = await detectTheme(themeStartup);
+  if (detectedTheme.selection.palette) setStatePalette(detectedTheme.selection.palette);
+  else setThemeMode(detectedTheme.selection.mode);
   enterAlternateScreen();
   hideCursor();
   enableMouse();

--- a/src/terminal/colors.test.ts
+++ b/src/terminal/colors.test.ts
@@ -1,30 +1,59 @@
 import { afterEach, describe, expect, test } from 'bun:test';
-import { getThemeMode, setThemeMode, stateRgb } from './colors.ts';
+import {
+  getThemeMode,
+  serializeThemeColor,
+  setStatePalette,
+  setThemeMode,
+  stateThemeColor,
+  type StatePalette,
+} from './colors.ts';
+
+const customPalette: StatePalette = {
+  permit: { kind: 'ansi', code: 33 },
+  question: { kind: 'rgb', r: 203, g: 166, b: 247 },
+  done: { kind: 'ansi', code: 32 },
+  busy: { kind: 'rgb', r: 250, g: 179, b: 135 },
+  idle: { kind: 'ansi', code: 34 },
+  shell: { kind: 'ansi', code: 90 },
+  down: { kind: 'rgb', r: 69, g: 71, b: 90 },
+};
 
 describe('theme palettes', () => {
   afterEach(() => setThemeMode('dark'));
 
   test('defaults to dark (Catppuccin Mocha)', () => {
     expect(getThemeMode()).toBe('dark');
-    expect(stateRgb('permit')).toEqual([249, 226, 175]);
-    expect(stateRgb('idle')).toEqual([137, 180, 250]);
+    expect(stateThemeColor('permit')).toEqual({ kind: 'rgb', r: 249, g: 226, b: 175 });
+    expect(stateThemeColor('idle')).toEqual({ kind: 'rgb', r: 137, g: 180, b: 250 });
   });
 
   test('light mode swaps to Catppuccin Latte', () => {
     setThemeMode('light');
     expect(getThemeMode()).toBe('light');
-    expect(stateRgb('permit')).toEqual([223, 142, 29]);
-    expect(stateRgb('question')).toEqual([136, 57, 239]);
-    expect(stateRgb('done')).toEqual([64, 160, 43]);
-    expect(stateRgb('busy')).toEqual([254, 100, 11]);
-    expect(stateRgb('idle')).toEqual([30, 102, 245]);
-    expect(stateRgb('shell')).toEqual([156, 160, 176]);
-    expect(stateRgb('down')).toEqual([188, 192, 204]);
+    expect(stateThemeColor('permit')).toEqual({ kind: 'rgb', r: 223, g: 142, b: 29 });
+    expect(stateThemeColor('question')).toEqual({ kind: 'rgb', r: 136, g: 57, b: 239 });
+    expect(stateThemeColor('done')).toEqual({ kind: 'rgb', r: 64, g: 160, b: 43 });
+    expect(stateThemeColor('busy')).toEqual({ kind: 'rgb', r: 254, g: 100, b: 11 });
+    expect(stateThemeColor('idle')).toEqual({ kind: 'rgb', r: 30, g: 102, b: 245 });
+    expect(stateThemeColor('shell')).toEqual({ kind: 'rgb', r: 156, g: 160, b: 176 });
+    expect(stateThemeColor('down')).toEqual({ kind: 'rgb', r: 188, g: 192, b: 204 });
   });
 
-  test('switching back restores Mocha', () => {
-    setThemeMode('light');
-    setThemeMode('dark');
-    expect(stateRgb('done')).toEqual([166, 227, 161]);
+  test('custom palettes can mix ANSI and RGB colors', () => {
+    setStatePalette(customPalette);
+    expect(getThemeMode()).toBeNull();
+    expect(stateThemeColor('permit')).toEqual({ kind: 'ansi', code: 33 });
+    expect(stateThemeColor('question')).toEqual({ kind: 'rgb', r: 203, g: 166, b: 247 });
+  });
+});
+
+describe('serializeThemeColor', () => {
+  test('serializes ANSI and RGB foreground colors', () => {
+    expect(serializeThemeColor({ kind: 'ansi', code: 94 }, true)).toBe('\x1b[94m');
+    expect(serializeThemeColor({ kind: 'rgb', r: 203, g: 166, b: 247 }, true)).toBe('\x1b[38;2;203;166;247m');
+  });
+
+  test('emits nothing when colors are disabled', () => {
+    expect(serializeThemeColor({ kind: 'ansi', code: 94 }, false)).toBe('');
   });
 });

--- a/src/terminal/colors.ts
+++ b/src/terminal/colors.ts
@@ -13,47 +13,65 @@ function code(c: string): string {
   return c;
 }
 
-function rgb(r: number, g: number, b: number): string {
-  return code(`\x1b[38;2;${r};${g};${b}m`);
-}
-
 export type StateColorKey = 'permit' | 'question' | 'done' | 'busy' | 'idle' | 'shell' | 'down';
 
-type StatePalette = Record<StateColorKey, readonly [number, number, number]>;
+export type AnsiColor = { kind: 'ansi'; code: number };
+export type RgbColor = { kind: 'rgb'; r: number; g: number; b: number };
+export type ThemeColor = AnsiColor | RgbColor;
+export type StatePalette = Record<StateColorKey, ThemeColor>;
+
+const rgb = (r: number, g: number, b: number): RgbColor => ({ kind: 'rgb', r, g, b });
+
+export function serializeThemeColor(color: ThemeColor, enabled = !(forceNoColor || noColor || !isTTY)): string {
+  if (!enabled) return '';
+  if (color.kind === 'ansi') return `\x1b[${color.code}m`;
+  return `\x1b[38;2;${color.r};${color.g};${color.b}m`;
+}
+
+function stateColor(color: ThemeColor): string {
+  return serializeThemeColor(color);
+}
 
 // Catppuccin Mocha (dark terminals): yellow, mauve, green, peach, blue, overlay0, surface1
 const MOCHA: StatePalette = {
-  permit: [249, 226, 175],
-  question: [203, 166, 247],
-  done: [166, 227, 161],
-  busy: [250, 179, 135],
-  idle: [137, 180, 250],
-  shell: [108, 112, 134],
-  down: [69, 71, 90],
+  permit: rgb(249, 226, 175),
+  question: rgb(203, 166, 247),
+  done: rgb(166, 227, 161),
+  busy: rgb(250, 179, 135),
+  idle: rgb(137, 180, 250),
+  shell: rgb(108, 112, 134),
+  down: rgb(69, 71, 90),
 };
 
 // Catppuccin Latte (light terminals): same roles, legible on white
 const LATTE: StatePalette = {
-  permit: [223, 142, 29],
-  question: [136, 57, 239],
-  done: [64, 160, 43],
-  busy: [254, 100, 11],
-  idle: [30, 102, 245],
-  shell: [156, 160, 176],
-  down: [188, 192, 204],
+  permit: rgb(223, 142, 29),
+  question: rgb(136, 57, 239),
+  done: rgb(64, 160, 43),
+  busy: rgb(254, 100, 11),
+  idle: rgb(30, 102, 245),
+  shell: rgb(156, 160, 176),
+  down: rgb(188, 192, 204),
 };
 
 let activePalette: StatePalette = MOCHA;
+let activeMode: ThemeMode | null = 'dark';
 
 export function setThemeMode(mode: ThemeMode): void {
   activePalette = mode === 'light' ? LATTE : MOCHA;
+  activeMode = mode;
 }
 
-export function getThemeMode(): ThemeMode {
-  return activePalette === LATTE ? 'light' : 'dark';
+export function setStatePalette(palette: StatePalette): void {
+  activePalette = palette;
+  activeMode = null;
 }
 
-export function stateRgb(key: StateColorKey): readonly [number, number, number] {
+export function getThemeMode(): ThemeMode | null {
+  return activeMode;
+}
+
+export function stateThemeColor(key: StateColorKey): ThemeColor {
   return activePalette[key];
 }
 
@@ -103,26 +121,26 @@ export const C = {
   get underline() {
     return code('\x1b[4m');
   },
-  // State colors route through the active palette (Mocha/Latte per theme).
+  // State colors route through the active built-in or custom palette.
   get permit() {
-    return rgb(...activePalette.permit);
+    return stateColor(activePalette.permit);
   },
   get question() {
-    return rgb(...activePalette.question);
+    return stateColor(activePalette.question);
   },
   get done() {
-    return rgb(...activePalette.done);
+    return stateColor(activePalette.done);
   },
   get busy() {
-    return rgb(...activePalette.busy);
+    return stateColor(activePalette.busy);
   },
   get idle() {
-    return rgb(...activePalette.idle);
+    return stateColor(activePalette.idle);
   },
   get shell() {
-    return rgb(...activePalette.shell);
+    return stateColor(activePalette.shell);
   },
   get down() {
-    return rgb(...activePalette.down);
+    return stateColor(activePalette.down);
   },
 } as const;

--- a/src/terminal/theme.test.ts
+++ b/src/terminal/theme.test.ts
@@ -1,15 +1,34 @@
 // src/terminal/theme.test.ts
 import { describe, expect, test } from 'bun:test';
 import {
+  loadCustomStatePalette,
   luminance,
   modeFromBackground,
   modeFromColorFgBg,
   parseOsc11Reply,
+  parseStatePalette,
+  parseThemeColor,
+  resolveThemePath,
+  resolveThemeSelection,
   resolveThemeMode,
   shouldQueryOsc,
   stripOsc11Reply,
   type ThemeSignals,
 } from './theme.ts';
+
+const paletteSource = {
+  colors: {
+    permit: 'yellow',
+    question: '#CBA6F7',
+    done: 'green',
+    busy: '#fab387',
+    idle: 'blue',
+    shell: 'bright-black',
+    down: '#45475a',
+  },
+};
+
+const palette = parseStatePalette(paletteSource);
 
 const signals = (over: Partial<ThemeSignals>): ThemeSignals => ({
   envTheme: undefined,
@@ -73,6 +92,107 @@ describe('modeFromColorFgBg', () => {
   test('junk is null', () => expect(modeFromColorFgBg('banana')).toBeNull());
 });
 
+describe('custom state palettes', () => {
+  test('maps all 16 ANSI names to their foreground codes', () => {
+    const names = [
+      'black',
+      'red',
+      'green',
+      'yellow',
+      'blue',
+      'magenta',
+      'cyan',
+      'white',
+      'bright-black',
+      'bright-red',
+      'bright-green',
+      'bright-yellow',
+      'bright-blue',
+      'bright-magenta',
+      'bright-cyan',
+      'bright-white',
+    ];
+    expect(names.map((name) => parseThemeColor(name))).toEqual(
+      [...Array(8).keys(), ...Array(8).keys()].map((offset, index) => ({
+        kind: 'ansi',
+        code: (index < 8 ? 30 : 90) + offset,
+      })),
+    );
+  });
+
+  test('accepts lowercase and uppercase six-digit RGB', () => {
+    expect(parseThemeColor('#cba6f7')).toEqual({ kind: 'rgb', r: 203, g: 166, b: 247 });
+    expect(parseThemeColor('#CBA6F7')).toEqual({ kind: 'rgb', r: 203, g: 166, b: 247 });
+  });
+
+  test.each(['#fff', '#cba6f7ff', '#gggggg', 'orange', 42])('rejects unsupported color %p', (value) => {
+    expect(() => parseThemeColor(value)).toThrow();
+  });
+
+  test('accepts a complete mixed palette', () => {
+    expect(palette.permit).toEqual({ kind: 'ansi', code: 33 });
+    expect(palette.question).toEqual({ kind: 'rgb', r: 203, g: 166, b: 247 });
+  });
+
+  for (const key of Object.keys(paletteSource.colors)) {
+    test(`rejects a palette missing ${key}`, () => {
+      const colors = { ...paletteSource.colors } as Record<string, unknown>;
+      delete colors[key];
+      expect(() => parseStatePalette({ colors })).toThrow(`missing color "${key}"`);
+    });
+  }
+
+  test('rejects unknown keys and missing or invalid colors tables', () => {
+    expect(() => parseStatePalette({ colors: { ...paletteSource.colors, accent: 'red' } })).toThrow(
+      'unknown color key "accent"',
+    );
+    expect(() => parseStatePalette({})).toThrow('theme must contain a [colors] table');
+    expect(() => parseStatePalette({ colors: 'red' })).toThrow('theme must contain a [colors] table');
+  });
+});
+
+describe('custom state palette loader', () => {
+  test('resolves XDG_CONFIG_HOME with HOME fallback for unset and empty values', () => {
+    expect(resolveThemePath({}, '/home/test')).toBe('/home/test/.config/fleet/theme.toml');
+    expect(resolveThemePath({ XDG_CONFIG_HOME: '' }, '/home/test')).toBe('/home/test/.config/fleet/theme.toml');
+    expect(resolveThemePath({ XDG_CONFIG_HOME: '/tmp/config' }, '/home/test')).toBe('/tmp/config/fleet/theme.toml');
+  });
+
+  test('returns null without warning when the file is missing', () => {
+    const warnings: string[] = [];
+    expect(
+      loadCustomStatePalette({ path: '/missing/theme.toml', exists: () => false, warn: (m) => warnings.push(m) }),
+    ).toBeNull();
+    expect(warnings).toEqual([]);
+  });
+
+  test('loads a valid TOML palette', () => {
+    const source = Object.entries(paletteSource.colors)
+      .map(([key, value]) => `${key} = "${value}"`)
+      .join('\n');
+    expect(
+      loadCustomStatePalette({ path: '/theme.toml', exists: () => true, read: () => `[colors]\n${source}` }),
+    ).toEqual(palette);
+  });
+
+  test.each([
+    ['invalid TOML', () => 'not = [valid'],
+    [
+      'unreadable file',
+      () => {
+        throw new Error('permission denied');
+      },
+    ],
+  ])('warns once and falls back for an %s', (_name, read) => {
+    const warnings: string[] = [];
+    expect(
+      loadCustomStatePalette({ path: '/theme.toml', exists: () => true, read, warn: (m) => warnings.push(m) }),
+    ).toBeNull();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('/theme.toml');
+  });
+});
+
 describe('resolveThemeMode precedence', () => {
   test('defaults to dark with no signals', () => {
     expect(resolveThemeMode(signals({}))).toBe('dark');
@@ -102,6 +222,32 @@ describe('resolveThemeMode precedence', () => {
   });
 });
 
+describe('resolveThemeSelection precedence', () => {
+  const withPalette = (over: Partial<ThemeSignals>) => signals({ customPalette: palette, ...over });
+
+  test('valid environment and tmux modes beat the custom palette', () => {
+    expect(resolveThemeSelection(withPalette({ envTheme: 'light', tmuxOption: 'dark' }))).toEqual({
+      mode: 'light',
+      palette: null,
+    });
+    expect(resolveThemeSelection(withPalette({ tmuxOption: 'dark' }))).toEqual({ mode: 'dark', palette: null });
+  });
+
+  test('custom palette beats automatic detection', () => {
+    expect(resolveThemeSelection(withPalette({ oscBackground: { r: 255, g: 255, b: 255 } }))).toEqual({
+      mode: null,
+      palette,
+    });
+  });
+
+  test('invalid overrides do not block the custom palette', () => {
+    expect(resolveThemeSelection(withPalette({ envTheme: 'solarized', tmuxOption: 'auto' }))).toEqual({
+      mode: null,
+      palette,
+    });
+  });
+});
+
 describe('shouldQueryOsc', () => {
   test('queries when outside tmux with no overrides', () => {
     expect(shouldQueryOsc({}, null)).toBe(true);
@@ -112,6 +258,9 @@ describe('shouldQueryOsc', () => {
   test('skips on explicit env or tmux option', () => {
     expect(shouldQueryOsc({ FLEET_THEME: 'light' }, null)).toBe(false);
     expect(shouldQueryOsc({}, 'dark')).toBe(false);
+  });
+  test('skips when a valid custom palette is selected', () => {
+    expect(shouldQueryOsc({}, null, palette)).toBe(false);
   });
   test('invalid override values do not skip by themselves', () => {
     expect(shouldQueryOsc({ FLEET_THEME: 'solarized' }, 'auto')).toBe(true);

--- a/src/terminal/theme.ts
+++ b/src/terminal/theme.ts
@@ -1,5 +1,9 @@
 // src/terminal/theme.ts
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import { getTmuxOption } from '../tmux/ipc.ts';
+import type { StateColorKey, StatePalette, ThemeColor } from './colors.ts';
 
 export type ThemeMode = 'light' | 'dark';
 
@@ -7,6 +11,100 @@ export interface Rgb {
   r: number;
   g: number;
   b: number;
+}
+
+const STATE_COLOR_KEYS = ['permit', 'question', 'done', 'busy', 'idle', 'shell', 'down'] as const;
+
+const ANSI_FOREGROUND_CODES: Record<string, number> = {
+  black: 30,
+  red: 31,
+  green: 32,
+  yellow: 33,
+  blue: 34,
+  magenta: 35,
+  cyan: 36,
+  white: 37,
+  'bright-black': 90,
+  'bright-red': 91,
+  'bright-green': 92,
+  'bright-yellow': 93,
+  'bright-blue': 94,
+  'bright-magenta': 95,
+  'bright-cyan': 96,
+  'bright-white': 97,
+};
+
+export function parseThemeColor(value: unknown): ThemeColor {
+  if (typeof value !== 'string') throw new Error('color values must be strings');
+  const ansiCode = ANSI_FOREGROUND_CODES[value];
+  if (ansiCode !== undefined) return { kind: 'ansi', code: ansiCode };
+  if (/^#[0-9a-fA-F]{6}$/.test(value)) {
+    return {
+      kind: 'rgb',
+      r: parseInt(value.slice(1, 3), 16),
+      g: parseInt(value.slice(3, 5), 16),
+      b: parseInt(value.slice(5, 7), 16),
+    };
+  }
+  throw new Error(`unsupported color ${JSON.stringify(value)}`);
+}
+
+function parsePaletteColor(key: StateColorKey, value: unknown): ThemeColor {
+  try {
+    return parseThemeColor(value);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(`invalid ${JSON.stringify(key)}: ${reason}`);
+  }
+}
+
+export function parseStatePalette(value: unknown): StatePalette {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error('theme must contain a [colors] table');
+  }
+  const colors = (value as Record<string, unknown>).colors;
+  if (typeof colors !== 'object' || colors === null || Array.isArray(colors)) {
+    throw new Error('theme must contain a [colors] table');
+  }
+  const colorValues = colors as Record<string, unknown>;
+  for (const key of Object.keys(colorValues)) {
+    if (!STATE_COLOR_KEYS.includes(key as StateColorKey)) throw new Error(`unknown color key ${JSON.stringify(key)}`);
+  }
+  const palette = {} as StatePalette;
+  for (const key of STATE_COLOR_KEYS) {
+    if (!(key in colorValues)) throw new Error(`missing color ${JSON.stringify(key)}`);
+    palette[key] = parsePaletteColor(key, colorValues[key]);
+  }
+  return palette;
+}
+
+export function resolveThemePath(env: { XDG_CONFIG_HOME?: string }, home: string): string {
+  const configHome = env.XDG_CONFIG_HOME || join(home, '.config');
+  return join(configHome, 'fleet', 'theme.toml');
+}
+
+interface ThemeLoaderOptions {
+  env?: { XDG_CONFIG_HOME?: string };
+  home?: string;
+  path?: string;
+  warn?: (message: string) => void;
+  exists?: (path: string) => boolean;
+  read?: (path: string) => string;
+}
+
+export function loadCustomStatePalette(options: ThemeLoaderOptions = {}): StatePalette | null {
+  const env = options.env ?? { XDG_CONFIG_HOME: Bun.env.XDG_CONFIG_HOME };
+  const path = options.path ?? resolveThemePath(env, options.home ?? homedir());
+  if (!(options.exists ?? existsSync)(path)) return null;
+  try {
+    return parseStatePalette(Bun.TOML.parse((options.read ?? ((file) => readFileSync(file, 'utf8')))(path)));
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    (options.warn ?? ((message) => process.stderr.write(`${message}\n`)))(
+      `fleet: invalid state palette at ${path}: ${reason}`,
+    );
+    return null;
+  }
 }
 
 // OSC 11 reply: ESC ] 11 ; rgb:RRRR/GGGG/BBBB terminated by BEL or ST (ESC \).
@@ -51,6 +149,22 @@ export interface ThemeSignals {
   oscBackground: Rgb | null; // parsed OSC 11 reply
   colorFgBg: string | undefined; // COLORFGBG env
   macAppearance: 'Dark' | 'Light' | null; // AppleInterfaceStyle; null off-macOS
+  customPalette?: StatePalette | null;
+}
+
+export type ThemeSelection = { mode: ThemeMode; palette: null } | { mode: null; palette: StatePalette };
+
+export interface ThemeStartup {
+  envTheme: string | undefined;
+  tmuxOption: string | null;
+  customPalette: StatePalette | null;
+}
+
+export function resolveThemeSelection(s: ThemeSignals): ThemeSelection {
+  if (s.envTheme === 'light' || s.envTheme === 'dark') return { mode: s.envTheme, palette: null };
+  if (s.tmuxOption === 'light' || s.tmuxOption === 'dark') return { mode: s.tmuxOption, palette: null };
+  if (s.customPalette) return { mode: null, palette: s.customPalette };
+  return { mode: resolveThemeMode(s), palette: null };
 }
 
 // First hit wins: explicit overrides, then measured signals, then default.
@@ -69,9 +183,14 @@ export function resolveThemeMode(s: ThemeSignals): ThemeMode {
 // Whether the OSC 11 round-trip is worth attempting. Inside tmux the query is
 // not forwarded to the outer terminal (verified on tmux 3.7a), so waiting out
 // the timeout only delays startup — skip straight to the env/OS rungs.
-export function shouldQueryOsc(env: { TMUX?: string; FLEET_THEME?: string }, tmuxOption: string | null): boolean {
+export function shouldQueryOsc(
+  env: { TMUX?: string; FLEET_THEME?: string },
+  tmuxOption: string | null,
+  customPalette: StatePalette | null = null,
+): boolean {
   if (env.FLEET_THEME === 'light' || env.FLEET_THEME === 'dark') return false;
   if (tmuxOption === 'light' || tmuxOption === 'dark') return false;
+  if (customPalette) return false;
   if (env.TMUX) return false;
   return true;
 }
@@ -92,6 +211,22 @@ export function readMacAppearance(): 'Dark' | 'Light' | null {
   } catch {
     return null;
   }
+}
+
+function explicitThemeMode(envTheme: string | undefined, tmuxOption: string | null): ThemeMode | null {
+  if (envTheme === 'light' || envTheme === 'dark') return envTheme;
+  if (tmuxOption === 'light' || tmuxOption === 'dark') return tmuxOption;
+  return null;
+}
+
+export function prepareTheme(): ThemeStartup {
+  const envTheme = Bun.env.FLEET_THEME;
+  const tmuxOption = readTmuxThemeOption();
+  return {
+    envTheme,
+    tmuxOption,
+    customPalette: explicitThemeMode(envTheme, tmuxOption) ? null : loadCustomStatePalette(),
+  };
 }
 
 const OSC11_QUERY = '\x1b]11;?\x07';
@@ -131,26 +266,30 @@ export function queryOscBackground(
   });
 }
 
-export async function detectThemeMode(): Promise<{ mode: ThemeMode; leftover: Buffer }> {
-  const envTheme = Bun.env.FLEET_THEME;
-  const tmuxOption = readTmuxThemeOption();
-  if (!shouldQueryOsc({ TMUX: Bun.env.TMUX, FLEET_THEME: envTheme }, tmuxOption)) {
-    const mode = resolveThemeMode({
+export async function detectTheme(startup = prepareTheme()): Promise<{ selection: ThemeSelection; leftover: Buffer }> {
+  const { envTheme, tmuxOption, customPalette } = startup;
+  const explicitMode = explicitThemeMode(envTheme, tmuxOption);
+  if (explicitMode) return { selection: { mode: explicitMode, palette: null }, leftover: Buffer.alloc(0) };
+
+  if (!shouldQueryOsc({ TMUX: Bun.env.TMUX, FLEET_THEME: envTheme }, tmuxOption, customPalette)) {
+    const selection = resolveThemeSelection({
       envTheme,
       tmuxOption,
       oscBackground: null,
       colorFgBg: Bun.env.COLORFGBG,
       macAppearance: readMacAppearance(),
+      customPalette,
     });
-    return { mode, leftover: Buffer.alloc(0) };
+    return { selection, leftover: Buffer.alloc(0) };
   }
   const { background, leftover } = await queryOscBackground();
-  const mode = resolveThemeMode({
+  const selection = resolveThemeSelection({
     envTheme,
     tmuxOption,
     oscBackground: background,
     colorFgBg: Bun.env.COLORFGBG,
     macAppearance: readMacAppearance(),
+    customPalette,
   });
-  return { mode, leftover };
+  return { selection, leftover };
 }


### PR DESCRIPTION
## Summary

Hi! I’ve been using Fleet in my tmux workflow and wanted its state colors to fit my terminal theme a little more naturally. This PR adds an optional custom state palette for Fleet’s seven agent states while keeping the existing automatic Catppuccin behavior as the default.

Fleet looks for:

`${XDG_CONFIG_HOME:-$HOME/.config}/fleet/theme.toml`

Each state color can use either one of the 16 canonical ANSI foreground names or a six-digit `#rrggbb` value. ANSI colors follow the active terminal palette, while RGB colors remain fixed. The two forms can be mixed within the same palette.

I kept this intentionally narrow to state colors rather than making it a complete UI theming system. It doesn’t change Fleet’s chrome, pane previews, glyphs, typography, or tmux status-line formatting.

## Behavior

- All seven state roles are required: `permit`, `question`, `done`, `busy`, `idle`, `shell`, and `down`.
- `FLEET_THEME` and tmux’s `@fleet-theme` continue to take precedence.
- A valid custom palette skips the OSC 11 background query.
- A missing file is treated normally without producing output.
- Invalid or unreadable files emit one warning and fall back to Fleet’s existing automatic theme selection.
- `NO_COLOR` continues to disable Fleet-generated color and styling.
- The palette is loaded once at startup.

The implementation uses Bun’s built-in TOML parser and adds no runtime dependencies.

## Testing

- Added coverage for ANSI and RGB parsing and serialization.
- Added strict schema and loader coverage, including missing, malformed, and unreadable files.
- Added selection-precedence and OSC-query coverage.
- Ran the full test suite, typecheck, lint, format check, and compiled build.
- Manually tested a custom truecolor palette in Ghostty 1.3.1 with tmux 3.7b while running multiple agents.

Happy to adjust the file name or schema if you’d prefer a different shape here.
