### PR TITLE
fix: send agent-aware keys when approving/denying permission prompts

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -63,7 +63,8 @@ import {
 } from './src/tmux/sessions.ts';
 import { tmux, tmuxOrNull } from './src/tmux/ipc.ts';
 import { detectPorts } from './src/tmux/ports.ts';
-import { sendKeys, sendRawKey } from './src/tmux/send.ts';
+import { sendKeys, sendKeyNames, sendRawKey } from './src/tmux/send.ts';
+import { resolvePermitKeys } from './src/state/permit-keys.ts';
 import { runStatus } from './src/cli/status.ts';
 import { runSidebar } from './src/cli/sidebar.ts';
 import { runNext } from './src/cli/next.ts';
@@ -1031,8 +1032,11 @@ async function launchTui(): Promise<number> {
               if (app.mode === TuiMode.PREVIEW) {
                 const sel = app.selectedState();
                 if (sel && sel.status === AgentStatus.PERMIT) {
+                  // Agent-aware approval: claude wants '1' (numbered menu),
+                  // codex/opencode want Enter, a genuine [y/n] prompt wants a
+                  // literal 'y' — resolved per agent + on-screen dialog (#40).
                   try {
-                    sendRawKey(sel.paneId, Buffer.from('y'));
+                    sendKeyNames(sel.paneId, resolvePermitKeys(sel.paneId, sel.agentType, 'approve'));
                   } catch {}
                 }
               }
@@ -1042,7 +1046,7 @@ async function launchTui(): Promise<number> {
                 const sel = app.selectedState();
                 if (sel && sel.status === AgentStatus.PERMIT) {
                   try {
-                    sendRawKey(sel.paneId, Buffer.from('n'));
+                    sendKeyNames(sel.paneId, resolvePermitKeys(sel.paneId, sel.agentType, 'deny'));
                   } catch {}
                   break;
                 }

--- a/src/state/detection.test.ts
+++ b/src/state/detection.test.ts
@@ -246,6 +246,29 @@ test('a valid user override replaces the built-in manifest entirely', () => {
   expect(detectFromPaneContent(['PICK ONE of these'], m)).toEqual({ status: AgentStatus.QUESTION, ruleId: 'q.only' });
 });
 
+// 3b. Answer keys (issue #40) ride the override path: valid rule- and
+//     manifest-level key arrays survive validation; junk entries are dropped and
+//     an all-junk array is treated as absent, never an error.
+test('an override carries approve/deny keys; junk key values are dropped', () => {
+  const cfg = writeOverride(
+    'claude',
+    JSON.stringify({
+      agent: 'claude',
+      rules: [{ id: 'permit.yn', pattern: '\\[y/n\\]', state: 'PERMIT', approveKeys: ['y', 7, ''], denyKeys: ['n'] }],
+      approveKeys: ['1'],
+      denyKeys: [42],
+    }),
+  );
+  process.env.XDG_CONFIG_HOME = cfg;
+  __resetManifestCache();
+
+  const m = loadDetectionManifest('claude');
+  expect(m.rules[0]!.approveKeys).toEqual(['y']); // non-strings dropped
+  expect(m.rules[0]!.denyKeys).toEqual(['n']);
+  expect(m.approveKeys).toEqual(['1']);
+  expect(m.denyKeys).toBeUndefined(); // all-junk array -> absent
+});
+
 // 4. Malformed override -> built-in + warn (must never throw). Two variants.
 test('a malformed-JSON override is ignored: built-in used, warning emitted, no throw', () => {
   const cfg = writeOverride('claude', '{ this is not valid json ]');

--- a/src/state/detection.ts
+++ b/src/state/detection.ts
@@ -11,6 +11,12 @@ export interface DetectionRule {
   pattern: string; // JavaScript RegExp source (JSON-escaped on disk)
   flags?: string; // e.g. "i"
   state: RuleState;
+  // tmux send-keys key names (e.g. ["y"], ["1"], ["Enter"], ["Escape"]) that
+  // answer THIS prompt, for PERMIT rules whose dialog differs from the agent's
+  // default (a genuine [y/n] prompt on an agent whose menus want Enter).
+  // Optional: absent means the manifest-level keys apply.
+  approveKeys?: string[];
+  denyKeys?: string[];
 }
 
 export interface DetectionManifest {
@@ -25,6 +31,12 @@ export interface DetectionManifest {
   // without the harness doing it). ORDERED; first match wins. Optional: absent
   // means the agent has no title signal.
   titleRules?: DetectionRule[];
+  // Agent-level default answer keys for a PERMIT dialog (tmux send-keys key
+  // names). Used when the matched PERMIT rule names no keys of its own, and for
+  // hook/title-sourced PERMIT where no screen rule matched at all. Absent means
+  // fall back to literal y/n (the pre-agent-aware behavior).
+  approveKeys?: string[];
+  denyKeys?: string[];
 }
 
 const DEFAULT_LINES_FROM_BOTTOM = 15;
@@ -62,6 +74,15 @@ export function getCompiledRegex(rule: DetectionRule): RegExp | null {
 // --- override validation (schema only; JSON.parse already ran) ---
 const VALID_STATES: ReadonlySet<string> = new Set(['PERMIT', 'QUESTION', 'BUSY', 'IDLE']);
 
+// Answer-key arrays from overrides: keep only non-empty strings; an empty or
+// non-array value is treated as absent (fall through to the next default),
+// never an error.
+function validateKeys(raw: unknown): string[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const keys = raw.filter((k): k is string => typeof k === 'string' && k.length > 0);
+  return keys.length > 0 ? keys : undefined;
+}
+
 function validateRules(raw: unknown[]): DetectionRule[] {
   const rules: DetectionRule[] = [];
   for (const r of raw) {
@@ -70,11 +91,15 @@ function validateRules(raw: unknown[]): DetectionRule[] {
     if (typeof rule.id !== 'string' || typeof rule.pattern !== 'string') continue;
     if (typeof rule.state !== 'string' || !VALID_STATES.has(rule.state)) continue;
     const flags = typeof rule.flags === 'string' ? rule.flags : undefined;
+    const approveKeys = validateKeys(rule.approveKeys);
+    const denyKeys = validateKeys(rule.denyKeys);
     const candidate: DetectionRule = {
       id: rule.id,
       pattern: rule.pattern,
       flags,
       state: rule.state as RuleState,
+      ...(approveKeys ? { approveKeys } : {}),
+      ...(denyKeys ? { denyKeys } : {}),
     };
     // Drop bad-regex rules at load with one warning (not once per scrape).
     if (getCompiledRegex(candidate) === null) continue;
@@ -96,6 +121,8 @@ function validateManifest(raw: unknown, agent: string): DetectionManifest {
     rules: validateRules(m.rules),
     // titleRules is optional; a non-array value is treated as absent, not an error.
     ...(Array.isArray(m.titleRules) ? { titleRules: validateRules(m.titleRules) } : {}),
+    ...(validateKeys(m.approveKeys) ? { approveKeys: validateKeys(m.approveKeys) } : {}),
+    ...(validateKeys(m.denyKeys) ? { denyKeys: validateKeys(m.denyKeys) } : {}),
   };
 }
 
@@ -142,7 +169,14 @@ export const CLAUDE_MANIFEST: DetectionManifest = {
     { id: 'busy.token-counter-min', pattern: '\\(\\d+m\\s+\\d+s\\s+·.*tokens?\\)', state: 'BUSY' },
     { id: 'busy.token-counter-sec', pattern: '\\(\\d+s\\s+·.*tokens?\\)', state: 'BUSY' },
     { id: 'busy.esc-interrupt', pattern: 'esc to interrupt', flags: 'i', state: 'BUSY' },
-    { id: 'permit.yn', pattern: '\\[y/n\\]|\\[Y/n\\]', flags: 'i', state: 'PERMIT' },
+    {
+      id: 'permit.yn',
+      pattern: '\\[y/n\\]|\\[Y/n\\]',
+      flags: 'i',
+      state: 'PERMIT',
+      approveKeys: ['y'],
+      denyKeys: ['n'],
+    },
     { id: 'permit.do-you-want', pattern: 'Do you want to (proceed|allow)', state: 'PERMIT' },
     { id: 'question.enter-select', pattern: 'Enter to select.*[↑↓]|Esc to cancel', state: 'QUESTION' },
     { id: 'busy.spinner-glyph', pattern: WORKING_GLYPH_PATTERN, state: 'BUSY' },
@@ -151,6 +185,13 @@ export const CLAUDE_MANIFEST: DetectionManifest = {
   // TITLE while working — so the title, not the glyph rule above, is the reliable
   // fast-cycle working signal for a hook-less claude.
   titleRules: [{ id: 'busy.title-spinner', pattern: WORKING_TITLE_PATTERN, state: 'BUSY' }],
+  // Claude's permission dialog is a numbered select menu ("❯ 1. Yes / 2. … / 3.
+  // No"), not a y/n prompt: a literal 'y' is ignored (issue #40). '1' selects
+  // "Yes" explicitly regardless of the highlighted row; Esc always cancels
+  // ("Esc to cancel" in the dialog footer). The permit.yn rule above overrides
+  // these for a genuine [y/n] prompt.
+  approveKeys: ['1'],
+  denyKeys: ['Escape'],
 };
 
 // --- the embedded built-in `codex` manifest (Phase 3) ---
@@ -169,7 +210,7 @@ export const CODEX_MANIFEST: DetectionManifest = {
   rules: [
     { id: 'permit.allow', pattern: 'allow command\\?', flags: 'i', state: 'PERMIT' },
     { id: 'permit.confirm', pattern: 'press enter to confirm or esc to cancel', flags: 'i', state: 'PERMIT' },
-    { id: 'permit.yn', pattern: '\\[y/n\\]', flags: 'i', state: 'PERMIT' },
+    { id: 'permit.yn', pattern: '\\[y/n\\]', flags: 'i', state: 'PERMIT', approveKeys: ['y'], denyKeys: ['n'] },
     { id: 'permit.do-you-want', pattern: 'do you want to', flags: 'i', state: 'PERMIT' },
   ],
   // Codex retitles its pane "Action Required" while blocked on approval — the
@@ -180,6 +221,11 @@ export const CODEX_MANIFEST: DetectionManifest = {
     { id: 'permit.title-action-required', pattern: 'Action Required', state: 'PERMIT' },
     { id: 'busy.title-spinner', pattern: WORKING_TITLE_PATTERN, state: 'BUSY' },
   ],
+  // Codex approval panels are arrow-select menus with "Yes" preselected
+  // ("press enter to confirm or esc to cancel" is the dialog's own footer), so
+  // Enter approves and Esc denies; permit.yn above overrides for [y/n] prompts.
+  approveKeys: ['Enter'],
+  denyKeys: ['Escape'],
 };
 
 // --- the embedded built-in `opencode` manifest ---
@@ -212,6 +258,11 @@ export const OPENCODE_MANIFEST: DetectionManifest = {
     // working; ≥4 in a row so a stray box-drawing char can't false-positive.
     { id: 'busy.progress-bar', pattern: '(■|⬝){4,}', state: 'BUSY' },
   ],
+  // opencode's permission dialog is a button row ("Allow once / Allow always /
+  // Reject") with "Allow once" preselected and "enter confirm · esc dismiss" as
+  // its footer — a literal 'y' is ignored (issue #40).
+  approveKeys: ['Enter'],
+  denyKeys: ['Escape'],
 };
 
 // --- the embedded built-in `pi` manifest ---

--- a/src/state/permit-keys.test.ts
+++ b/src/state/permit-keys.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from 'bun:test';
+import { resolvePermitKeysFromLines } from './permit-keys.ts';
+import { CLAUDE_MANIFEST, CODEX_MANIFEST, OPENCODE_MANIFEST, type DetectionManifest } from './detection.ts';
+
+// Regression lock for issue #40: pressing `y` on a PERMIT agent used to send a
+// literal 'y' to every agent, but claude's permission dialog is a numbered
+// select menu and opencode's is a button row — both ignore 'y'. The resolver
+// maps the on-screen dialog to the keys that actually answer it.
+
+// Bottom of the real claude-blocked fixture (see detection.test.ts): the
+// numbered "Do you want to proceed?" menu.
+const CLAUDE_MENU_FRAME = [
+  '⏺ Bash(rm -rf node_modules && npm install)',
+  '  ⎿  Running…',
+  '',
+  '│ Do you want to proceed?',
+  '│ ❯ 1. Yes',
+  '│   2. No, and tell Claude what to do differently (esc)',
+];
+
+// Real opencode permission dialog frame (verified live against opencode 1.18).
+const OPENCODE_PERMIT_FRAME = [
+  '┃  △ Permission required',
+  '┃    ← Access external directory /tmp/proj',
+  '┃',
+  '┃   Allow once   Allow always   Reject',
+  '┃   ⇆ select  enter confirm',
+];
+
+describe('claude', () => {
+  test('numbered menu dialog approves with 1, denies with Escape', () => {
+    expect(resolvePermitKeysFromLines(CLAUDE_MENU_FRAME, CLAUDE_MANIFEST, 'approve')).toEqual(['1']);
+    expect(resolvePermitKeysFromLines(CLAUDE_MENU_FRAME, CLAUDE_MANIFEST, 'deny')).toEqual(['Escape']);
+  });
+
+  test('a genuine [y/n] prompt keeps the literal y/n keys (rule override)', () => {
+    const lines = ['Allow Edit to /path/file.ts?', '[y/n]'];
+    expect(resolvePermitKeysFromLines(lines, CLAUDE_MANIFEST, 'approve')).toEqual(['y']);
+    expect(resolvePermitKeysFromLines(lines, CLAUDE_MANIFEST, 'deny')).toEqual(['n']);
+  });
+
+  test('hook-sourced PERMIT with no on-screen match falls to the manifest default', () => {
+    // The dialog scrolled away (or the scrape missed it) but the hook still
+    // says PERMIT — the manifest default answers the agent's native dialog.
+    expect(resolvePermitKeysFromLines(['❯'], CLAUDE_MANIFEST, 'approve')).toEqual(['1']);
+    expect(resolvePermitKeysFromLines([], CLAUDE_MANIFEST, 'deny')).toEqual(['Escape']);
+  });
+});
+
+describe('opencode', () => {
+  test('permission dialog approves with Enter (Allow once preselected), denies with Escape', () => {
+    expect(resolvePermitKeysFromLines(OPENCODE_PERMIT_FRAME, OPENCODE_MANIFEST, 'approve')).toEqual(['Enter']);
+    expect(resolvePermitKeysFromLines(OPENCODE_PERMIT_FRAME, OPENCODE_MANIFEST, 'deny')).toEqual(['Escape']);
+  });
+});
+
+describe('codex', () => {
+  test('"press enter to confirm" panel approves with Enter, denies with Escape', () => {
+    const lines = ['Apply this patch?', 'press enter to confirm or esc to cancel'];
+    expect(resolvePermitKeysFromLines(lines, CODEX_MANIFEST, 'approve')).toEqual(['Enter']);
+    expect(resolvePermitKeysFromLines(lines, CODEX_MANIFEST, 'deny')).toEqual(['Escape']);
+  });
+
+  test('a [y/n] prompt keeps the literal y/n keys (rule override)', () => {
+    const lines = ['run `git push`? [y/n]'];
+    expect(resolvePermitKeysFromLines(lines, CODEX_MANIFEST, 'approve')).toEqual(['y']);
+    expect(resolvePermitKeysFromLines(lines, CODEX_MANIFEST, 'deny')).toEqual(['n']);
+  });
+});
+
+describe('fallback', () => {
+  const bare: DetectionManifest = { agent: 'mystery', linesFromBottom: 15, promptMarker: '', rules: [] };
+
+  test('a manifest with no rules and no defaults falls back to literal y/n', () => {
+    expect(resolvePermitKeysFromLines(['something? [y/n]'], bare, 'approve')).toEqual(['y']);
+    expect(resolvePermitKeysFromLines(['something? [y/n]'], bare, 'deny')).toEqual(['n']);
+  });
+
+  test('a matched PERMIT rule without keys on a manifest without defaults falls back to y/n', () => {
+    const m: DetectionManifest = {
+      ...bare,
+      rules: [{ id: 'permit.custom', pattern: 'approve\\?', state: 'PERMIT' }],
+    };
+    expect(resolvePermitKeysFromLines(['approve?'], m, 'approve')).toEqual(['y']);
+  });
+
+  test('only the bottom window is matched — a prompt above it cannot pick the keys', () => {
+    const m: DetectionManifest = {
+      ...bare,
+      linesFromBottom: 2,
+      rules: [{ id: 'permit.yn', pattern: '\\[y/n\\]', state: 'PERMIT', approveKeys: ['y'] }],
+      approveKeys: ['Enter'],
+    };
+    const lines = ['old prompt [y/n]', 'line', 'line'];
+    expect(resolvePermitKeysFromLines(lines, m, 'approve')).toEqual(['Enter']);
+  });
+
+  test('first matching PERMIT rule wins; non-PERMIT rules are skipped', () => {
+    const m: DetectionManifest = {
+      ...bare,
+      rules: [
+        { id: 'busy.counter', pattern: 'tokens', state: 'BUSY' },
+        { id: 'permit.a', pattern: 'confirm', state: 'PERMIT', approveKeys: ['Enter'] },
+        { id: 'permit.b', pattern: 'confirm', state: 'PERMIT', approveKeys: ['z'] },
+      ],
+    };
+    expect(resolvePermitKeysFromLines(['tokens · confirm'], m, 'approve')).toEqual(['Enter']);
+  });
+});

--- a/src/state/permit-keys.ts
+++ b/src/state/permit-keys.ts
@@ -1,0 +1,46 @@
+import { getCompiledRegex, loadDetectionManifest, type DetectionManifest } from './detection.ts';
+import { capturePaneLines } from './scraper.ts';
+
+export type PermitAction = 'approve' | 'deny';
+
+// The literal y/n the TUI sent before answer keys were agent-aware. Kept as the
+// last resort so unknown agents and user overrides without key specs behave
+// exactly as before: correct for genuine [y/n] prompts, a no-op for menu
+// dialogs.
+const FALLBACK_KEYS: Record<PermitAction, string[]> = { approve: ['y'], deny: ['n'] };
+
+// Resolve the tmux send-keys key names that answer the permission dialog on
+// screen. Precedence: matched PERMIT rule's own keys > manifest defaults >
+// literal y/n. Matching walks the manifest's PERMIT rules in order (first match
+// wins, same contract as detection) over the same bottom window detection uses;
+// no match falls through to the manifest defaults — that covers hook- and
+// title-sourced PERMIT where the screen shows no known prompt text.
+export function resolvePermitKeysFromLines(
+  lines: string[],
+  manifest: DetectionManifest,
+  action: PermitAction,
+): string[] {
+  const bottomText = lines.slice(-manifest.linesFromBottom).join('\n');
+
+  for (const rule of manifest.rules) {
+    if (rule.state !== 'PERMIT') continue;
+    const re = getCompiledRegex(rule);
+    if (re && re.test(bottomText)) {
+      const keys = action === 'approve' ? rule.approveKeys : rule.denyKeys;
+      if (keys && keys.length > 0) return keys;
+      break; // matched a PERMIT rule without its own keys — use the manifest default
+    }
+  }
+
+  const defaults = action === 'approve' ? manifest.approveKeys : manifest.denyKeys;
+  return defaults && defaults.length > 0 ? defaults : FALLBACK_KEYS[action];
+}
+
+// Live variant for the TUI keypress: capture the pane NOW (its dialog may have
+// changed since the last scrape tick) and resolve against the owning agent's
+// manifest. `agent` is AgentState.agentType; empty degrades to claude, matching
+// the scrape path's default.
+export function resolvePermitKeys(paneId: string, agent: string, action: PermitAction): string[] {
+  const manifest = loadDetectionManifest(agent.length > 0 ? agent : 'claude');
+  return resolvePermitKeysFromLines(capturePaneLines(paneId), manifest, action);
+}

--- a/src/tmux/send.ts
+++ b/src/tmux/send.ts
@@ -14,6 +14,16 @@ export function sendKeys(paneId: string, text: string): void {
   tmuxOrThrow(['send-keys', '-t', paneId, 'Enter'], 'send-keys Enter failed');
 }
 
+// Send a sequence of tmux key NAMES (e.g. ['1'], ['Enter'], ['Escape']) — the
+// resolved answer to a permission dialog (see state/permit-keys.ts). No -l:
+// tmux translates named keys itself; single characters pass through as those
+// keys. `--` guards a hypothetical key spec starting with '-'.
+export function sendKeyNames(paneId: string, keys: string[]): void {
+  for (const key of keys) {
+    tmuxOrThrow(['send-keys', '-t', paneId, '--', key], 'send-keys named key failed');
+  }
+}
+
 const SPECIAL_KEY_MAP: Record<number, string> = {
   0x0d: 'Enter',
   0x7f: 'BSpace',


### PR DESCRIPTION
Fixes #40

## Problem

Pressing `y` (approve) or `n` (deny) on a PERMIT agent in preview mode sent a **literal `y`/`n` character** to the pane (`sendRawKey(sel.paneId, Buffer.from('y'))`). That only answers genuine `[y/n]` text prompts — but:

- **Claude Code**'s permission dialog is a numbered select menu (`❯ 1. Yes / 2. Yes, always… / 3. No`) — accepts `1`/`2`/`3`, arrows + Enter, Esc. A literal `y` is ignored.
- **OpenCode**'s dialog is a button row (`Allow once / Allow always / Reject`, footer `⇆ select · enter confirm · esc dismiss`) — also ignores `y`.

Reproduced live against both: fleet's own detection rules (`permit.do-you-want`, `permit.required`) correctly flag these dialogs as PERMIT and advertise `[y] approve`, but the keystroke sent could never satisfy the dialogs those rules detect.

## Fix

Answer keys become part of the detection manifest, resolved per agent and per on-screen dialog:

- `DetectionManifest` gains optional `approveKeys`/`denyKeys` defaults (tmux key names):
  - **claude**: `['1']` / `['Escape']` — `1` selects "Yes" explicitly regardless of highlight; the dialog's own footer says "Esc to cancel"
  - **codex**: `['Enter']` / `['Escape']` — its prompts literally say "press enter to confirm or esc to cancel"
  - **opencode**: `['Enter']` / `['Escape']` — "Allow once" is preselected; "esc dismiss"
- `DetectionRule` gains optional per-rule overrides, set on the `permit.yn` rules so a genuine `[y/n]` prompt keeps literal `y`/`n`.
- New `resolvePermitKeys()` (`src/state/permit-keys.ts`) re-captures the pane at keypress time (the dialog may have changed since the last scrape tick) and walks the manifest's PERMIT rules in order: **matched rule keys → manifest defaults → literal `y`/`n` fallback**. Unknown agents and user overrides without key specs behave exactly as before.
- User detection overrides (`~/.config/fleet/detection/<agent>.json`) can carry both fields; junk values are validated away.

## Verification

- `bun run typecheck` / `bun test` (592 pass, incl. 10 new resolver tests + an override-keys validation test) / `bun run lint` / `bun run format`
- **Live against real Claude Code**: triggered a Bash permission dialog → `tmux send-keys -- 1` (exactly what fleet now sends) approved it and the command ran; a second dialog → `Escape` denied it and the command never ran
- **Live against real OpenCode 1.18**: literal `y` confirmed ignored (the reported bug); `Enter` accepted the `△ Permission required` dialog
