### PR TITLE
feat: control-mode tmux IPC, click-to-jump notifications, and detection hardening

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -27,7 +27,13 @@ import {
 } from './src/state/hooks.ts';
 import { readLastEvents, deriveStatusFromEvents } from './src/state/events.ts';
 import { acknowledgePlan } from './src/state/acknowledge.ts';
-import { detectFromPaneContent, detectFromTitle, scrapePane, capturePaneLines, capturePaneLinesVia } from './src/state/scraper.ts';
+import {
+  detectFromPaneContent,
+  detectFromTitle,
+  scrapePane,
+  capturePaneLines,
+  capturePaneLinesVia,
+} from './src/state/scraper.ts';
 import { loadDetectionManifest } from './src/state/detection.ts';
 import { loadRenames, saveRename } from './src/state/rename.ts';
 import {

--- a/index.ts
+++ b/index.ts
@@ -27,7 +27,7 @@ import {
 } from './src/state/hooks.ts';
 import { readLastEvents, deriveStatusFromEvents } from './src/state/events.ts';
 import { acknowledgePlan } from './src/state/acknowledge.ts';
-import { detectFromPaneContent, detectFromTitle, scrapePane, capturePaneLines } from './src/state/scraper.ts';
+import { detectFromPaneContent, detectFromTitle, scrapePane, capturePaneLines, capturePaneLinesVia } from './src/state/scraper.ts';
 import { loadDetectionManifest } from './src/state/detection.ts';
 import { loadRenames, saveRename } from './src/state/rename.ts';
 import {
@@ -40,6 +40,7 @@ import {
   type ResolvedHookStatus,
 } from './src/state/types.ts';
 import { decideNotifications, applySuppression } from './src/notify/transitions.ts';
+import { readClientFocus } from './src/tmux/clients.ts';
 import { deliverDesktop } from './src/notify/deliver.ts';
 import { AgentRegistry } from './src/agents/registry.ts';
 import type { AgentDir } from './src/agents/config.ts';
@@ -57,19 +58,22 @@ import {
   switchClient,
   killPane,
   gitBranch,
-  currentPaneId,
   type ListPanesResult,
   type PaneInfo,
 } from './src/tmux/sessions.ts';
+import { TmuxControlClient } from './src/tmux/control.ts';
+import { listPanesResultVia } from './src/tmux/control-adapter.ts';
+import { flipControlDead, shouldAttemptControl, type ControlLatch } from './src/tmux/control-router.ts';
 import { tmux, tmuxOrNull } from './src/tmux/ipc.ts';
 import { detectPorts } from './src/tmux/ports.ts';
 import { sendKeys, sendKeyNames, sendRawKey } from './src/tmux/send.ts';
 import { resolvePermitKeys } from './src/state/permit-keys.ts';
-import { runStatus } from './src/cli/status.ts';
+import { runStatus, formatStatusLine, resolveStatusLineSegment } from './src/cli/status.ts';
 import { runSidebar } from './src/cli/sidebar.ts';
 import { runNext } from './src/cli/next.ts';
 import { runSend } from './src/cli/send.ts';
 import { runInstall, runUninstall } from './src/cli/install.ts';
+import { runNotificationOpen } from './src/cli/notification-open.ts';
 import { runInstallCodex, runUninstallCodex } from './src/cli/install-codex.ts';
 import { runInstallPi, runUninstallPi } from './src/cli/install-pi.ts';
 import { runDoctor } from './src/cli/doctor.ts';
@@ -78,6 +82,7 @@ import { runExplain } from './src/cli/explain.ts';
 import { runStatusLineInject, runStatusLineRemove, emitWindowColors, rollupEnabled } from './src/cli/statusline.ts';
 import { runWait } from './src/cli/wait.ts';
 import { readFileSync, appendFileSync, existsSync } from 'node:fs';
+import { readFreshSegmentCache, writeSegmentCache } from './src/state/segment-cache.ts';
 
 const VERSION: string = packageJson.version;
 const FAST_REFRESH_MS = 500;
@@ -267,6 +272,19 @@ function reloadRenameCache(): void {
 }
 
 function refreshSlowCaches(panes: PaneInfo[], hookStatuses: ResolvedHookStatus[]): void {
+  refreshSlowCachesWithCapture(panes, hookStatuses, capturePaneLines);
+}
+
+// Same scan as refreshSlowCaches, but the per-pane capture is supplied by the
+// caller. The fork path passes capturePaneLines (sync); the control-mode TUI
+// path pre-fetches every pane via the control client, then passes a sync
+// lookup into the cache so the rest of the slow-tick work (git, ports,
+// discovery, classification) runs unchanged and shared between both paths.
+function refreshSlowCachesWithCapture(
+  panes: PaneInfo[],
+  hookStatuses: ResolvedHookStatus[],
+  captureFn: (paneId: string) => string[],
+): void {
   const paths = new Set<string>();
   for (const p of panes) paths.add(p.currentPath);
   branchCache.clear();
@@ -307,7 +325,7 @@ function refreshSlowCaches(panes: PaneInfo[], hookStatuses: ResolvedHookStatus[]
   // identity, and hook-less panes are only named by discovery below.
   const captureCache = new Map<string, string[]>();
   for (const p of panes) {
-    const lines = capturePaneLines(p.paneId);
+    const lines = captureFn(p.paneId);
     if (lines.length > 0) captureCache.set(p.paneId, lines);
   }
 
@@ -470,6 +488,64 @@ function fullRefreshStates(dirs: AgentDir[]): AgentState[] {
   return refreshStates(dirs, { panesResult, hookStatuses });
 }
 
+// --- TUI control-mode refresh seam ---------------------------------------
+// Async variants the TUI tick selects between. When the control client is
+// live, list-panes + per-pane capture go through it (one long-lived child,
+// zero forks); on ANY throw the latch flips, the client is closed, and the
+// batch re-runs through the synchronous fork path. After a flip, the latch
+// stays dead for the whole session — no retries. These are thin shells over
+// the shared refreshStates / refreshSlowCachesWithCapture so pane data shapes
+// are identical between paths. CLI one-shot paths never call these.
+async function refreshStatesTui(
+  dirs: AgentDir[],
+  client: TmuxControlClient | null,
+  latch: ControlLatch,
+): Promise<AgentState[]> {
+  if (client === null || latch.dead) return refreshStates(dirs);
+  try {
+    const panesResult = await listPanesResultVia(client);
+    const hookStatuses = readAllStatusDirs(dirs);
+    return refreshStates(dirs, { panesResult, hookStatuses });
+  } catch {
+    flipControlDead(latch);
+    try {
+      await client.close();
+    } catch {}
+    return refreshStates(dirs);
+  }
+}
+
+async function fullRefreshStatesTui(
+  dirs: AgentDir[],
+  client: TmuxControlClient | null,
+  latch: ControlLatch,
+): Promise<AgentState[]> {
+  if (client === null || latch.dead) return fullRefreshStates(dirs);
+  try {
+    // Resync barrier before the scan batch — drains any stale/unsolicited
+    // blocks so the list-panes read pairs with its own response.
+    await client.sync();
+    const panesResult = await listPanesResultVia(client);
+    const hookStatuses = readAllStatusDirs(dirs);
+    // Pre-fetch every pane's capture via the control client, then hand the
+    // cache to the shared slow-tick body so git/ports/discovery/classification
+    // run identically to the fork path.
+    const captureCache = new Map<string, string[]>();
+    for (const p of panesResult.panes) {
+      const lines = await capturePaneLinesVia(client, p.paneId);
+      if (lines.length > 0) captureCache.set(p.paneId, lines);
+    }
+    refreshSlowCachesWithCapture(panesResult.panes, hookStatuses, (id) => captureCache.get(id) ?? []);
+    return refreshStates(dirs, { panesResult, hookStatuses });
+  } catch {
+    flipControlDead(latch);
+    try {
+      await client.close();
+    } catch {}
+    return fullRefreshStates(dirs);
+  }
+}
+
 async function handleCli(args: string[]): Promise<number | null> {
   if (args.includes('--version') || args.includes('-v')) return printVersion();
   if (args.includes('--help') || args.includes('-h')) return printHelp();
@@ -484,13 +560,28 @@ async function handleCli(args: string[]): Promise<number | null> {
 
   switch (command) {
     case 'status': {
+      if (args.includes('--statusline')) {
+        // Serve the running TUI's already-computed segment when its cache is
+        // fresh, so this cold-booted Bun process does zero state reads / tmux
+        // forks on the hot path. On a miss, live-compute exactly as before and
+        // seed the cache for the next status-interval. Window colors are emitted
+        // by the running TUI on its own tick when the cache is fresh; on a miss
+        // (TUI closed) this process still emits them as today.
+        const cached = readFreshSegmentCache();
+        if (cached !== null) {
+          if (cached.length > 0) process.stdout.write(cached + '\n');
+          return 0;
+        }
+        const states = fullRefreshStates(dirs);
+        const { segment } = resolveStatusLineSegment(null, () => formatStatusLine(states));
+        writeSegmentCache(segment);
+        if (segment.length > 0) process.stdout.write(segment + '\n');
+        if (rollupEnabled()) emitWindowColors(states);
+        return 0;
+      }
       const states = fullRefreshStates(dirs);
       const output = runStatus(args.slice(1), states);
       if (output.length > 0) process.stdout.write(output + '\n');
-      // Emit runs even when output is empty: an all-calm bar still needs every
-      // window UNSET to clear stale tints. Gated on --statusline (the single
-      // per-redraw fleet call) and the opt-in @fleet_rollup option.
-      if (args.includes('--statusline') && rollupEnabled()) emitWindowColors(states);
       return 0;
     }
     case 'next': {
@@ -583,6 +674,9 @@ async function handleCli(args: string[]): Promise<number | null> {
       if (args[1] === 'codex') return runUninstallCodex();
       if (args[1] === 'pi') return runUninstallPi();
       return runUninstall();
+    case 'notification-open': {
+      return runNotificationOpen(args.slice(1));
+    }
     case 'doctor':
       return runDoctor();
     case 'reconcile': {
@@ -790,6 +884,15 @@ async function launchTui(): Promise<number> {
   // watching the dashboard. Null when launched outside tmux (harmless: per-pane
   // suppression still works).
   const fleetPaneId = process.env.TMUX_PANE ?? null;
+  // The running TUI is the authoritative source of the statusline segment and
+  // (when the rollup is opted in) the per-window @fleet_state tints, so it
+  // refreshes the cache the CLI `status --statusline` path reads and emits
+  // window colors on its own tick — letting that CLI path short-circuit with
+  // zero state reads / tmux forks once the cache is warm. Only meaningful inside
+  // tmux; read the rollup gate once (it spawns tmux) rather than per tick.
+  const insideTmux = process.env.TMUX !== undefined && process.env.TMUX.length > 0;
+  const rollupOn = insideTmux && rollupEnabled();
+  let lastWrittenSegment: string | null = null;
   let notifyPrev = new Map<string, AgentStatus>();
 
   // Compare this snapshot's statuses to the last and fire a silent desktop toast
@@ -799,12 +902,12 @@ async function launchTui(): Promise<number> {
   const maybeNotify = (states: AgentState[]) => {
     const { candidates, previous } = decideNotifications(states, notifyPrev);
     notifyPrev = previous;
-    if (candidates.length === 0) return; // resolve the active pane only when something fires
-    // null when tmux can't answer, which disables per-pane suppression —
+    if (candidates.length === 0) return; // resolve focus only when something fires
+    // Empty focus set (tmux down / no clients) suppresses nothing —
     // better a redundant toast than a missed one.
-    const activePaneId = currentPaneId();
-    for (const n of applySuppression(candidates, activePaneId, fleetPaneId)) {
-      deliverDesktop(`${STATUS_DISPLAY[n.status].label}: ${n.label}`, n.agentType);
+    const { focusedPanes } = readClientFocus();
+    for (const n of applySuppression(candidates, focusedPanes, fleetPaneId)) {
+      deliverDesktop(`${STATUS_DISPLAY[n.status].label}: ${n.label}`, n.agentType, n.paneId);
     }
   };
 
@@ -813,6 +916,22 @@ async function launchTui(): Promise<number> {
     app.tmuxDown = !lastTmuxOk;
     app.hooksMissing = !statusDirs.some((d) => existsSync(d));
     needsRender = true;
+    // Keep the CLI's statusline cache warm with the SAME renderer the CLI uses
+    // (formatStatusLine) so a cached hit is byte-identical to a live compute.
+    // Skip the write when the segment is unchanged since the last tick — the
+    // statusline is quiet most of the time, so this is usually a no-op fs call.
+    if (insideTmux) {
+      const segment = formatStatusLine(states);
+      if (segment !== lastWrittenSegment) {
+        writeSegmentCache(segment);
+        lastWrittenSegment = segment;
+      }
+      // Window tints used to be emitted by the CLI status path on every
+      // status-interval; now that the CLI short-circuits on a cache hit while
+      // the TUI runs, the TUI owns them so they stay live (one batched tmux
+      // spawn per tick, gated on the opt-in @fleet_rollup option).
+      if (rollupOn) emitWindowColors(states);
+    }
   };
 
   const doRefresh = () => applyStates(refreshStates(dirs));
@@ -841,6 +960,29 @@ async function launchTui(): Promise<number> {
     let slowTimer: ReturnType<typeof setInterval> | null = null;
     let finished = false;
 
+    // Control-mode fast path: one long-lived `tmux -C` child replaces a fork
+    // per list-panes / capture-pane on the hot loop. Opt-in (TUI-only, $TMUX
+    // set, FLEET_CONTROL_MODE !== '0'); connect failure or ANY later throw
+    // flips the latch to dead for the whole session and the loop reverts to
+    // the fork path permanently. The latch + client live in this closure.
+    const controlEnabled = shouldAttemptControl(process.env);
+    const controlLatch: ControlLatch = { dead: false };
+    let controlClient: TmuxControlClient | null = null;
+    // Guards against overlapping ticks: control reads are async, so a slow
+    // tick could still be draining when the fast interval fires. Skip the
+    // tick if the previous one is still running — do not queue.
+    let tickInFlight = false;
+
+    const safeCloseControl = async () => {
+      const c = controlClient;
+      controlClient = null;
+      if (c) {
+        try {
+          await c.close();
+        } catch {}
+      }
+    };
+
     const finish = (code: number) => {
       if (finished) return;
       finished = true;
@@ -849,6 +991,11 @@ async function launchTui(): Promise<number> {
       if (watcherTimeout !== null) clearTimeout(watcherTimeout);
       stopWatching();
       process.stdin.removeAllListeners('data');
+      // Close the control client best-effort on exit (detach + reap + unlink
+      // the capture temp file). Fire-and-forget: finish() is called from sync
+      // input handlers and resolve() ends the promise; the child is reaped
+      // during the microtask gap before process.exit.
+      void safeCloseControl();
       restore();
       resolve(code);
     };
@@ -1132,26 +1279,75 @@ async function launchTui(): Promise<number> {
 
     const isTyping = () => app.mode === TuiMode.SEND || app.mode === TuiMode.RENAME || app.isFiltering();
 
+    // Async ticks: route list-panes + capture through the control client when
+    // it's live, fall back to the fork path (permanently) on any error. The
+    // in-flight guard skips a tick if the previous one is still draining — it
+    // never queues, so a slow control batch simply stretches the interval.
+    const runFastTick = async () => {
+      if (tickInFlight || finished) return;
+      tickInFlight = true;
+      try {
+        const states = await refreshStatesTui(dirs, controlClient, controlLatch);
+        if (finished) return;
+        maybeNotify(states);
+        if (isTyping()) return;
+        applyStates(states);
+        if (app.visibleStates().some((s) => s.status === AgentStatus.BUSY)) {
+          app.pulsePhase = !app.pulsePhase;
+          needsRender = true;
+        }
+        tick();
+      } catch {
+        // Defensive: refreshStatesTui already falls back to fork, but never
+        // let an unexpected throw crash the TUI.
+      } finally {
+        tickInFlight = false;
+      }
+    };
+
+    const runSlowTick = async () => {
+      if (tickInFlight || finished) return;
+      if (isTyping()) return;
+      tickInFlight = true;
+      try {
+        const states = await fullRefreshStatesTui(dirs, controlClient, controlLatch);
+        if (finished) return;
+        applyStates(states);
+        tick();
+      } catch {
+        // Defensive: fullRefreshStatesTui already falls back to fork.
+      } finally {
+        tickInFlight = false;
+      }
+    };
+
+    // Attempt the control-mode connection (TUI-only, opt-in). Connect failure
+    // is silent: controlClient stays null and every tick uses the fork path
+    // for the whole session. On success the client is published so the next
+    // tick reads via control; onWake (debounced ~100ms inside control.ts)
+    // triggers an immediate fast tick, respecting the in-flight guard.
+    if (controlEnabled) {
+      const candidate = new TmuxControlClient({ onWake: () => void runFastTick() });
+      void candidate
+        .connect()
+        .then(() => {
+          if (!controlLatch.dead && !finished) controlClient = candidate;
+        })
+        .catch(() => {
+          void candidate.close().catch(() => {});
+        });
+    }
+
     // Fast timer: keep running in passthrough (preview needs live updates).
     // Notification detection runs every tick even while typing — only the list
     // refresh + render pause, so a background agent finishing still toasts.
     refreshTimer = setInterval(() => {
-      const states = refreshStates(dirs);
-      maybeNotify(states);
-      if (isTyping()) return;
-      applyStates(states);
-      if (app.visibleStates().some((s) => s.status === AgentStatus.BUSY)) {
-        app.pulsePhase = !app.pulsePhase;
-        needsRender = true;
-      }
-      tick();
+      void runFastTick();
     }, FAST_REFRESH_MS);
 
     // Slow timer: skip if user is actively typing
     slowTimer = setInterval(() => {
-      if (isTyping()) return;
-      doFullRefresh();
-      tick();
+      void runSlowTick();
     }, SLOW_REFRESH_MS);
 
     tick();

--- a/scripts/install-notifier.sh
+++ b/scripts/install-notifier.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Assemble, ad-hoc sign, and install the FleetNotifier.app notification helper.
+# UNUserNotificationCenter requires a signed, registered app bundle; ad-hoc
+# signing is enough for local builds, but the bundle must live in a real
+# Applications folder (temporary directories cannot register on macOS 26).
+#
+# usage: install-notifier.sh [--quiet] [dest-dir]   (default: ~/Applications)
+#
+# --quiet installs/refreshes the app without requesting permission — used by
+# the automatic `fleet install`; macOS then asks with the first real
+# notification. Without --quiet the helper's --setup runs after a successful
+# build so an explicit `scripts/install-notifier.sh` registers the bundle,
+# asks for permission, and reports the result.
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")/.." && pwd)"
+src="$DIR/scripts/notifier/FleetNotifier.swift"
+
+# Not macOS, or the toolchain is missing: degrade gracefully. Never fail a
+# `fleet install` over the helper.
+[ "$(uname -s)" = Darwin ] || { echo "fleet: FleetNotifier is macOS-only — skipping" >&2; exit 0; }
+command -v swiftc >/dev/null 2>&1 || { echo "fleet: swiftc not found — skipping FleetNotifier install" >&2; exit 0; }
+command -v codesign >/dev/null 2>&1 || { echo "fleet: codesign not found — skipping FleetNotifier install" >&2; exit 0; }
+
+quiet=0
+if [ "${1:-}" = "--quiet" ]; then
+  quiet=1
+  shift
+fi
+dest="${1:-$HOME/Applications}"
+
+if [ ! -f "$src" ]; then
+  echo "fleet: FleetNotifier.swift not found at $src — skipping" >&2
+  exit 0
+fi
+
+app="$dest/FleetNotifier.app"
+exe="$app/Contents/MacOS/fleet-notifier"
+plist="$app/Contents/Info.plist"
+
+# Idempotent: skip the compile + sign when the installed binary is at least as
+# new as the source. A `touch` of the .swift or a source pull refreshes it.
+if [ -x "$exe" ] && [ -f "$plist" ] && [ "$(stat -f %m "$exe")" -ge "$(stat -f %m "$src")" ]; then
+  echo "FleetNotifier.app already up to date"
+else
+  version="$(grep -m 1 '"version"' "$DIR/package.json" | sed 's/.*"version": *"\([^"]*\)".*/\1/')"
+  : "${version:=0.0.0}"
+
+  # xcrun finds the active toolchain; fall back to a bare swiftc on PATH.
+  if command -v xcrun >/dev/null 2>&1 && xcrun --find swiftc >/dev/null 2>&1; then
+    swiftc=(xcrun swiftc)
+  else
+    swiftc=(swiftc)
+  fi
+
+  rm -rf "$app"
+  mkdir -p "$app/Contents/MacOS"
+  cat > "$plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleIdentifier</key>
+	<string>com.nicknisi.fleet.notifier</string>
+	<key>CFBundleName</key>
+	<string>FleetNotifier</string>
+	<key>CFBundleDisplayName</key>
+	<string>FleetNotifier</string>
+	<key>CFBundleExecutable</key>
+	<string>fleet-notifier</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$version</string>
+	<key>CFBundleVersion</key>
+	<string>$version</string>
+	<key>LSUIElement</key>
+	<true/>
+</dict>
+</plist>
+PLIST
+
+  if ! "${swiftc[@]}" "$src" -O -framework Cocoa -framework UserNotifications -o "$exe" 2>"$dest/.fleet-notifier-build.log"; then
+    echo "fleet: FleetNotifier compile failed — skipping" >&2
+    cat "$dest/.fleet-notifier-build.log" >&2 || true
+    rm -f "$dest/.fleet-notifier-build.log"
+    exit 0
+  fi
+  rm -f "$dest/.fleet-notifier-build.log"
+
+  if ! codesign --force --sign - "$app" >/dev/null 2>&1; then
+    echo "fleet: FleetNotifier codesign failed — skipping" >&2
+    rm -rf "$app"
+    exit 0
+  fi
+  echo "installed $app"
+fi
+
+[ "$quiet" = 1 ] && exit 0
+
+# --setup registers the bundle, asks for permission, waits for the user's
+# answer, and posts a test notification when granted.
+if "$exe" --setup; then
+  echo "✓ click-to-jump notifications enabled"
+else
+  echo "Notifications are off. Enable: System Settings → Notifications → FleetNotifier."
+fi

--- a/scripts/notifier/FleetNotifier.swift
+++ b/scripts/notifier/FleetNotifier.swift
@@ -1,0 +1,251 @@
+// FleetNotifier.app helper: posts native macOS notifications through
+// UNUserNotificationCenter and runs the click command when the body is
+// clicked. Must run from inside the installed, ad-hoc signed FleetNotifier.app
+// bundle (see scripts/install-notifier.sh); macOS 26 grants notification
+// permission only to apps in registered locations, so the helper lives at
+// ~/Applications/FleetNotifier.app.
+//
+// usage: fleet-notifier [--spawned] <title> <body> [click-command]
+//        fleet-notifier --setup
+//
+// Without --spawned it re-executes itself detached and returns immediately, so
+// the caller never blocks on the click window. The spawned instance keeps the
+// main run loop alive until the notification is clicked, dismissed, or the
+// click window elapses, then removes the delivered notification and exits.
+//
+// Denied permission is authoritative: an installed helper that the user has
+// denied exits without posting — denial means silence, never a fallback. An
+// undetermined status still spawns so the first delivery can prompt.
+//
+// --setup is the install-time flow: it requests permission, waits for the
+// user's answer to the prompt, and posts a test notification when granted;
+// exit 0 = granted, non-zero = denied/unavailable.
+
+import Cocoa
+import UserNotifications
+
+// Bounded lifetime for the click wait. A stale helper holding a notification
+// open is worse than a missed click; a few hours covers any reasonable away
+// period. After it elapses the notification is closed and later clicks are
+// no-ops.
+private let clickWindow: TimeInterval = 6 * 60 * 60
+
+private struct Parsed {
+    let spawned: Bool
+    let title: String
+    let body: String
+    let clickCommand: String?
+}
+
+private func parse(_ args: [String]) -> Parsed? {
+    var rest = args
+    var spawned = false
+    if let first = rest.first, first == "--spawned" {
+        spawned = true
+        rest.removeFirst()
+    }
+    guard rest.count == 2 || rest.count == 3 else { return nil }
+    return Parsed(
+        spawned: spawned,
+        title: rest[0],
+        body: rest[1],
+        clickCommand: rest.count == 3 ? rest[2] : nil
+    )
+}
+
+// Synchronous wrapper around getNotificationSettings — the completion handler
+// fires on an internal queue, so a semaphore is safe here (the main run loop
+// is not yet running in the detach path).
+private func authorizationStatus() -> UNAuthorizationStatus? {
+    let center = UNUserNotificationCenter.current()
+    let sem = DispatchSemaphore(value: 0)
+    var status: UNAuthorizationStatus?
+    center.getNotificationSettings { settings in
+        status = settings.authorizationStatus
+        sem.signal()
+    }
+    if sem.wait(timeout: .now() + 10) == .timedOut { return nil }
+    return status
+}
+
+// Request authorization, waiting for the user's answer to the system prompt.
+private func requestAuthorization() -> Bool {
+    let center = UNUserNotificationCenter.current()
+    let sem = DispatchSemaphore(value: 0)
+    var granted = false
+    center.requestAuthorization(options: [.alert, .sound]) { ok, _ in
+        granted = ok
+        sem.signal()
+    }
+    if sem.wait(timeout: .now() + 60) == .timedOut { return false }
+    return granted
+}
+
+// Re-execute this binary detached with --spawned so the caller returns at
+// once. Denied permission means silence: report failure and spawn nothing.
+private func detach(_ parsed: Parsed) -> Int32 {
+    if let status = authorizationStatus(), status == .denied {
+        return 4
+    }
+    guard let exe = Bundle.main.executableURL else { return 1 }
+    let proc = Process()
+    proc.executableURL = exe
+    var arguments = ["--spawned", parsed.title, parsed.body]
+    if let click = parsed.clickCommand { arguments.append(click) }
+    proc.arguments = arguments
+    // Detach with stdio tied to /dev/null so the helper never writes back to
+    // the caller's stdout/stderr (it is background-only and normally silent).
+    let null = FileHandle(forUpdatingAtPath: "/dev/null")
+    proc.standardInput = null
+    proc.standardOutput = null
+    proc.standardError = null
+    do {
+        try proc.run()
+        return 0
+    } catch {
+        return 1
+    }
+}
+
+// Delegate capturing the first user response to the posted notification. The
+// default action is a body click; anything else (dismiss, timeout) is treated
+// as a non-click.
+private final class ResponseDelegate: NSObject, UNUserNotificationCenterDelegate {
+    var clicked = false
+    var resolved = false
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        // The helper is background-only (LSUIElement), but present the banner
+        // regardless so a re-entry while still alive still shows it.
+        completionHandler([.banner, .sound])
+    }
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        if response.actionIdentifier == UNNotificationDefaultActionIdentifier {
+            clicked = true
+        }
+        resolved = true
+        completionHandler()
+    }
+}
+
+// Run the click command via /bin/sh -c. Returns 0 on success, 6 on failure.
+private func runClick(_ command: String) -> Int32 {
+    let proc = Process()
+    proc.launchPath = "/bin/sh"
+    proc.arguments = ["-c", command]
+    do {
+        try proc.run()
+        proc.waitUntilExit()
+        return proc.terminationStatus == 0 ? 0 : 6
+    } catch {
+        return 6
+    }
+}
+
+// Spawned path: the bundle owns the permission, so check + request, post, and
+// keep the main run loop alive awaiting the body click.
+private func runSpawned(_ parsed: Parsed) -> Int32 {
+    switch authorizationStatus() {
+    case .denied: return 4
+    case .none: return 5
+    default: break
+    }
+    if !requestAuthorization() { return 4 }
+
+    let center = UNUserNotificationCenter.current()
+    let delegate = ResponseDelegate()
+    center.delegate = delegate
+
+    let content = UNMutableNotificationContent()
+    content.title = parsed.title
+    content.body = parsed.body
+    content.sound = .default
+
+    let identifier = "fleet-notifier-\(Int(Date().timeIntervalSince1970))"
+    let request = UNNotificationRequest(
+        identifier: identifier,
+        content: content,
+        trigger: nil
+    )
+
+    var posted = false
+    let postSem = DispatchSemaphore(value: 0)
+    center.add(request) { error in
+        posted = (error == nil)
+        postSem.signal()
+    }
+    if postSem.wait(timeout: .now() + 10) == .timedOut { return 5 }
+    if !posted { return 5 }
+
+    // Run the main run loop in short slices so the delegate callback (delivered
+    // on the main loop) can flip `resolved`. Bounded by the click window.
+    let deadline = Date(timeIntervalSinceNow: clickWindow)
+    while !delegate.resolved && Date() < deadline {
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.2))
+    }
+
+    center.removeDeliveredNotifications(withIdentifiers: [identifier])
+
+    if delegate.clicked, let click = parsed.clickCommand {
+        return runClick(click)
+    }
+    return 0
+}
+
+// --setup: request permission interactively and report the result. exit 0 =
+// granted (and a test notification posted), non-zero = denied/unavailable.
+private func runSetup() -> Int32 {
+    switch authorizationStatus() {
+    case .denied: return 4
+    case .none: return 5
+    default: break
+    }
+    if !requestAuthorization() { return 4 }
+
+    let center = UNUserNotificationCenter.current()
+    let content = UNMutableNotificationContent()
+    content.title = "Fleet"
+    content.body = "Notifications are ready."
+    content.sound = .default
+    let request = UNNotificationRequest(
+        identifier: "fleet-notifier-setup",
+        content: content,
+        trigger: nil
+    )
+    var posted = false
+    let sem = DispatchSemaphore(value: 0)
+    center.add(request) { error in
+        posted = (error == nil)
+        sem.signal()
+    }
+    if sem.wait(timeout: .now() + 10) == .timedOut { return 5 }
+    return posted ? 0 : 5
+}
+
+let arguments = CommandLine.arguments.dropFirst().map { String($0) }
+
+if arguments == ["--setup"] {
+    exit(runSetup())
+}
+
+guard let parsed = parse(arguments) else {
+    FileHandle.standardError.write(
+        Data("usage: fleet-notifier [--spawned] <title> <body> [click-command]\n".utf8)
+    )
+    exit(2)
+}
+
+if parsed.spawned {
+    exit(runSpawned(parsed))
+} else {
+    exit(detach(parsed))
+}

--- a/src/cli/doctor.test.ts
+++ b/src/cli/doctor.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { installedPluginHasHooks, marketplaceSourceOk } from './doctor.ts';
+import { focusEventsOn, installedPluginHasHooks, marketplaceSourceOk } from './doctor.ts';
 
 let pluginsRoot: string;
 
@@ -99,5 +99,14 @@ describe('marketplaceSourceOk', () => {
   test('returns false when the source dir lacks hooks', () => {
     mkdirSync(join(pluginsRoot, 'fleet'), { recursive: true });
     expect(marketplaceSourceOk(pluginsRoot)).toBe(false);
+  });
+});
+
+describe('focusEventsOn', () => {
+  test('true only for the exact value "on"', () => {
+    expect(focusEventsOn('on')).toBe(true);
+    expect(focusEventsOn('off')).toBe(false);
+    expect(focusEventsOn('')).toBe(false);
+    expect(focusEventsOn(null)).toBe(false);
   });
 });

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
-import { tmux } from '../tmux/ipc.ts';
+import { tmux, getTmuxOption } from '../tmux/ipc.ts';
 import { loadAgentDirs } from '../agents/config.ts';
 import { marketplaceDir } from './install.ts';
 
@@ -9,6 +9,9 @@ interface Check {
   name: string;
   ok: boolean;
   detail: string;
+  // Advisory checks render a warning but never fail the overall exit code —
+  // used for recommendations like enabling focus-events.
+  advisory?: boolean;
 }
 
 interface InstalledPluginEntry {
@@ -37,7 +40,13 @@ export function installedPluginHasHooks(pluginsRoot: string, prefix = 'fleet@'):
   return false;
 }
 
-// The plugin cache can hold hooks while the marketplace *source* is broken —
+// The global focus-events option gates per-client focus detection. With it
+// off, every real client's selected pane is treated as focused (a coarser but
+// still useful fallback). It's a recommendation, not a hard failure.
+export function focusEventsOn(option: string | null): boolean {
+  return option === 'on';
+}
+
 // e.g. a symlink into a Homebrew keg that `brew upgrade` deleted. Claude Code
 // then drops the plugin at session start and hooks silently stop firing, while
 // the cache-based check above still passes. existsSync follows symlinks, so a
@@ -112,12 +121,22 @@ export function runDoctor(): number {
     });
   }
 
+  const focusEvents = getTmuxOption('focus-events');
+  checks.push({
+    name: 'focus-events',
+    ok: focusEventsOn(focusEvents),
+    advisory: true,
+    detail: focusEventsOn(focusEvents)
+      ? 'on'
+      : `off — per-client focus detection needs 'set -g focus-events on' for accurate suppression`,
+  });
+
   let allOk = true;
   for (const check of checks) {
-    const icon = check.ok ? '✓' : '✗';
-    const color = check.ok ? '\x1b[32m' : '\x1b[31m';
+    const icon = check.ok ? '✓' : check.advisory ? '!' : '✗';
+    const color = check.ok ? '\x1b[32m' : check.advisory ? '\x1b[33m' : '\x1b[31m';
     process.stdout.write(`${color}${icon}\x1b[0m ${check.name}: ${check.detail}\n`);
-    if (!check.ok) allOk = false;
+    if (!check.ok && !check.advisory) allOk = false;
   }
 
   return allOk ? 0 : 1;

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -237,9 +237,7 @@ export function runNotifierInstallStep(): void {
   if (setup.exitCode === 0) {
     process.stdout.write('Enabled click-to-jump notifications (FleetNotifier.app installed)\n');
   } else {
-    process.stdout.write(
-      '  notifications are off — enable: System Settings → Notifications → FleetNotifier\n',
-    );
+    process.stdout.write('  notifications are off — enable: System Settings → Notifications → FleetNotifier\n');
   }
 }
 

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -211,6 +211,47 @@ export function linkPluginDir(fleetDir: string, link: string): void {
   symlinkSync(fleetDir, link);
 }
 
+// macOS-only best-effort click-to-jump notification helper. The FleetNotifier.app
+// bundle (built by scripts/install-notifier.sh into ~/Applications) owns the
+// notification permission on macOS 26; --setup requests it interactively. Any
+// failure is reported and swallowed so the main install/uninstall never fails
+// over the helper, and non-darwin platforms skip it entirely.
+const NOTIFIER_APP = join(homedir(), 'Applications', 'FleetNotifier.app');
+const NOTIFIER_HELPER = join(NOTIFIER_APP, 'Contents', 'MacOS', 'fleet-notifier');
+
+export function runNotifierInstallStep(): void {
+  if (process.platform !== 'darwin') return;
+  const fleetDir = fleetPluginDir();
+  if (!fleetDir) return;
+  const script = join(fleetDir, 'scripts', 'install-notifier.sh');
+  if (!existsSync(script)) return;
+
+  const build = Bun.spawnSync({ cmd: ['bash', script, '--quiet'], stdout: 'inherit', stderr: 'inherit' });
+  if (build.exitCode !== 0) {
+    process.stdout.write('  skipped macOS notification helper (install failed)\n');
+    return;
+  }
+  if (!existsSync(NOTIFIER_HELPER)) return;
+
+  const setup = Bun.spawnSync({ cmd: [NOTIFIER_HELPER, '--setup'], stdout: 'inherit', stderr: 'inherit' });
+  if (setup.exitCode === 0) {
+    process.stdout.write('Enabled click-to-jump notifications (FleetNotifier.app installed)\n');
+  } else {
+    process.stdout.write(
+      '  notifications are off — enable: System Settings → Notifications → FleetNotifier\n',
+    );
+  }
+}
+
+export function runNotifierUninstallStep(): void {
+  if (process.platform !== 'darwin') return;
+  try {
+    rmSync(NOTIFIER_APP, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+}
+
 export function runInstall(): number {
   const fleetDir = fleetPluginDir();
   if (fleetDir === null) {
@@ -254,6 +295,8 @@ export function runInstall(): number {
     );
   }
 
+  runNotifierInstallStep();
+
   // Window state rollup is intentionally NOT offered here. Its tmux config
   // (see addTmuxRollupLines) overrides window-status-format wholesale, which
   // would discard a user's themed window formatting — fleet extends tmux, it
@@ -266,6 +309,7 @@ export function runInstall(): number {
 
 export function runUninstall(): number {
   runStatusLineRemove();
+  runNotifierUninstallStep();
 
   const confPath = tmuxConfPath();
   if (removeTmuxConfLine(confPath)) {

--- a/src/cli/notification-open.test.ts
+++ b/src/cli/notification-open.test.ts
@@ -77,11 +77,7 @@ describe('listPanesArgs / listClientsArgs', () => {
     ]);
   });
   test('list-clients with the activity/name/flags format', () => {
-    expect(listClientsArgs('-')).toEqual([
-      'list-clients',
-      '-F',
-      '#{client_activity}\t#{client_name}\t#{client_flags}',
-    ]);
+    expect(listClientsArgs('-')).toEqual(['list-clients', '-F', '#{client_activity}\t#{client_name}\t#{client_flags}']);
   });
 });
 

--- a/src/cli/notification-open.test.ts
+++ b/src/cli/notification-open.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  activationCommand,
+  jumpArgs,
+  listClientsArgs,
+  listPanesArgs,
+  parseOpenArgs,
+  parsePaneRefs,
+  pickClient,
+  socketArgs,
+  validPane,
+} from './notification-open.ts';
+
+describe('validPane', () => {
+  test('accepts % followed by digits', () => {
+    expect(validPane('%0')).toBe(true);
+    expect(validPane('%42')).toBe(true);
+    expect(validPane('%99999')).toBe(true);
+  });
+  test('rejects non-pane targets', () => {
+    expect(validPane('')).toBe(false);
+    expect(validPane('%')).toBe(false);
+    expect(validPane('%abc')).toBe(false);
+    expect(validPane('42')).toBe(false);
+    expect(validPane('main:0.1')).toBe(false);
+    expect(validPane('%1a')).toBe(false);
+  });
+});
+
+describe('parseOpenArgs', () => {
+  test('parses paneId alone, defaulting socket/bundle to -', () => {
+    expect(parseOpenArgs(['%7'])).toEqual({ paneId: '%7', socketPath: '-', terminalBundleId: '-' });
+  });
+  test('parses paneId + socket + bundle', () => {
+    expect(parseOpenArgs(['%7', '/tmp/sock', 'com.apple.Terminal'])).toEqual({
+      paneId: '%7',
+      socketPath: '/tmp/sock',
+      terminalBundleId: 'com.apple.Terminal',
+    });
+  });
+  test('parses paneId + socket, defaulting bundle to -', () => {
+    expect(parseOpenArgs(['%7', '/tmp/sock'])).toEqual({
+      paneId: '%7',
+      socketPath: '/tmp/sock',
+      terminalBundleId: '-',
+    });
+  });
+  test('rejects empty args and a non-pane first arg', () => {
+    expect(parseOpenArgs([])).toBe(null);
+    expect(parseOpenArgs(['not-a-pane'])).toBe(null);
+    expect(parseOpenArgs(['7'])).toBe(null);
+  });
+});
+
+describe('socketArgs', () => {
+  test('omits -S for unknown / empty socket', () => {
+    expect(socketArgs('-')).toEqual([]);
+    expect(socketArgs('')).toEqual([]);
+  });
+  test('passes -S <socket> for a real socket', () => {
+    expect(socketArgs('/tmp/tmux-1000/default')).toEqual(['-S', '/tmp/tmux-1000/default']);
+  });
+});
+
+describe('listPanesArgs / listClientsArgs', () => {
+  test('list-panes -a with the pane ref format', () => {
+    expect(listPanesArgs('-')).toEqual(['list-panes', '-a', '-F', '#{pane_id}\t#{session_name}']);
+  });
+  test('prepends -S when a socket is known', () => {
+    expect(listPanesArgs('/tmp/sock')).toEqual([
+      '-S',
+      '/tmp/sock',
+      'list-panes',
+      '-a',
+      '-F',
+      '#{pane_id}\t#{session_name}',
+    ]);
+  });
+  test('list-clients with the activity/name/flags format', () => {
+    expect(listClientsArgs('-')).toEqual([
+      'list-clients',
+      '-F',
+      '#{client_activity}\t#{client_name}\t#{client_flags}',
+    ]);
+  });
+});
+
+describe('parsePaneRefs', () => {
+  test('parses pane_id and session_name columns', () => {
+    const refs = parsePaneRefs('%5\tmain\n%7\tfeature-work\n');
+    expect(refs).toEqual([
+      { paneId: '%5', sessionName: 'main' },
+      { paneId: '%7', sessionName: 'feature-work' },
+    ]);
+  });
+  test('drops blank lines and rows missing a field', () => {
+    const refs = parsePaneRefs('\n%5\t\nnot-a-pane\tmain\n%7\tmain\n');
+    expect(refs).toEqual([{ paneId: '%7', sessionName: 'main' }]);
+  });
+});
+
+describe('pickClient', () => {
+  test('picks the highest-activity non-control-mode client', () => {
+    const out = [
+      '100\t/dev/ttys001\tfocus,read-only',
+      '500\t/dev/ttys002\t',
+      '300\t/dev/ttys003\tcontrol-mode',
+      '400\t/dev/ttys004\t',
+    ].join('\n');
+    expect(pickClient(out)).toBe('/dev/ttys002');
+  });
+  test('ignores every control-mode client even if it has the highest activity', () => {
+    const out = ['10\t/dev/ttys001\t', '999\t/dev/ttys002\tcontrol-mode'].join('\n');
+    expect(pickClient(out)).toBe('/dev/ttys001');
+  });
+  test('returns null when no eligible client is attached', () => {
+    expect(pickClient('')).toBe(null);
+    expect(pickClient('1\t/dev/ttys001\tcontrol-mode')).toBe(null);
+    expect(pickClient('notanumber\t/dev/ttys001\t')).toBe(null);
+  });
+});
+
+describe('activationCommand', () => {
+  test('open -b <bundleId> for a known bundle', () => {
+    expect(activationCommand('com.apple.Terminal')).toEqual(['open', '-b', 'com.apple.Terminal']);
+    expect(activationCommand('com.mitchellh.ghostty')).toEqual(['open', '-b', 'com.mitchellh.ghostty']);
+  });
+  test('null for unknown / empty bundle so activation is skipped', () => {
+    expect(activationCommand('-')).toBe(null);
+    expect(activationCommand('')).toBe(null);
+  });
+});
+
+describe('jumpArgs', () => {
+  test('switches the client onto the pane session, then selects window and pane', () => {
+    expect(jumpArgs('-', '/dev/ttys001', '%7', 'main')).toEqual([
+      'switch-client',
+      '-c',
+      '/dev/ttys001',
+      '-t',
+      'main',
+      ';',
+      'select-window',
+      '-t',
+      '%7',
+      ';',
+      'select-pane',
+      '-t',
+      '%7',
+    ]);
+  });
+  test('prepends -S when a socket is known', () => {
+    const args = jumpArgs('/tmp/sock', '/dev/ttys001', '%7', 'main');
+    expect(args.slice(0, 2)).toEqual(['-S', '/tmp/sock']);
+    expect(args[2]).toBe('switch-client');
+  });
+});

--- a/src/cli/notification-open.ts
+++ b/src/cli/notification-open.ts
@@ -1,0 +1,163 @@
+// `fleet notification-open <paneId> [socketPath] [terminalBundleId]` — the
+// click handler for a native notification. Revalidates the pane, picks the
+// most recently active non-control-mode client, activates the terminal FIRST,
+// then jumps tmux to the exact pane. Stale/missing targets are silent no-ops
+// (exit 0) so a click on a notification for a pane that has since closed does
+// nothing rather than erroring.
+//
+// Structure: pure planners (arg parse + tmux arg builders + client picker) are
+// exported for unit testing; `runNotificationOpen` is the thin shell that
+// drives them through src/tmux/ipc.ts. Activation must precede the jump so the
+// terminal is foregrounded before tmux moves the client.
+
+import { tmux } from '../tmux/ipc.ts';
+
+export interface OpenPaneArgs {
+  paneId: string;
+  socketPath: string; // '-' for unknown
+  terminalBundleId: string; // '-' for unknown
+}
+
+export interface PaneRef {
+  paneId: string;
+  sessionName: string;
+}
+
+const PANE_REF_FORMAT = '#{pane_id}\t#{session_name}';
+const CLIENT_FORMAT = '#{client_activity}\t#{client_name}\t#{client_flags}';
+
+// A pane target is a tmux pane id: `%` followed by one or more digits.
+export function validPane(pane: string): boolean {
+  return /^%\d+$/.test(pane);
+}
+
+// Parse the CLI args. socketPath/bundleId default to '-' (unknown) when
+// omitted. Invalid arity or a non-pane-id first arg → null (usage error).
+export function parseOpenArgs(args: string[]): OpenPaneArgs | null {
+  const [paneId, socketPath = '-', terminalBundleId = '-'] = args;
+  if (!paneId || !validPane(paneId)) return null;
+  return { paneId, socketPath, terminalBundleId };
+}
+
+// tmux socket args: pass `-S <socket>` only when a real socket is given. '-'
+// means unknown (e.g. notification fired outside tmux's env), so fall back to
+// the default socket by omitting -S entirely.
+export function socketArgs(socketPath: string): string[] {
+  return socketPath !== '-' && socketPath.length > 0 ? ['-S', socketPath] : [];
+}
+
+export function listPanesArgs(socketPath: string): string[] {
+  return [...socketArgs(socketPath), 'list-panes', '-a', '-F', PANE_REF_FORMAT];
+}
+
+export function listClientsArgs(socketPath: string): string[] {
+  return [...socketArgs(socketPath), 'list-clients', '-F', CLIENT_FORMAT];
+}
+
+// Parse list-panes output (pane_id\tsession_name) into refs. Lines with a
+// missing field are dropped — a stray tab in a session name cannot shift the
+// two columns here since pane_id is first and has no tabs.
+export function parsePaneRefs(stdout: string): PaneRef[] {
+  const refs: PaneRef[] = [];
+  for (const line of stdout.split('\n')) {
+    if (line.length === 0) continue;
+    const parts = line.split('\t');
+    const paneId = parts[0];
+    const sessionName = parts[1];
+    if (paneId && sessionName && validPane(paneId)) {
+      refs.push({ paneId, sessionName });
+    }
+  }
+  return refs;
+}
+
+// Pick the highest-#{client_activity} client that is NOT in control-mode.
+// control-mode clients (copy-mode-style read-only clients like fleet's own
+// sidebar scraper) must never receive a switch-client. Returns null when no
+// eligible client is attached.
+export function pickClient(stdout: string): string | null {
+  let best: { activity: number; name: string } | null = null;
+  for (const line of stdout.split('\n')) {
+    if (line.length === 0) continue;
+    const parts = line.split('\t');
+    const activity = parseInt(parts[0] ?? '', 10);
+    const name = parts[1];
+    const flags = parts[2] ?? '';
+    if (Number.isNaN(activity) || !name) continue;
+    if (flags.split(',').includes('control-mode')) continue;
+    if (best === null || activity > best.activity) {
+      best = { activity, name };
+    }
+  }
+  return best?.name ?? null;
+}
+
+// `open -b <bundleId>` activates the terminal. Returns null when bundleId is
+// '-'/empty so the caller skips activation (unknown terminal).
+export function activationCommand(bundleId: string): string[] | null {
+  if (bundleId === '-' || bundleId.length === 0) return null;
+  return ['open', '-b', bundleId];
+}
+
+// The exact-pane jump: switch the chosen client onto the pane's session, then
+// select the pane's window and the pane itself. `;` joins the three tmux
+// commands in one process (same shape as the reference open_pane).
+export function jumpArgs(
+  socketPath: string,
+  client: string,
+  paneId: string,
+  sessionName: string,
+): string[] {
+  return [
+    ...socketArgs(socketPath),
+    'switch-client',
+    '-c',
+    client,
+    '-t',
+    sessionName,
+    ';',
+    'select-window',
+    '-t',
+    paneId,
+    ';',
+    'select-pane',
+    '-t',
+    paneId,
+  ];
+}
+
+// Thin shell: drive the planners through tmux. Every failure path is a silent
+// exit 0 (stale pane, no client, tmux down) so a notification click never
+// surfaces an error to the user.
+export function runNotificationOpen(args: string[]): number {
+  const parsed = parseOpenArgs(args);
+  if (!parsed) {
+    process.stderr.write('Usage: fleet notification-open <paneId> [socketPath] [terminalBundleId]\n');
+    return 1;
+  }
+  const { paneId, socketPath, terminalBundleId } = parsed;
+
+  // Verify the pane still exists. Stale target → silent no-op.
+  const panes = tmux(listPanesArgs(socketPath));
+  if (panes.exitCode !== 0) return 0;
+  const ref = parsePaneRefs(panes.stdout).find((p) => p.paneId === paneId);
+  if (!ref) return 0;
+
+  // Pick the most recently active real client. No client → silent no-op.
+  const clients = tmux(listClientsArgs(socketPath));
+  if (clients.exitCode !== 0) return 0;
+  const client = pickClient(clients.stdout);
+  if (!client) return 0;
+
+  // Activate the terminal FIRST so the jump lands in a foreground window.
+  const activate = activationCommand(terminalBundleId);
+  if (activate) {
+    Bun.spawnSync({ cmd: activate, stdout: 'ignore', stderr: 'ignore' });
+  }
+
+  // Then jump tmux to the exact pane.
+  tmux(jumpArgs(socketPath, client, paneId, ref.sessionName));
+  return 0;
+}
+
+

--- a/src/cli/notification-open.ts
+++ b/src/cli/notification-open.ts
@@ -102,12 +102,7 @@ export function activationCommand(bundleId: string): string[] | null {
 // The exact-pane jump: switch the chosen client onto the pane's session, then
 // select the pane's window and the pane itself. `;` joins the three tmux
 // commands in one process (same shape as the reference open_pane).
-export function jumpArgs(
-  socketPath: string,
-  client: string,
-  paneId: string,
-  sessionName: string,
-): string[] {
+export function jumpArgs(socketPath: string, client: string, paneId: string, sessionName: string): string[] {
   return [
     ...socketArgs(socketPath),
     'switch-client',
@@ -159,5 +154,3 @@ export function runNotificationOpen(args: string[]): number {
   tmux(jumpArgs(socketPath, client, paneId, ref.sessionName));
   return 0;
 }
-
-

--- a/src/cli/status.test.ts
+++ b/src/cli/status.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from 'bun:test';
-import { formatTmuxStatus, formatPlainStatus, formatStatusLine, formatAge, windowColorArgs } from './status.ts';
+import {
+  formatTmuxStatus,
+  formatPlainStatus,
+  formatStatusLine,
+  formatAge,
+  windowColorArgs,
+  resolveStatusLineSegment,
+} from './status.ts';
 import { AgentStatus, ACK_ALL_RANGE, SIDEBAR_RANGE, type AgentState } from '../state/types.ts';
 
 const makeState = (overrides: Partial<AgentState>): AgentState => ({
@@ -318,5 +325,42 @@ describe('windowColorArgs', () => {
 
   test('returns no args for an empty state list', () => {
     expect(windowColorArgs([])).toHaveLength(0);
+  });
+});
+
+describe('resolveStatusLineSegment', () => {
+  // A fresh cached value short-circuits the live path: computeLive is never
+  // called, so no tmux forks or state reads happen on a cache hit. The decision
+  // is pure — no real tmux/filesystem needed.
+  test('returns the cached segment as a hit and never calls computeLive', () => {
+    let liveCalls = 0;
+    const computeLive = () => {
+      liveCalls++;
+      return formatStatusLine([makeState({ status: AgentStatus.PERMIT })]);
+    };
+    const result = resolveStatusLineSegment('cached-segment', computeLive);
+    expect(result).toEqual({ segment: 'cached-segment', hit: true });
+    expect(liveCalls).toBe(0);
+  });
+
+  test('falls back to computeLive on a miss (null cache) and reports hit: false', () => {
+    const states = [makeState({ status: AgentStatus.PERMIT, window: 'p-win' })];
+    const result = resolveStatusLineSegment(null, () => formatStatusLine(states));
+    expect(result.hit).toBe(false);
+    expect(result.segment).toContain('p-win');
+    // Byte-identical to the live renderer the TUI uses.
+    expect(result.segment).toBe(formatStatusLine(states));
+  });
+
+  test('a miss with an empty cache string is still treated as a hit', () => {
+    // An empty bar is a valid cached value (sidebar button only); null is the
+    // only miss signal, so the CLI never recomputes just to render nothing.
+    let liveCalls = 0;
+    const result = resolveStatusLineSegment('', () => {
+      liveCalls++;
+      return 'live';
+    });
+    expect(result).toEqual({ segment: '', hit: true });
+    expect(liveCalls).toBe(0);
   });
 });

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -121,6 +121,21 @@ export function windowColorArgs(states: AgentState[]): string[][] {
   return args;
 }
 
+// Decide the `--statusline` segment, preferring a fresh cache so a live TUI's
+// already-computed segment is reused without cold-booting Bun or re-reading
+// agent state. Pure: the caller hands in whatever it read from the cache (null
+// on miss) and a thunk for the live compute, and gets back the segment plus
+// whether it was a cache hit. Split out so the short-circuit is testable without
+// a real tmux/filesystem — the thin CLI shell in index.ts wires real I/O around
+// it.
+export function resolveStatusLineSegment(
+  cached: string | null,
+  computeLive: () => string,
+): { segment: string; hit: boolean } {
+  if (cached !== null) return { segment: cached, hit: true };
+  return { segment: computeLive(), hit: false };
+}
+
 export function runStatus(args: string[], states: AgentState[]): string {
   const tmuxMode = args.includes('--tmux');
   const statusLineMode = args.includes('--statusline');

--- a/src/notify/deliver.test.ts
+++ b/src/notify/deliver.test.ts
@@ -126,11 +126,7 @@ describe('planDarwinDelivery — ladder decision', () => {
       () => true,
     );
     expect(spec.program).toBe(helperPath(home));
-    expect(spec.args).toEqual([
-      'Codex finished',
-      'context',
-      "'/exe' 'notification-open' '%7' '-' '-'",
-    ]);
+    expect(spec.args).toEqual(['Codex finished', 'context', "'/exe' 'notification-open' '%7' '-' '-'"]);
     expect(spec.detached).toBe(true);
     expect(spec.stdin).toBeUndefined();
   });
@@ -143,7 +139,13 @@ describe('planDarwinDelivery — ladder decision', () => {
   });
 
   test('helper absent → silent osascript spec (no sound, no click)', () => {
-    const spec = planDarwinDelivery('Codex finished', 'context', "'/exe' 'notification-open'", '/Users/me', () => false);
+    const spec = planDarwinDelivery(
+      'Codex finished',
+      'context',
+      "'/exe' 'notification-open'",
+      '/Users/me',
+      () => false,
+    );
     expect(spec.program).toBe('osascript');
     expect(spec.args[0]).toBe('-e');
     const script = spec.args[1]!;

--- a/src/notify/deliver.test.ts
+++ b/src/notify/deliver.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  buildClickCommand,
+  deliverDesktop,
+  helperPath,
+  planDarwinDelivery,
+  sanitizeNotificationText,
+  truncateText,
+} from './deliver.ts';
+
+describe('sanitizeNotificationText', () => {
+  test('strips CSI sequences (ESC [ ... final byte)', () => {
+    expect(sanitizeNotificationText('\x1b[31mred\x1b[0m text')).toBe('red text');
+    expect(sanitizeNotificationText('\x1b[1;31;42mhi\x1b[0m')).toBe('hi');
+  });
+
+  test('strips OSC strings terminated by BEL', () => {
+    expect(sanitizeNotificationText('\x1b]0;secret\x07visible')).toBe('visible');
+  });
+
+  test('strips OSC strings terminated by ST (ESC \\)', () => {
+    expect(sanitizeNotificationText('\x1b]8;;https://example.test\x1b\\link')).toBe('link');
+  });
+
+  test('strips DCS/SOS/PM/APC control strings', () => {
+    expect(sanitizeNotificationText('\x1bPqping\x1b\\pong')).toBe('pong');
+    expect(sanitizeNotificationText('\x1b_X\x1b\\y')).toBe('y');
+  });
+
+  test('strips lone C1 CSI (0x9b)', () => {
+    // 0x9b followed by parameters (31) and a final byte (m, 0x6d) — the whole
+    // sequence is consumed; 'rest' survives.
+    expect(sanitizeNotificationText('\u009b31mrest')).toBe('rest');
+  });
+
+  test('drops other control chars', () => {
+    expect(sanitizeNotificationText('a\x00b\x07c')).toBe('abc');
+  });
+
+  test('maps whitespace to single spaces and collapses runs', () => {
+    expect(sanitizeNotificationText('a\t\n b   c')).toBe('a b c');
+  });
+
+  test('combined real-world pane title', () => {
+    const input = '\x1b]0;secret\x07\x1b[31mImplement\x1b[0m\nnow';
+    expect(sanitizeNotificationText(input)).toBe('Implement now');
+  });
+
+  test('handles empty and whitespace-only input', () => {
+    expect(sanitizeNotificationText('')).toBe('');
+    expect(sanitizeNotificationText('   \n\t  ')).toBe('');
+  });
+
+  test('preserves unicode', () => {
+    expect(sanitizeNotificationText('界 🙂 codex')).toBe('界 🙂 codex');
+  });
+});
+
+describe('truncateText', () => {
+  test('under limit returns unchanged', () => {
+    expect(truncateText('abc', 80)).toBe('abc');
+  });
+
+  test('at limit returns unchanged', () => {
+    expect(truncateText('abc', 3)).toBe('abc');
+  });
+
+  test('over limit adds ellipsis and caps at limit (char-based)', () => {
+    expect(truncateText('abcdef', 4)).toBe('abc…');
+  });
+
+  test('is unicode-safe (counts code points, not UTF-16 units)', () => {
+    const s = '界'.repeat(100);
+    const out = truncateText(s, 5);
+    expect(Array.from(out)).toHaveLength(5);
+    expect(out.endsWith('…')).toBe(true);
+  });
+
+  test('title/body limits are 80 and 240', () => {
+    const long = '🙂'.repeat(300);
+    expect(Array.from(truncateText(long, 80))).toHaveLength(80);
+    expect(Array.from(truncateText(long, 240))).toHaveLength(240);
+  });
+});
+
+describe('buildClickCommand', () => {
+  test('quotes every argument and places paneId before socket', () => {
+    expect(buildClickCommand('/usr/local/bin/fleet', '%7', '/tmp/sock', 'com.mitchellh.ghostty')).toBe(
+      "'/usr/local/bin/fleet' 'notification-open' '%7' '/tmp/sock' 'com.mitchellh.ghostty'",
+    );
+  });
+
+  test('shell-quotes embedded single quotes', () => {
+    expect(buildClickCommand("/tmp/agent's mon", '%7', '/tmp/tmux socket', 'com.apple.Terminal')).toBe(
+      "'/tmp/agent'\"'\"'s mon' 'notification-open' '%7' '/tmp/tmux socket' 'com.apple.Terminal'",
+    );
+  });
+
+  test('passes through "-" placeholders untouched (still quoted)', () => {
+    expect(buildClickCommand('/exe', '%1', '-', '-')).toBe("'/exe' 'notification-open' '%1' '-' '-'");
+  });
+
+  test('spaces are contained within the quotes', () => {
+    expect(buildClickCommand('/a b/c', '%2', '/path with space', 'bundle id')).toBe(
+      "'/a b/c' 'notification-open' '%2' '/path with space' 'bundle id'",
+    );
+  });
+});
+
+describe('helperPath', () => {
+  test('resolves under the injected home', () => {
+    expect(helperPath('/Users/me')).toBe('/Users/me/Applications/FleetNotifier.app/Contents/MacOS/fleet-notifier');
+  });
+});
+
+describe('planDarwinDelivery — ladder decision', () => {
+  const sanitized = (s: string) => s; // planner receives already-sanitized text
+
+  test('helper present → helper spec with [title, body, clickCommand], detached', () => {
+    const home = '/Users/me';
+    const spec = planDarwinDelivery(
+      sanitized('Codex finished'),
+      sanitized('context'),
+      "'/exe' 'notification-open' '%7' '-' '-'",
+      home,
+      () => true,
+    );
+    expect(spec.program).toBe(helperPath(home));
+    expect(spec.args).toEqual([
+      'Codex finished',
+      'context',
+      "'/exe' 'notification-open' '%7' '-' '-'",
+    ]);
+    expect(spec.detached).toBe(true);
+    expect(spec.stdin).toBeUndefined();
+  });
+
+  test('helper present without click command → helper spec with only [title, body]', () => {
+    const spec = planDarwinDelivery('t', 'b', null, '/Users/me', () => true);
+    expect(spec.program).toBe(helperPath('/Users/me'));
+    expect(spec.args).toEqual(['t', 'b']);
+    expect(spec.detached).toBe(true);
+  });
+
+  test('helper absent → silent osascript spec (no sound, no click)', () => {
+    const spec = planDarwinDelivery('Codex finished', 'context', "'/exe' 'notification-open'", '/Users/me', () => false);
+    expect(spec.program).toBe('osascript');
+    expect(spec.args[0]).toBe('-e');
+    const script = spec.args[1]!;
+    expect(script).toContain('display notification');
+    expect(script).toContain('with title');
+    expect(script).not.toContain('sound name'); // silent
+    expect(spec.detached).toBeUndefined();
+  });
+
+  test('osascript fallback AppleScript-quotes the title and body', () => {
+    const spec = planDarwinDelivery('He said "hi"', 'body\\line', null, '/Users/me', () => false);
+    const script = spec.args[1]!;
+    expect(script).toContain('"He said \\"hi\\""');
+    expect(script).toContain('"body\\\\line"');
+  });
+});
+
+describe('deliverDesktop — never throws', () => {
+  // Guard against the helper-spawn path throwing on non-darwin; we only assert
+  // it doesn't throw. No macOS UI is exercised here.
+  test('unknown platform is a no-op (does not throw)', () => {
+    const before = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'freebsd', configurable: true });
+    try {
+      expect(() => deliverDesktop('t', 'b', '%1')).not.toThrow();
+    } finally {
+      Object.defineProperty(process, 'platform', { value: before, configurable: true });
+    }
+  });
+});

--- a/src/notify/deliver.ts
+++ b/src/notify/deliver.ts
@@ -54,7 +54,10 @@ export function sanitizeNotificationText(s: string): string {
   const n = chars.length;
   const isWs = (ch: string) => ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r' || ch === '\v' || ch === '\f';
   // oxlint-disable-next-line no-control-regex
-  const isControl = (ch: string) => { const c = ch.codePointAt(0)!; return c < 0x20 || (c >= 0x7f && c < 0xa0); };
+  const isControl = (ch: string) => {
+    const c = ch.codePointAt(0)!;
+    return c < 0x20 || (c >= 0x7f && c < 0xa0);
+  };
   const skipCsi = () => {
     while (i < n) {
       const ch = chars[i]!;
@@ -197,12 +200,7 @@ export function deliverDesktop(title: string, body: string, paneId: string): voi
     if (process.platform === 'darwin') {
       const safeTitle = truncateText(sanitizeNotificationText(title), TITLE_LIMIT);
       const safeBody = truncateText(sanitizeNotificationText(body), BODY_LIMIT);
-      const click = buildClickCommand(
-        process.execPath,
-        paneId,
-        tmuxSocket(process.env),
-        terminalBundle(process.env),
-      );
+      const click = buildClickCommand(process.execPath, paneId, tmuxSocket(process.env), terminalBundle(process.env));
       const spec = planDarwinDelivery(safeTitle, safeBody, click, homedir(), existsSync);
       runSpec(spec);
       return;

--- a/src/notify/deliver.ts
+++ b/src/notify/deliver.ts
@@ -2,6 +2,23 @@
 // unsupported — a notifier must never crash the render loop (fleet's
 // never-crash-the-host principle). See the no-audible-cue constraint: no
 // `sound name` (macOS) / no `-u critical` (Linux), so these stay silent.
+//
+// macOS delivery is a ladder: when the native FleetNotifier helper is installed
+// (~/Applications/FleetNotifier.app/Contents/MacOS/fleet-notifier) it is spawned
+// detached with [title, body, clickCommand] — the helper posts through
+// UNUserNotificationCenter and runs the click command (a `fleet notification-open
+// <paneId> <socket> <bundle>` invocation) when the body is clicked. An installed
+// helper is authoritative: a failure (typically denied permission) means silence,
+// never an AppleScript end-run. When the helper is absent, the silent osascript
+// path is used unchanged. The helper path is re-resolved on every delivery so
+// installing the app takes effect without restarting the sidebar.
+
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+
+const HELPER_REL = 'Applications/FleetNotifier.app/Contents/MacOS/fleet-notifier';
+const TITLE_LIMIT = 80;
+const BODY_LIMIT = 240;
 
 // AppleScript-escape a string into a double-quoted literal. osascript is spawned
 // via argv (no shell), so only AppleScript-level escaping is needed: backslash and
@@ -16,18 +33,185 @@ function q(s: string): string {
   return `"${escaped}"`;
 }
 
-// macOS: osascript display notification WITHOUT `sound name` => silent.
+// Shell-quote a single argument into a POSIX single-quoted literal, escaping any
+// embedded single quotes as '\' + "'" + '\' (i.e. the standard '"'"' trick) so
+// the click command is safe to feed to /bin/sh -c on click.
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\"'\"'")}'`;
+}
+
+// Strip terminal control sequences from notification text so a hostile or noisy
+// pane title can't inject escapes into the toast. Ports the Rust sanitize():
+//   - ESC [ ... final byte 0x40–0x7e  → CSI sequence, dropped
+//   - ESC ]/P/X/^/_ ... terminated by BEL or ESC \ → OSC/DCS/SOS/PM/APC, dropped
+//   - lone 0x9b (C1 CSI) → CSI sequence, dropped
+//   - whitespace → single space; other control chars dropped
+//   - runs of whitespace collapsed to a single space
+export function sanitizeNotificationText(s: string): string {
+  const chars = Array.from(s);
+  let clean = '';
+  let i = 0;
+  const n = chars.length;
+  const isWs = (ch: string) => ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r' || ch === '\v' || ch === '\f';
+  // oxlint-disable-next-line no-control-regex
+  const isControl = (ch: string) => { const c = ch.codePointAt(0)!; return c < 0x20 || (c >= 0x7f && c < 0xa0); };
+  const skipCsi = () => {
+    while (i < n) {
+      const ch = chars[i]!;
+      i += 1;
+      const c = ch.codePointAt(0)!;
+      if (c >= 0x40 && c <= 0x7e) break;
+    }
+  };
+  const skipControlString = () => {
+    while (i < n) {
+      const ch = chars[i]!;
+      i += 1;
+      if (ch === '\x07') break;
+      if (ch === '\x1b') {
+        if (i < n && chars[i] === '\\') {
+          i += 1;
+          break;
+        }
+      }
+    }
+  };
+  while (i < n) {
+    const ch = chars[i]!;
+    i += 1;
+    if (ch === '\x1b') {
+      if (i < n) {
+        const next = chars[i]!;
+        if (next === '[') {
+          i += 1;
+          skipCsi();
+        } else if (next === ']' || next === 'P' || next === 'X' || next === '^' || next === '_') {
+          i += 1;
+          skipControlString();
+        }
+      }
+    } else if (ch === '\x9b') {
+      skipCsi();
+    } else if (isWs(ch)) {
+      clean += ' ';
+    } else if (!isControl(ch)) {
+      clean += ch;
+    }
+  }
+  return clean.trim().replace(/\s+/g, ' ');
+}
+
+// Char-based truncation with a trailing ellipsis when the text exceeds the limit.
+export function truncateText(s: string, limit: number): string {
+  const chars = Array.from(s);
+  if (chars.length <= limit) return s;
+  const ell = '…';
+  const keep = Math.max(0, limit - ell.length);
+  return chars.slice(0, keep).join('') + ell;
+}
+
+// Build the click command the helper runs when the notification body is clicked:
+// `<fleet-exe> notification-open <paneId> <socketPath> <terminalBundleId>`, every
+// argument shell-quoted. The helper invokes it via `/bin/sh -c` on click.
+export function buildClickCommand(fleetExe: string, paneId: string, socket: string, bundle: string): string {
+  return [fleetExe, 'notification-open', paneId, socket, bundle].map(shellQuote).join(' ');
+}
+
+// Resolve the helper path under a (possibly injected) home directory.
+export function helperPath(home: string): string {
+  return `${home}/${HELPER_REL}`;
+}
+
+// First comma-field of $TMUX, or '-' when unset/empty (matches the sibling
+// notification-open CLI's contract).
+function tmuxSocket(env: NodeJS.ProcessEnv): string {
+  const tmux = env.TMUX;
+  if (!tmux) return '-';
+  const first = tmux.split(',')[0];
+  return first && first.length > 0 ? first : '-';
+}
+
+function terminalBundle(env: NodeJS.ProcessEnv): string {
+  return env.__CFBundleIdentifier ?? '-';
+}
+
+export interface CommandSpec {
+  program: string;
+  args: string[];
+  stdin?: string;
+  detached?: boolean;
+}
+
+// Pure planner for the macOS delivery ladder. Returns the command to spawn:
+// the native helper (detached, with click command) when its binary exists, or
+// the silent osascript fallback otherwise. `exists` is injected so tests can
+// drive both branches without touching the filesystem.
+export function planDarwinDelivery(
+  title: string,
+  body: string,
+  clickCommand: string | null,
+  home: string,
+  exists: (path: string) => boolean,
+): CommandSpec {
+  const helper = helperPath(home);
+  if (exists(helper)) {
+    const args = [title, body];
+    if (clickCommand != null) args.push(clickCommand);
+    return { program: helper, args, detached: true };
+  }
+  // Silent osascript fallback — no `sound name`, no click handling.
+  const script = `display notification ${q(body)} with title ${q(title)}`; // no sound
+  return { program: 'osascript', args: ['-e', script] };
+}
+
+// Thin spawn shell around a CommandSpec. Never throws; swallow spawn errors.
+function runSpec(spec: CommandSpec): void {
+  const child = Bun.spawn({
+    cmd: [spec.program, ...spec.args],
+    stdin: spec.stdin != null ? 'pipe' : 'ignore',
+    stdout: 'ignore',
+    stderr: 'ignore',
+    detached: spec.detached ?? false,
+  });
+  if (spec.stdin != null) {
+    try {
+      child.stdin?.write(spec.stdin);
+      child.stdin?.end();
+    } catch {
+      /* ignore */
+    }
+  }
+  if (spec.detached) {
+    try {
+      child.unref();
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+// macOS: helper ladder if installed, else silent osascript.
 // Linux: notify-send only when a desktop session is present.
-export function deliverDesktop(title: string, body: string): void {
+export function deliverDesktop(title: string, body: string, paneId: string): void {
   try {
     if (process.platform === 'darwin') {
-      const script = `display notification ${q(body)} with title ${q(title)}`; // no sound
-      Bun.spawn(['osascript', '-e', script], { stdout: 'ignore', stderr: 'ignore' });
+      const safeTitle = truncateText(sanitizeNotificationText(title), TITLE_LIMIT);
+      const safeBody = truncateText(sanitizeNotificationText(body), BODY_LIMIT);
+      const click = buildClickCommand(
+        process.execPath,
+        paneId,
+        tmuxSocket(process.env),
+        terminalBundle(process.env),
+      );
+      const spec = planDarwinDelivery(safeTitle, safeBody, click, homedir(), existsSync);
+      runSpec(spec);
       return;
     }
     if (process.platform === 'linux') {
       if (!process.env.DISPLAY && !process.env.WAYLAND_DISPLAY) return; // headless/SSH => no-op
-      Bun.spawn(['notify-send', '-u', 'normal', title, body], { stdout: 'ignore', stderr: 'ignore' });
+      const safeTitle = truncateText(sanitizeNotificationText(title), TITLE_LIMIT);
+      const safeBody = truncateText(sanitizeNotificationText(body), BODY_LIMIT);
+      Bun.spawn(['notify-send', '-u', 'normal', safeTitle, safeBody], { stdout: 'ignore', stderr: 'ignore' });
       return;
     }
     // other platforms: no-op

--- a/src/notify/notify.test.ts
+++ b/src/notify/notify.test.ts
@@ -113,28 +113,36 @@ describe('decideNotifications — detection', () => {
 describe('applySuppression', () => {
   const candidates = [notif('%1'), notif('%2')];
 
-  test('activePaneId === a candidate pane → that one dropped, others kept', () => {
-    expect(applySuppression(candidates, '%1', null)).toEqual([notif('%2')]);
+  test('candidate pane ∈ focusedPanes → that one dropped, others kept', () => {
+    expect(applySuppression(candidates, new Set(['%1']), null)).toEqual([notif('%2')]);
   });
 
-  test('activePaneId === fleetPaneId → all dropped (watching the dashboard)', () => {
-    expect(applySuppression(candidates, '%9', '%9')).toEqual([]);
+  test('fleetPaneId ∈ focusedPanes → all dropped (watching the dashboard)', () => {
+    expect(applySuppression(candidates, new Set(['%9']), '%9')).toEqual([]);
   });
 
   test('watching fleet drops toasts even for a pane that is also a candidate', () => {
-    // Focus is fleet's pane, which happens to equal a candidate pane id.
-    expect(applySuppression(candidates, '%1', '%1')).toEqual([]);
+    // Fleet's pane is focused and happens to equal a candidate pane id.
+    expect(applySuppression(candidates, new Set(['%1']), '%1')).toEqual([]);
   });
 
-  test('activePaneId === null → nothing dropped (suppression disabled)', () => {
-    expect(applySuppression(candidates, null, null)).toEqual(candidates);
+  test('empty focusedPanes → nothing dropped (suppression disabled)', () => {
+    expect(applySuppression(candidates, new Set(), null)).toEqual(candidates);
   });
 
-  test('null active pane disables suppression even when fleetPaneId is set', () => {
-    expect(applySuppression(candidates, null, '%9')).toEqual(candidates);
+  test('empty focus set suppresses nothing even when fleetPaneId is set', () => {
+    expect(applySuppression(candidates, new Set(), '%9')).toEqual(candidates);
   });
 
-  test('active pane not among candidates → all kept', () => {
-    expect(applySuppression(candidates, '%7', '%9')).toEqual(candidates);
+  test('no candidate pane ∈ focusedPanes → all kept', () => {
+    expect(applySuppression(candidates, new Set(['%7']), '%9')).toEqual(candidates);
+  });
+
+  test('two clients: agent pane visible in client B is suppressed; a hidden agent still fires', () => {
+    // Client B is viewing %2 (an agent pane that just stopped); client A is on
+    // a non-agent pane %5. %2 is focused → its toast is suppressed. %1 stopped
+    // too but nobody is watching it → its toast still fires.
+    const cands = [notif('%1'), notif('%2')];
+    expect(applySuppression(cands, new Set(['%2', '%5']), null)).toEqual([notif('%1')]);
   });
 });

--- a/src/notify/transitions.ts
+++ b/src/notify/transitions.ts
@@ -38,15 +38,18 @@ export function decideNotifications(
   return { candidates, previous: next };
 }
 
-// Suppression: silent entirely while you're viewing fleet's own pane (you can see
-// the change on the dashboard); otherwise drop the one pane you're viewing.
-// activePaneId === null disables suppression (used when the active pane can't be
-// resolved — better a redundant toast than a missed one).
+// Suppression: silent entirely while you're viewing fleet's own pane (you can
+// see the change on the dashboard); otherwise drop candidates whose pane a real
+// tmux client is currently focused on. `focusedPanes` is the multi-client focus
+// set from readClientFocus() — empty when tmux can't answer, which suppresses
+// nothing (better a redundant toast than a missed one). `fleetPaneId` is null
+// when fleet runs outside tmux, in which case per-pane suppression still applies.
 export function applySuppression(
   candidates: Notification[],
-  activePaneId: string | null,
+  focusedPanes: Set<string>,
   fleetPaneId: string | null,
 ): Notification[] {
-  if (activePaneId != null && activePaneId === fleetPaneId) return []; // watching the dashboard
-  return candidates.filter((c) => c.paneId !== activePaneId);
+  if (fleetPaneId != null && focusedPanes.has(fleetPaneId)) return []; // watching the dashboard
+  if (focusedPanes.size === 0) return candidates; // suppress nothing when unknown
+  return candidates.filter((c) => !focusedPanes.has(c.paneId));
 }

--- a/src/state/detection.test.ts
+++ b/src/state/detection.test.ts
@@ -421,14 +421,7 @@ describe('claude: field-tested permit phrases', () => {
   }
 
   test('a live token counter outranks a lingering answered "waiting for permission" prompt', () => {
-    const lines = [
-      '│ waiting for permission',
-      '│ ❯ 1. Yes',
-      '',
-      '✽ Processing… (20m 29s · ↓ 45.4k tokens)',
-      '',
-      '❯',
-    ];
+    const lines = ['│ waiting for permission', '│ ❯ 1. Yes', '', '✽ Processing… (20m 29s · ↓ 45.4k tokens)', '', '❯'];
     expect(detectFromPaneContent(lines, CLAUDE_MANIFEST)).toEqual({
       status: AgentStatus.BUSY,
       ruleId: 'busy.token-counter-min',

--- a/src/state/detection.test.ts
+++ b/src/state/detection.test.ts
@@ -395,6 +395,47 @@ describe('claude: live working indicators outrank a lingering answered prompt', 
   });
 });
 
+// 8b. Field-tested Claude Code permission-dialog phrases (herdr/tmux-agents-mon
+//     agents/claude.conf BLOCKED_SCREEN) added as case-insensitive PERMIT rules
+//     in tier 2. Each phrase alone reads PERMIT; a live token counter alongside
+//     a lingering answered one of these prompts still reads BUSY (tier 1 wins).
+describe('claude: field-tested permit phrases', () => {
+  const cases: Array<{ name: string; lines: string[]; ruleId: string }> = [
+    { name: 'waiting for permission', lines: ['waiting for permission'], ruleId: 'permit.waiting-for-permission' },
+    {
+      name: 'do you want to allow this connection?',
+      lines: ['do you want to allow this connection?'],
+      ruleId: 'permit.allow-connection',
+    },
+    { name: 'tab to amend', lines: ['tab to amend'], ruleId: 'permit.tab-to-amend' },
+    { name: 'ctrl+e to explain', lines: ['ctrl+e to explain'], ruleId: 'permit.ctrl-e-explain' },
+    { name: 'run a dynamic workflow?', lines: ['run a dynamic workflow?'], ruleId: 'permit.dynamic-workflow' },
+  ];
+  for (const c of cases) {
+    test(`${c.name} → PERMIT via ${c.ruleId}`, () => {
+      expect(detectFromPaneContent([...c.lines, '❯'], CLAUDE_MANIFEST)).toEqual({
+        status: AgentStatus.PERMIT,
+        ruleId: c.ruleId,
+      });
+    });
+  }
+
+  test('a live token counter outranks a lingering answered "waiting for permission" prompt', () => {
+    const lines = [
+      '│ waiting for permission',
+      '│ ❯ 1. Yes',
+      '',
+      '✽ Processing… (20m 29s · ↓ 45.4k tokens)',
+      '',
+      '❯',
+    ];
+    expect(detectFromPaneContent(lines, CLAUDE_MANIFEST)).toEqual({
+      status: AgentStatus.BUSY,
+      ruleId: 'busy.token-counter-min',
+    });
+  });
+});
+
 // 9. The opencode built-in, verified against real captured opencode frames
 //    (herdr/agent-radar-derived patterns). Previously a hook-less opencode could
 //    only ever read BUSY/IDLE from the glyph scan.

--- a/src/state/detection.ts
+++ b/src/state/detection.ts
@@ -178,6 +178,14 @@ export const CLAUDE_MANIFEST: DetectionManifest = {
       denyKeys: ['n'],
     },
     { id: 'permit.do-you-want', pattern: 'Do you want to (proceed|allow)', state: 'PERMIT' },
+    // Field-tested Claude Code permission-dialog phrases (herdr/tmux-agents-mon
+    // agents/claude.conf BLOCKED_SCREEN) fleet previously missed. All are
+    // case-insensitive; the manifest-level approve/deny keys (1 / Escape) apply.
+    { id: 'permit.waiting-for-permission', pattern: 'waiting for permission', flags: 'i', state: 'PERMIT' },
+    { id: 'permit.allow-connection', pattern: 'do you want to allow this connection\\?', flags: 'i', state: 'PERMIT' },
+    { id: 'permit.tab-to-amend', pattern: 'tab to amend', flags: 'i', state: 'PERMIT' },
+    { id: 'permit.ctrl-e-explain', pattern: 'ctrl\\+e to explain', flags: 'i', state: 'PERMIT' },
+    { id: 'permit.dynamic-workflow', pattern: 'run a dynamic workflow\\?', flags: 'i', state: 'PERMIT' },
     { id: 'question.enter-select', pattern: 'Enter to select.*[↑↓]|Esc to cancel', state: 'QUESTION' },
     { id: 'busy.spinner-glyph', pattern: WORKING_GLYPH_PATTERN, state: 'BUSY' },
   ],
@@ -196,8 +204,10 @@ export const CLAUDE_MANIFEST: DetectionManifest = {
 
 // --- the embedded built-in `codex` manifest (Phase 3) ---
 // Codex fires PreToolUse+Stop hooks, so BUSY/DONE come from the hook (which is
-// authoritative and faster than any spinner regex) — no BUSY scrape rule is
-// needed. Codex has no Notification hook and its on-screen prompts don't cleanly
+// authoritative and faster than any spinner regex). A busy.esc-interrupt screen
+// rule is kept as a hook-less fallback (herdr WORKING_SCREEN) so a captured
+// working frame still reads BUSY when no hook is wired. Codex has no Notification
+// hook and its on-screen prompts don't cleanly
 // separate a permission request from a question, so every prompt rule is PERMIT
 // (QUESTION is not currently sourced for Codex — a documented limitation). Rules
 // are ORDERED, first match wins, exactly like CLAUDE_MANIFEST; ids follow the
@@ -212,6 +222,10 @@ export const CODEX_MANIFEST: DetectionManifest = {
     { id: 'permit.confirm', pattern: 'press enter to confirm or esc to cancel', flags: 'i', state: 'PERMIT' },
     { id: 'permit.yn', pattern: '\\[y/n\\]', flags: 'i', state: 'PERMIT', approveKeys: ['y'], denyKeys: ['n'] },
     { id: 'permit.do-you-want', pattern: 'do you want to', flags: 'i', state: 'PERMIT' },
+    // Hook-less BUSY fallback (herdr WORKING_SCREEN='esc to interrupt'). Codex's
+    // PreToolUse+Stop hooks are authoritative and faster, so this only lands
+    // when no hook is wired — it never overrides a permit rule above it.
+    { id: 'busy.esc-interrupt', pattern: 'esc to interrupt', flags: 'i', state: 'BUSY' },
   ],
   // Codex retitles its pane "Action Required" while blocked on approval — the
   // signal its missing Notification hook never provides — and prefixes a braille

--- a/src/state/fixtures.test.ts
+++ b/src/state/fixtures.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'bun:test';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { detectFromPaneContent, detectFromTitle } from './scraper.ts';
+import { loadDetectionManifest } from './detection.ts';
+import { AgentStatus } from './types.ts';
+
+// Real-capture fixture corpus sweep. Every *.txt in src/state/fixtures/ is a
+// tmux capture-pane dump from a live agent pane (sources: herdr/tmux-agents-mon
+// tests/fixtures). The filename encodes the expected fleet state:
+//   <agent>-<expected>[-n].txt   where expected ∈ permit|question|busy|idle
+// The sweep parses the stem, loads the agent's manifest, runs detectFromPaneContent
+// on the split lines, and asserts the expected AgentStatus. Where a <stem>.title
+// sidecar exists AND the manifest has titleRules (claude, codex), it additionally
+// asserts detectFromTitle on busy/permit expectations (the title rides the fast
+// tick and is the authoritative blocked/working signal for those agents).
+//
+// codex-idle is intentionally absent: codex's composer renders a "› <placeholder>"
+// idle line, not the "❯" marker, so fleet's screen detection returns null and the
+// "- project" title matches no title rule — a documented limitation (herdr
+// codex.conf pulls the idle subject from rollout files, not the screen). See the
+// summary in the task notes; dropped as unresolvable rather than guessed.
+
+const FIXTURES_DIR = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
+
+const EXPECTED_TO_STATUS: Record<string, AgentStatus> = {
+  permit: AgentStatus.PERMIT,
+  question: AgentStatus.QUESTION,
+  busy: AgentStatus.BUSY,
+  idle: AgentStatus.IDLE,
+};
+
+interface FixtureCase {
+  file: string;
+  agent: string;
+  expected: AgentStatus;
+}
+
+function discoverFixtures(): FixtureCase[] {
+  const txts = readdirSync(FIXTURES_DIR).filter((f) => f.endsWith('.txt') && !f.endsWith('.title'));
+  const cases: FixtureCase[] = [];
+  for (const file of txts) {
+    const stem = file.replace(/\.txt$/, '');
+    const parts = stem.split('-');
+    const agent = parts[0]!;
+    const expectedSlug = parts[1]!;
+    const expected = EXPECTED_TO_STATUS[expectedSlug];
+    if (!expected) throw new Error(`fixture "${file}" has no recognized expected state in its name`);
+    cases.push({ file, agent, expected });
+  }
+  return cases;
+}
+
+describe('fixture corpus: real captures classify to their filename-encoded state', () => {
+  const cases = discoverFixtures();
+  if (cases.length === 0) test('fixtures present', () => expect.unreachable('no fixtures discovered'));
+
+  for (const c of cases) {
+    describe(`${c.file} → ${c.expected}`, () => {
+      const path = join(FIXTURES_DIR, c.file);
+      const content = readFileSync(path, 'utf-8');
+      const lines = content.split('\n');
+      const manifest = loadDetectionManifest(c.agent);
+      const titlePath = join(FIXTURES_DIR, c.file.replace(/\.txt$/, '.title'));
+      const hasTitle = existsSync(titlePath);
+      const title = hasTitle ? readFileSync(titlePath, 'utf-8').trim() : '';
+      const hasTitleRules = (manifest.titleRules?.length ?? 0) > 0;
+
+      test('detectFromPaneContent matches the expected state', () => {
+        expect(detectFromPaneContent(lines, manifest).status).toBe(c.expected);
+      });
+
+      if (hasTitle && hasTitleRules && (c.expected === AgentStatus.BUSY || c.expected === AgentStatus.PERMIT)) {
+        test('detectFromTitle matches the expected state', () => {
+          expect(detectFromTitle(title, manifest).status).toBe(c.expected);
+        });
+      }
+    });
+  }
+});

--- a/src/state/fixtures/claude-busy.title
+++ b/src/state/fixtures/claude-busy.title
@@ -1,0 +1,1 @@
+⠂ tmux-agents-mon-plugin

--- a/src/state/fixtures/claude-busy.txt
+++ b/src/state/fixtures/claude-busy.txt
@@ -1,0 +1,46 @@
+      49    local b="${1##*/}"
+      50    b="${b%.js}"; b="${b%.cmd}"; b="${b%.exe}"
+
+⏺ Update(tmux-agents-mon/scripts/scan.sh)
+  ⎿  Added 3 lines, removed 4 lines
+       98  }
+       99
+      100  identify_agent() { # $1=pane_pid $2=pane_current_command -> prints agent index
+      101 -  local base idx line
+      102 -  base="$(normalize_bin "$2")"
+      103 -  agent_for_bin "$base" && return 0
+      104 -  is_generic_runtime "$base" || return 1
+      101 +  local idx line
+      102 +  agent_for_bin "$(normalize_bin "$2")" && return 0
+      103 +  # no direct match: walk pane's process tree (wrappers, node CLIs, odd shells)
+      104    while IFS= read -r line; do
+      105      [ -n "$line" ] || continue
+      106      idx="$(agent_for_bin "$(normalize_bin "${line%% *}")")" && { printf '%s' "$idx"; return 0; }
+
+  Thought for 19s, ran 1 shell command
+
+⏺ Update(tmux-agents-mon/scripts/scan.sh)
+  ⎿  Added 1 line
+      137
+      138  scan() { # one line per agent pane: pane_id \t loc \t agent \t state \t dir
+      139    local pane pid cmd path loc title idx state
+      140 +  PS_CACHE="$(ps -axo pid=,ppid=,command=)"  # one ps per scan; subshells inherit
+      141    while IFS=$'\t' read -r pane pid cmd path loc title; do
+      142      [ -n "${AGENTS_MON_SELF:-}" ] && [ "$pane" = "$AGENTS_MON_SELF" ] && continue  # sidebar skips itself
+      143      idx="$(identify_agent "$pid" "$cmd")" || continue
+
+  Thought for 1m 37s
+
+⏺ Now fixtures — capture real screens from the live panes:
+
+  Running 1 shell command…
+  ⎿  $ cd /Users/dev/Projects/demo/tmux-agents-mon && mkdir -p tests/fixtures && tmux capture-pane -p -t %25 > tests/fixtures/claude-idle.txt && tmux
+     capture-pane -p -t %7 > tests/fixtures/codex-idle.txt && tmux capture-pane -p -t %26 > tests/fixtures/pi-idle.txt && tmux capture-pane -…
+
+✽ Processing… (20m 29s · ↓ 45.4k tokens)
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── tmux-agents-mon-plugin ──
+❯ 
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+   /Users/dev/Projects/demo  Fable 5 10%                                                                                                                  /rc
+  -- INSERT -- ⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents

--- a/src/state/fixtures/claude-idle.title
+++ b/src/state/fixtures/claude-idle.title
@@ -1,0 +1,1 @@
+✳ project

--- a/src/state/fixtures/claude-idle.txt
+++ b/src/state/fixtures/claude-idle.txt
@@ -1,0 +1,23 @@
+⏺ Read the failing test and traced the assertion to the date formatting helper.
+
+⏺ Read(src/utils/format.ts)
+  ⎿  Read 42 lines
+
+⏺ The helper drops the timezone offset before comparing, so tests pass locally
+  but fail in CI (UTC). Fixed by comparing epoch milliseconds instead.
+
+⏺ Update(src/utils/format.ts)
+  ⎿  Updated src/utils/format.ts with 2 additions and 2 removals
+
+⏺ Bash(npm test)
+  ⎿  Test Suites: 4 passed, 4 total
+     Tests:       31 passed, 31 total
+
+⏺ All tests pass. The fix compares epoch milliseconds, which is
+  timezone-independent, instead of formatted strings.
+
+────────────────────────────────────────────────────────────────────────────────
+❯
+────────────────────────────────────────────────────────────────────────────────
+   demo main  Claude  2%                                                     /rc
+  -- INSERT -- ⏵⏵ bypass permissions on (shift+tab to cycle)

--- a/src/state/fixtures/claude-permit.txt
+++ b/src/state/fixtures/claude-permit.txt
@@ -1,0 +1,14 @@
+⏺ Bash(rm -rf node_modules && npm install)
+  ⎿  Running…
+
+╭──────────────────────────────────────────────────────────────╮
+│ Bash command                                                 │
+│                                                              │
+│   rm -rf node_modules && npm install                         │
+│   Reinstall dependencies                                     │
+│                                                              │
+│ Do you want to proceed?                                      │
+│ ❯ 1. Yes                                                     │
+│   2. Yes, and don't ask again for rm and npm commands        │
+│   3. No, and tell Claude what to do differently (esc)        │
+╰──────────────────────────────────────────────────────────────╯

--- a/src/state/fixtures/codex-busy.title
+++ b/src/state/fixtures/codex-busy.title
@@ -1,0 +1,1 @@
+⠇ refactor auth module

--- a/src/state/fixtures/codex-busy.txt
+++ b/src/state/fixtures/codex-busy.txt
@@ -1,0 +1,5 @@
+• Working on refactoring the auth module
+
+  ⠧ Thinking (12s · esc to interrupt)
+
+  ctrl+c to quit

--- a/src/state/fixtures/codex-permit.txt
+++ b/src/state/fixtures/codex-permit.txt
@@ -1,0 +1,8 @@
+• I need to run a command that touches files outside the workspace.
+
+  ▌ Allow command?
+  ▌   rm -rf /tmp/build-cache
+  ▌
+  ▌ press enter to confirm or esc to cancel
+
+  ctrl+c to quit

--- a/src/state/fixtures/opencode-busy.txt
+++ b/src/state/fixtures/opencode-busy.txt
@@ -1,0 +1,5 @@
+│ Analyzing the codebase structure
+
+■■■■■■⬝⬝⬝⬝⬝⬝
+
+working · esc to interrupt

--- a/src/state/fixtures/opencode-permit.txt
+++ b/src/state/fixtures/opencode-permit.txt
@@ -1,0 +1,7 @@
+│  Write src/index.ts
+
+△ Permission required
+
+  Allow opencode to write to src/index.ts?
+
+  ↑↓ select · enter confirm · esc dismiss

--- a/src/state/scraper.test.ts
+++ b/src/state/scraper.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from 'bun:test';
-import { detectFromPaneContent, detectFromTitle } from './scraper.ts';
+import { capturePaneLinesVia, detectFromPaneContent, detectFromTitle } from './scraper.ts';
 import { CLAUDE_MANIFEST, CODEX_MANIFEST, OPENCODE_MANIFEST, PI_MANIFEST } from './detection.ts';
 import { AgentStatus } from './types.ts';
+import type { ControlReadClient } from '../tmux/control-adapter.ts';
 
 describe('detectFromPaneContent', () => {
   test('detects permission prompt [y/n]', () => {
@@ -111,5 +112,24 @@ describe('detectFromTitle', () => {
   test('manifests without titleRules never title-match', () => {
     expect(detectFromTitle('⠂ anything', PI_MANIFEST).status).toBeNull();
     expect(detectFromTitle('Action Required', OPENCODE_MANIFEST).status).toBeNull();
+  });
+});
+
+describe('capturePaneLinesVia', () => {
+  // SCRAPE_LINES is 50 — the bottom window the scraper evaluates.
+  test('returns the processed capture (same post-processing as the fork path)', async () => {
+    const fake: ControlReadClient = {
+      run: async () => '',
+      capturePane: async () => 'top\nmid   \nbottom\n\n',
+    };
+    expect(await capturePaneLinesVia(fake, '%1')).toEqual(['top', 'mid', 'bottom']);
+  });
+
+  test('propagates control errors so the TUI wrapper can flip the latch', async () => {
+    const fake: ControlReadClient = {
+      run: async () => '',
+      capturePane: async () => Promise.reject(new Error('dead')),
+    };
+    await expect(capturePaneLinesVia(fake, '%1')).rejects.toThrow('dead');
   });
 });

--- a/src/state/scraper.ts
+++ b/src/state/scraper.ts
@@ -1,5 +1,6 @@
 import { AgentStatus, type DetectResult } from './types.ts';
 import { capturePane } from '../tmux/sessions.ts';
+import { capturePaneVia, type ControlReadClient } from '../tmux/control-adapter.ts';
 import {
   CLAUDE_MANIFEST,
   getCompiledRegex,
@@ -73,6 +74,14 @@ export function capturePaneLines(paneId: string): string[] {
   } catch {
     return [];
   }
+}
+
+// Control-mode variant of capturePaneLines: same SCRAPE_LINES window and
+// empty-on-failure semantic for NON-control errors, but a TmuxControlError (or
+// any throw from the control client) propagates so the TUI's tick wrapper can
+// flip the control latch and fall back to the fork path for the whole batch.
+export async function capturePaneLinesVia(client: ControlReadClient, paneId: string): Promise<string[]> {
+  return await capturePaneVia(client, paneId, SCRAPE_LINES);
 }
 
 export function scrapePane(paneId: string, agent: string): AgentStatus | null {

--- a/src/state/segment-cache.test.ts
+++ b/src/state/segment-cache.test.ts
@@ -1,0 +1,107 @@
+import { afterAll, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, utimesSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { cacheFilePath, readFreshSegmentCache, writeSegmentCache } from './segment-cache.ts';
+
+// Isolate every test in its own TMPDIR + $TMUX so the cache path is unique per
+// test and never touches a real fleet cache. Restored in `after` so a leaked
+// env value can't bleed into the next test file.
+const prevTmpdir = process.env.TMPDIR;
+const prevTmux = process.env.TMUX;
+let workDir: string;
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'fleet-segment-cache-test-'));
+  process.env.TMPDIR = workDir;
+  process.env.TMUX = '/tmp/tmux-501/default,12345,0';
+});
+
+afterAll(() => {
+  if (workDir) rmSync(workDir, { recursive: true, force: true });
+  if (prevTmpdir === undefined) delete process.env.TMPDIR;
+  else process.env.TMPDIR = prevTmpdir;
+  if (prevTmux === undefined) delete process.env.TMUX;
+  else process.env.TMUX = prevTmux;
+});
+
+describe('cacheFilePath', () => {
+  test('embeds the uid and a sanitized tmux socket basename', () => {
+    process.env.TMUX = '/tmp/tmux-501/my-socket,12345,0';
+    const p = cacheFilePath();
+    expect(p).toContain(`fleet-statusline-${process.getuid!()}-my-socket.cache`);
+  });
+
+  test('falls back to "default" outside tmux', () => {
+    delete process.env.TMUX;
+    const p = cacheFilePath();
+    expect(p).toContain(`fleet-statusline-${process.getuid!()}-default.cache`);
+  });
+
+  test('strips non-filename characters from the socket field', () => {
+    process.env.TMUX = '/path with spaces/odd socket!,1,2';
+    const p = cacheFilePath();
+    // Only [A-Za-z0-9._-] survive the basename + sanitize pass.
+    expect(p).toMatch(/fleet-statusline-\d+-oddsocket\.cache$/);
+  });
+});
+
+describe('writeSegmentCache + readFreshSegmentCache', () => {
+  test('a fresh write is readable verbatim', () => {
+    const segment = '#[range=user|fleet-sidebar]#[fg=cyan] ☰ #[norange]';
+    writeSegmentCache(segment);
+    expect(readFreshSegmentCache()).toBe(segment);
+  });
+
+  test('write is atomic: the temp file is renamed into place (no partial file)', () => {
+    const segment = 'hello-statusline';
+    writeSegmentCache(segment);
+    // The cache file exists with the exact content; no stray temp remains.
+    expect(readFreshSegmentCache()).toBe(segment);
+    // An overwrite is also atomic and immediately readable.
+    writeSegmentCache('second');
+    expect(readFreshSegmentCache()).toBe('second');
+  });
+
+  test('returns null when the cache file is missing (fs errors safe)', () => {
+    expect(readFreshSegmentCache()).toBeNull();
+  });
+
+  test('returns null when the cache mtime is older than maxAgeSecs', () => {
+    writeSegmentCache('stale-segment');
+    // Push mtime 60s into the past — well beyond the 6s default.
+    const old = (Date.now() / 1000) - 60;
+    utimesSync(cacheFilePath(), old, old);
+    expect(readFreshSegmentCache()).toBeNull();
+    // A larger maxAgeSecs still considers it fresh.
+    expect(readFreshSegmentCache(120)).toBe('stale-segment');
+  });
+
+  test('treats the boundary as fresh: age == maxAgeSecs is NOT stale', () => {
+    writeSegmentCache('boundary');
+    const exactly = (Date.now() / 1000) - 6;
+    utimesSync(cacheFilePath(), exactly, exactly);
+    // ageSecs > maxAgeSecs is the gate, so age == 6 is still fresh.
+    expect(readFreshSegmentCache(6)).toBe('boundary');
+  });
+
+  test('writeSegmentCache never throws when the tmp dir is gone', () => {
+    // Point TMPDIR at a path that doesn't exist; writeFileSync will throw, but
+    // writeSegmentCache must swallow it (the cache is an optimization).
+    const saved = process.env.TMPDIR;
+    const ghost = join(workDir, 'does-not-exist');
+    process.env.TMPDIR = ghost;
+    try {
+      expect(() => writeSegmentCache('anything')).not.toThrow();
+      expect(readFreshSegmentCache()).toBeNull();
+    } finally {
+      process.env.TMPDIR = saved;
+    }
+  });
+
+  test('readFreshSegmentCache never throws on an unreadable/odd path', () => {
+    // Make the cache "file" be a directory → readFileSync throws EISDIR.
+    mkdirSync(cacheFilePath(), { recursive: true });
+    expect(readFreshSegmentCache()).toBeNull();
+  });
+});

--- a/src/state/segment-cache.test.ts
+++ b/src/state/segment-cache.test.ts
@@ -70,7 +70,7 @@ describe('writeSegmentCache + readFreshSegmentCache', () => {
   test('returns null when the cache mtime is older than maxAgeSecs', () => {
     writeSegmentCache('stale-segment');
     // Push mtime 60s into the past — well beyond the 6s default.
-    const old = (Date.now() / 1000) - 60;
+    const old = Date.now() / 1000 - 60;
     utimesSync(cacheFilePath(), old, old);
     expect(readFreshSegmentCache()).toBeNull();
     // A larger maxAgeSecs still considers it fresh.
@@ -79,7 +79,7 @@ describe('writeSegmentCache + readFreshSegmentCache', () => {
 
   test('treats the boundary as fresh: age == maxAgeSecs is NOT stale', () => {
     writeSegmentCache('boundary');
-    const exactly = (Date.now() / 1000) - 6;
+    const exactly = Date.now() / 1000 - 6;
     utimesSync(cacheFilePath(), exactly, exactly);
     // ageSecs > maxAgeSecs is the gate, so age == 6 is still fresh.
     expect(readFreshSegmentCache(6)).toBe('boundary');

--- a/src/state/segment-cache.ts
+++ b/src/state/segment-cache.ts
@@ -1,0 +1,65 @@
+import { tmpdir } from 'node:os';
+import { readFileSync, renameSync, statSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// tmux's `status-format[1]` runs `#(fleet status --statusline)` every
+// status-interval, and each invocation cold-boots Bun and recomputes the full
+// agent state — work the running TUI already does every FAST_REFRESH_MS. This
+// module is the cache the running process refreshes and the CLI reads: the CLI
+// serves the cached segment when fresh and only falls back to a live compute
+// when the cache is stale (TUI closed, machine slept, …).
+//
+// Reference pattern: tmux-agents-mon cmd_status serves from a cache file the
+// running process refreshes; live-compute only when the cache mtime is older
+// than a few seconds.
+
+// $TMUX is `<socket>,<pid>,<session-id>` (the first comma-field is the socket
+// path). We basename it so an absolute socket path doesn't leak filesystem
+// layout into the cache filename, strip anything that isn't filename-safe, and
+// fall back to 'default' outside tmux. Embedding the socket keeps caches from
+// two distinct tmux servers from colliding, and the uid keeps them from
+// colliding across users on a shared tmpdir.
+function tmuxSocketId(): string {
+  const tmux = process.env.TMUX;
+  if (!tmux || tmux.length === 0) return 'default';
+  const firstField = tmux.split(',')[0] ?? '';
+  if (firstField.length === 0) return 'default';
+  const base = firstField.split('/').pop() ?? '';
+  const sanitized = base.replace(/[^A-Za-z0-9._-]/g, '');
+  return sanitized.length > 0 ? sanitized : 'default';
+}
+
+export function cacheFilePath(): string {
+  const uid = typeof process.getuid === 'function' ? process.getuid() : 0;
+  return join(tmpdir(), `fleet-statusline-${uid}-${tmuxSocketId()}.cache`);
+}
+
+// Atomic write: write a temp file beside the target then rename. rename is
+// atomic on the same filesystem, so a concurrent reader never sees a partial
+// segment. Never throws — a cache write failure is non-fatal; the worst case is
+// the CLI falls back to a live compute on the next status-interval.
+export function writeSegmentCache(segment: string): void {
+  try {
+    const path = cacheFilePath();
+    const tmp = `${path}.${process.pid}.tmp`;
+    writeFileSync(tmp, segment);
+    renameSync(tmp, path);
+  } catch {
+    // Swallow: the cache is an optimization, not a correctness requirement.
+  }
+}
+
+// null on missing/stale/any fs error. maxAgeSecs bounds staleness: the running
+// TUI refreshes every 500ms, so 6s covers ~12 missed refreshes before the CLI
+// falls back to a live compute (TUI closed, machine slept, …). Never throws.
+export function readFreshSegmentCache(maxAgeSecs = 6): string | null {
+  try {
+    const path = cacheFilePath();
+    const st = statSync(path);
+    const ageSecs = (Date.now() - st.mtimeMs) / 1000;
+    if (ageSecs > maxAgeSecs) return null;
+    return readFileSync(path, 'utf8');
+  } catch {
+    return null;
+  }
+}

--- a/src/tmux/clients.test.ts
+++ b/src/tmux/clients.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from 'bun:test';
+import { parseClients } from './clients.ts';
+
+// Ports the three test cases from snirt/tmux-agents-mon's focus.rs. The
+// popup-discount case is intentionally omitted (that mechanism is not ported);
+// see the module doc comment.
+
+describe('parseClients — focus-events ON', () => {
+  test('requires the focused flag and ignores control-mode clients', () => {
+    const rows = [
+      '20\tclient-1\t$1\t%2\twork\tattached,focused,utf8',
+      '30\tclient-2\t$2\t%3\twork\tattached,utf8',
+      '40\tcontrol\t$3\t%4\tagents-mon\tattached,focused,control-mode,utf8',
+    ].join('\n');
+    const focus = parseClients(rows, true);
+
+    // client-1 is focused → %2 counts; client-2 lacks the focused flag → %3 does
+    // not; the control-mode client is dropped entirely. activePaneId follows the
+    // highest-activity *real* client (client-2 → %3), independent of focus.
+    expect(focus.focusedPanes).toEqual(new Set(['%2']));
+    expect(focus.activePaneId).toBe('%3');
+  });
+});
+
+describe('parseClients — focus-events OFF', () => {
+  test('treats every selected real-client pane as focused', () => {
+    const rows = [
+      '20\tclient-1\t$1\t%2\twork\tattached,utf8',
+      '30\tclient-2\t$2\t%3\tagents-mon\tattached,utf8',
+    ].join('\n');
+    const focus = parseClients(rows, false);
+
+    expect(focus.focusedPanes).toEqual(new Set(['%2', '%3']));
+    expect(focus.activePaneId).toBe('%3');
+  });
+});
+
+describe('parseClients — activity / activePaneId', () => {
+  test('activePaneId is the highest-activity real client pane', () => {
+    const rows = [
+      '5\tclient-1\t$1\t%2\twork\tattached,focused,utf8',
+      '99\tclient-2\t$2\t%3\twork\tattached,focused,utf8',
+      '50\tcontrol\t$3\t%4\tagents-mon\tattached,focused,control-mode,utf8',
+    ].join('\n');
+    const focus = parseClients(rows, true);
+
+    expect(focus.activePaneId).toBe('%3'); // client-2 has the max activity (99)
+    // control client dropped from focus even though it was focused+flagged.
+    expect(focus.focusedPanes).toEqual(new Set(['%2', '%3']));
+  });
+});
+
+describe('parseClients — robustness', () => {
+  test('skips malformed rows and empty input yields an empty result', () => {
+    const rows = [
+      'notanumber\tclient-1\t$1\t%2\twork\tattached,utf8', // non-numeric activity
+      '20\tonly\tthree\tfields', // too few fields
+      '', // blank line
+    ].join('\n');
+    const focus = parseClients(rows, true);
+    expect(focus.focusedPanes).toEqual(new Set());
+    expect(focus.activePaneId).toBe(null);
+  });
+
+  test('splits into at most 6 fields so a tab in the title does not corrupt flags', () => {
+    // A title containing a tab must not shift the flags column.
+    const rows = ['20\tclient-1\t$1\t%2\tleft\tright\tattached,focused,utf8'].join('\n');
+    const focus = parseClients(rows, true);
+    expect(focus.focusedPanes).toEqual(new Set(['%2']));
+    expect(focus.activePaneId).toBe('%2');
+  });
+});

--- a/src/tmux/clients.test.ts
+++ b/src/tmux/clients.test.ts
@@ -24,10 +24,9 @@ describe('parseClients — focus-events ON', () => {
 
 describe('parseClients — focus-events OFF', () => {
   test('treats every selected real-client pane as focused', () => {
-    const rows = [
-      '20\tclient-1\t$1\t%2\twork\tattached,utf8',
-      '30\tclient-2\t$2\t%3\tagents-mon\tattached,utf8',
-    ].join('\n');
+    const rows = ['20\tclient-1\t$1\t%2\twork\tattached,utf8', '30\tclient-2\t$2\t%3\tagents-mon\tattached,utf8'].join(
+      '\n',
+    );
     const focus = parseClients(rows, false);
 
     expect(focus.focusedPanes).toEqual(new Set(['%2', '%3']));

--- a/src/tmux/clients.ts
+++ b/src/tmux/clients.ts
@@ -1,0 +1,81 @@
+import { getTmuxOption, tmuxOrNull } from './ipc.ts';
+
+// Multi-client focus model for notification suppression, ported from
+// snirt/tmux-agents-mon's focus.rs. A pane counts as "focused" only when a
+// real (non-control-mode) tmux client is viewing it AND, with focus-events on,
+// that client carries the `focused` flag. With focus-events off we fall back to
+// treating every real client's selected pane as focused (tmux can't tell us
+// which client truly has keyboard focus).
+//
+// The popup-discount mechanism from the reference is intentionally NOT ported
+// here; fleet has no popup today. If one is added, port `discount_client` so a
+// popup owning one client's input doesn't suppress a second client viewing the
+// same pane. (Future work.)
+
+export interface ClientFocus {
+  focusedPanes: Set<string>;
+  activePaneId: string | null;
+}
+
+// Pure parser: turns the tab-separated `tmux list-clients -F` output into the
+// focus set + highest-activity pane. Splitting into at most 6 fields keeps tabs
+// embedded in a pane title from corrupting the flags column. Malformed rows
+// (missing fields or non-numeric activity) and control-mode clients are
+// skipped — control clients never own focus.
+export function parseClients(rows: string, focusEvents: boolean): ClientFocus {
+  interface Row {
+    activity: number;
+    pane: string;
+    focused: boolean;
+  }
+  const parsed: Row[] = [];
+
+  for (const line of rows.split('\n')) {
+    if (line.length === 0) continue;
+    // Split into at most 6 fields with the 6th being the *remainder* after the
+    // 5th tab (matches Rust splitn, so a tab inside the title/flags can't shift
+    // the flags column out of reach). flag matching is comma-based so extra tab
+    // text folded into flags still yields a clean flag set.
+    const parts = line.split('\t');
+    if (parts.length < 6) continue;
+    const activityStr = parts[0]!;
+    const pane = parts[3]!;
+    const flags = parts.slice(5).join('\t');
+    const activity = Number(activityStr);
+    if (!Number.isFinite(activity)) continue; // NaN/empty activity — malformed
+    const flagList = flags.split(',');
+    if (flagList.includes('control-mode')) continue;
+    parsed.push({ activity, pane, focused: flagList.includes('focused') });
+  }
+
+  const focusedPanes = new Set<string>();
+  for (const row of parsed) {
+    if (!focusEvents || row.focused) focusedPanes.add(row.pane);
+  }
+
+  let activePaneId: string | null = null;
+  let maxActivity = -Infinity;
+  for (const row of parsed) {
+    if (row.activity > maxActivity) {
+      maxActivity = row.activity;
+      activePaneId = row.pane;
+    }
+  }
+
+  return { focusedPanes, activePaneId };
+}
+
+// Live read: runs `tmux list-clients` and reads the global focus-events option.
+// Any tmux failure (no server, spawn error) collapses to an empty focus set and
+// a null active pane — callers then suppress nothing, preferring a redundant
+// toast over a missed one.
+export function readClientFocus(): ClientFocus {
+  const out = tmuxOrNull([
+    'list-clients',
+    '-F',
+    '#{client_activity}\t#{client_name}\t#{session_id}\t#{pane_id}\t#{pane_title}\t#{client_flags}',
+  ]);
+  if (out === null) return { focusedPanes: new Set(), activePaneId: null };
+  const focusEvents = getTmuxOption('focus-events') === 'on';
+  return parseClients(out, focusEvents);
+}

--- a/src/tmux/control-adapter.test.ts
+++ b/src/tmux/control-adapter.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from 'bun:test';
+import { capturePaneVia, listPanesResultVia, type ControlReadClient } from './control-adapter.ts';
+import { listPanesCommand } from './sessions.ts';
+
+// A minimal in-process stub of the control client's read surface — never
+// spawns tmux. Records the commands it was asked to run so the adapters' wire
+// format (quoting, command string) is unit-testable without a real server.
+function fakeClient(opts: {
+  run?: (cmd: string) => Promise<string>;
+  capturePane?: (paneId: string) => Promise<string>;
+}): ControlReadClient & { runCalls: string[]; captureCalls: string[] } {
+  const runCalls: string[] = [];
+  const captureCalls: string[] = [];
+  return {
+    runCalls,
+    captureCalls,
+    run: (cmd: string) => {
+      runCalls.push(cmd);
+      return opts.run ? opts.run(cmd) : Promise.resolve('');
+    },
+    capturePane: (paneId: string) => {
+      captureCalls.push(paneId);
+      return opts.capturePane ? opts.capturePane(paneId) : Promise.resolve('');
+    },
+  };
+}
+
+describe('listPanesResultVia', () => {
+  test('runs listPanesCommand (single-quoted format) and parses the body identically to the fork path', async () => {
+    const line = ['%3', 's', 'w', '@5', '2', '/p', '123', '1', '1', '1', 't'].join('\t');
+    const client = fakeClient({ run: async () => line });
+    const res = await listPanesResultVia(client);
+    expect(res.ok).toBe(true);
+    expect(res.panes).toHaveLength(1);
+    expect(res.panes[0]!.paneId).toBe('%3');
+    expect(res.panes[0]!.windowId).toBe('@5');
+    expect(res.panes[0]!.focused).toBe(true);
+    // The exact command string from sessions.ts is sent verbatim — no
+    // re-derivation, so the fork and control paths share one format source.
+    expect(client.runCalls).toEqual([listPanesCommand()]);
+  });
+
+  test('an empty body yields ok:true with no panes', async () => {
+    const client = fakeClient({ run: async () => '' });
+    const res = await listPanesResultVia(client);
+    expect(res).toEqual({ ok: true, panes: [] });
+  });
+
+  test('propagates run() rejections (the TUI wrapper flips the latch on throw)', async () => {
+    const client = fakeClient({ run: async () => Promise.reject(new Error('boom')) });
+    await expect(listPanesResultVia(client)).rejects.toThrow('boom');
+  });
+});
+
+describe('capturePaneVia', () => {
+  test('calls client.capturePane and applies the shared line post-processing', async () => {
+    const client = fakeClient({ capturePane: async () => 'line one   \nline two\n\n\n' });
+    const lines = await capturePaneVia(client, '%7', 50);
+    expect(lines).toEqual(['line one', 'line two']);
+    expect(client.captureCalls).toEqual(['%7']);
+  });
+
+  test('respects maxLines (bottom window)', async () => {
+    const client = fakeClient({ capturePane: async () => '1\n2\n3\n4\n5' });
+    expect(await capturePaneVia(client, '%1', 2)).toEqual(['4', '5']);
+  });
+
+  test('propagates capturePane() rejections', async () => {
+    const client = fakeClient({ capturePane: async () => Promise.reject(new Error('dead')) });
+    await expect(capturePaneVia(client, '%1', 10)).rejects.toThrow('dead');
+  });
+});

--- a/src/tmux/control-adapter.ts
+++ b/src/tmux/control-adapter.ts
@@ -6,12 +6,7 @@
 // wrapper catches them and flips the control latch).
 
 import type { TmuxControlClient } from './control.ts';
-import {
-  listPanesCommand,
-  parsePanesOutput,
-  processCaptureOutput,
-  type ListPanesResult,
-} from './sessions.ts';
+import { listPanesCommand, parsePanesOutput, processCaptureOutput, type ListPanesResult } from './sessions.ts';
 
 /** The subset of TmuxControlClient the adapters need — also a stub seam. */
 export interface ControlReadClient {
@@ -35,11 +30,7 @@ export async function listPanesResultVia(client: ControlReadClient): Promise<Lis
  * TmuxControlClient.capturePane), then the same line post-processing the fork
  * path applies, so the scraper sees an identical line array.
  */
-export async function capturePaneVia(
-  client: ControlReadClient,
-  paneId: string,
-  maxLines: number,
-): Promise<string[]> {
+export async function capturePaneVia(client: ControlReadClient, paneId: string, maxLines: number): Promise<string[]> {
   const output = await client.capturePane(paneId);
   return processCaptureOutput(output, maxLines);
 }

--- a/src/tmux/control-adapter.ts
+++ b/src/tmux/control-adapter.ts
@@ -1,0 +1,48 @@
+// Async adapters that route the TUI's list-panes + per-pane capture reads
+// through a long-lived TmuxControlClient instead of one fork per command.
+// They reuse sessions.ts's format string, row parser, and capture output
+// post-processing so pane data shapes are byte-identical to the fork path —
+// the only difference is the transport. Errors propagate (the TUI's tick
+// wrapper catches them and flips the control latch).
+
+import type { TmuxControlClient } from './control.ts';
+import {
+  listPanesCommand,
+  parsePanesOutput,
+  processCaptureOutput,
+  type ListPanesResult,
+} from './sessions.ts';
+
+/** The subset of TmuxControlClient the adapters need — also a stub seam. */
+export interface ControlReadClient {
+  run(cmd: string): Promise<string>;
+  capturePane(paneId: string): Promise<string>;
+}
+
+/**
+ * list-panes via control mode. Runs the SAME format string sessions.ts uses
+ * (listPanesCommand) and parses with parsePanesOutput, so PaneInfo shapes are
+ * identical to the fork path. Throws on %error / exit / death — the caller
+ * flips the control latch and falls back to the fork path for the batch.
+ */
+export async function listPanesResultVia(client: ControlReadClient): Promise<ListPanesResult> {
+  const stdout = await client.run(listPanesCommand());
+  return { ok: true, panes: parsePanesOutput(stdout) };
+}
+
+/**
+ * capture-pane via control mode (the buffer + save-buffer dance in
+ * TmuxControlClient.capturePane), then the same line post-processing the fork
+ * path applies, so the scraper sees an identical line array.
+ */
+export async function capturePaneVia(
+  client: ControlReadClient,
+  paneId: string,
+  maxLines: number,
+): Promise<string[]> {
+  const output = await client.capturePane(paneId);
+  return processCaptureOutput(output, maxLines);
+}
+
+// Exported so callers can pass a typed null without importing the class.
+export type { TmuxControlClient };

--- a/src/tmux/control-protocol.test.ts
+++ b/src/tmux/control-protocol.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test } from 'bun:test';
+import { ControlProtocol } from './control-protocol.ts';
+
+function feedAll(protocol: ControlProtocol, chunks: string[]): ReturnType<ControlProtocol['feed']> {
+  let events: ReturnType<ControlProtocol['feed']> = [];
+  for (const c of chunks) events = events.concat(protocol.feed(c));
+  return events;
+}
+
+function blockEvents(events: ReturnType<ControlProtocol['feed']>) {
+  return events.filter((e) => e.kind === 'block');
+}
+
+describe('ControlProtocol greeting', () => {
+  test('consumes an unsolicited %begin/%end block as one block event', () => {
+    const p = new ControlProtocol();
+    const ev = p.feed('%begin 1700000000 0 flags\n%end 1700000000 0 flags\n');
+    expect(ev).toHaveLength(1);
+    expect(ev[0]).toMatchObject({ kind: 'block', tag: '0', body: '', isError: false });
+  });
+});
+
+describe('ControlProtocol tag-matched termination', () => {
+  test('a matching %end tag closes the block', () => {
+    const p = new ControlProtocol();
+    const ev = p.feed(
+      '%begin 1 7 f\nline one\nline two\n%end 1 7 f\n',
+    );
+    expect(ev).toHaveLength(1);
+    const b = ev[0]!;
+    expect(b.kind).toBe('block');
+    if (b.kind !== 'block') throw new Error('unreachable');
+    expect(b.tag).toBe('7');
+    expect(b.body).toBe('line one\nline two');
+    expect(b.isError).toBe(false);
+  });
+
+  test('a %end with a mismatched tag is body content, not a terminator', () => {
+    const p = new ControlProtocol();
+    const ev = p.feed(
+      '%begin 1 7 f\n%end 1 999 f\nreal end\n%end 1 7 f\n',
+    );
+    const blocks = blockEvents(ev);
+    expect(blocks).toHaveLength(1);
+    const b = blocks[0]!;
+    if (b.kind !== 'block') throw new Error('unreachable');
+    expect(b.body).toBe('%end 1 999 f\nreal end');
+  });
+
+  test('a %error with matching tag surfaces isError=true', () => {
+    const p = new ControlProtocol();
+    const ev = p.feed('%begin 1 3 f\nboom\n%error 1 3 f\n');
+    expect(ev).toHaveLength(1);
+    const b = ev[0]!;
+    if (b.kind !== 'block') throw new Error('unreachable');
+    expect(b.isError).toBe(true);
+    expect(b.body).toBe('boom');
+    expect(b.tag).toBe('3');
+  });
+
+  test('a %error with mismatched tag is body content', () => {
+    const p = new ControlProtocol();
+    const ev = p.feed('%begin 1 3 f\n%error 1 8 f\n%error 1 3 f\n');
+    const blocks = blockEvents(ev);
+    expect(blocks).toHaveLength(1);
+    const b = blocks[0]!;
+    if (b.kind !== 'block') throw new Error('unreachable');
+    expect(b.isError).toBe(true);
+    expect(b.body).toBe('%error 1 8 f');
+  });
+});
+
+describe('ControlProtocol %exit', () => {
+  test('emits an exit event', () => {
+    const p = new ControlProtocol();
+    const ev = p.feed('%exit\n');
+    expect(ev).toHaveLength(1);
+    expect(ev[0]).toMatchObject({ kind: 'exit' });
+  });
+
+  test('%exit with trailing detail still exits', () => {
+    const p = new ControlProtocol();
+    const ev = p.feed('%exit server gone\n');
+    expect(ev[0]).toMatchObject({ kind: 'exit' });
+  });
+});
+
+describe('ControlProtocol chunk splitting', () => {
+  test('chunks split mid-line reassemble correctly', () => {
+    const p = new ControlProtocol();
+    const ev = feedAll(p, [
+      '%beg',
+      'in 1 2 f\nhel',
+      'lo\n%end 1 2 ',
+      'f\n',
+    ]);
+    const blocks = blockEvents(ev);
+    expect(blocks).toHaveLength(1);
+    const b = blocks[0]!;
+    if (b.kind !== 'block') throw new Error('unreachable');
+    expect(b.body).toBe('hello');
+    expect(b.tag).toBe('2');
+  });
+
+  test('chunks split mid-%end do not terminate early', () => {
+    const p = new ControlProtocol();
+    const ev = feedAll(p, [
+      '%begin 1 5 f\nbody\n%en',
+      'd 1 999 f\n%end 1 5 f\n',
+    ]);
+    const blocks = blockEvents(ev);
+    expect(blocks).toHaveLength(1);
+    const b = blocks[0]!;
+    if (b.kind !== 'block') throw new Error('unreachable');
+    expect(b.body).toBe('body\n%end 1 999 f');
+  });
+
+  test('CRLF line endings are handled like LF', () => {
+    const p = new ControlProtocol();
+    const ev = p.feed('%begin 1 4 f\r\nhi\r\n%end 1 4 f\r\n');
+    const b = blockEvents(ev)[0]!;
+    if (b.kind !== 'block') throw new Error('unreachable');
+    expect(b.body).toBe('hi');
+  });
+
+  test('a partial line with no newline is buffered across feeds', () => {
+    const p = new ControlProtocol();
+    expect(p.feed('no newline yet')).toEqual([]);
+    const ev = p.feed(' continued\n%begin 1 1 f\nok\n%end 1 1 f\n');
+    // first complete line is a notification (non-wake), then a block.
+    expect(ev[0]).toMatchObject({ kind: 'notification', line: 'no newline yet continued' });
+    expect(ev[1]).toMatchObject({ kind: 'block', tag: '1' });
+  });
+});
+
+describe('ControlProtocol wake classification', () => {
+  const wake = [
+    '%window-pane-changed @1 %3',
+    '%session-window-changed $1 @1',
+    '%session-changed $1 foo',
+    '%client-session-changed $1 foo',
+    '%layout-change @1 %3 5d2e 80x24 0,0,80',
+  ];
+  for (const line of wake) {
+    test(`wake: ${line.split(' ')[0]}`, () => {
+      const p = new ControlProtocol();
+      const ev = p.feed(`${line}\n`);
+      expect(ev).toHaveLength(1);
+      expect(ev[0]).toMatchObject({ kind: 'wake', reason: line });
+    });
+  }
+
+  const ignored = [
+    '%output %3 hello',
+    '%pane-mode-changed @1',
+    '%window-add @2',
+    '%unlinked-window-close @3',
+    '%client-detached dev',
+    '%extension tmux-pipe',
+  ];
+  for (const line of ignored) {
+    test(`ignored (notification): ${line.split(' ')[0]}`, () => {
+      const p = new ControlProtocol();
+      const ev = p.feed(`${line}\n`);
+      expect(ev).toHaveLength(1);
+      expect(ev[0]).toMatchObject({ kind: 'notification', line });
+    });
+  }
+});
+
+describe('ControlProtocol multiple blocks', () => {
+  test('two back-to-back blocks each terminate on their own tag', () => {
+    const p = new ControlProtocol();
+    const ev = p.feed(
+      '%begin 1 1 f\na\n%end 1 1 f\n%begin 1 2 f\nb\n%end 1 2 f\n',
+    );
+    const blocks = blockEvents(ev);
+    expect(blocks).toHaveLength(2);
+    expect((blocks[0] as { body: string }).body).toBe('a');
+    expect((blocks[1] as { body: string }).body).toBe('b');
+  });
+});

--- a/src/tmux/control-protocol.test.ts
+++ b/src/tmux/control-protocol.test.ts
@@ -23,9 +23,7 @@ describe('ControlProtocol greeting', () => {
 describe('ControlProtocol tag-matched termination', () => {
   test('a matching %end tag closes the block', () => {
     const p = new ControlProtocol();
-    const ev = p.feed(
-      '%begin 1 7 f\nline one\nline two\n%end 1 7 f\n',
-    );
+    const ev = p.feed('%begin 1 7 f\nline one\nline two\n%end 1 7 f\n');
     expect(ev).toHaveLength(1);
     const b = ev[0]!;
     expect(b.kind).toBe('block');
@@ -37,9 +35,7 @@ describe('ControlProtocol tag-matched termination', () => {
 
   test('a %end with a mismatched tag is body content, not a terminator', () => {
     const p = new ControlProtocol();
-    const ev = p.feed(
-      '%begin 1 7 f\n%end 1 999 f\nreal end\n%end 1 7 f\n',
-    );
+    const ev = p.feed('%begin 1 7 f\n%end 1 999 f\nreal end\n%end 1 7 f\n');
     const blocks = blockEvents(ev);
     expect(blocks).toHaveLength(1);
     const b = blocks[0]!;
@@ -88,12 +84,7 @@ describe('ControlProtocol %exit', () => {
 describe('ControlProtocol chunk splitting', () => {
   test('chunks split mid-line reassemble correctly', () => {
     const p = new ControlProtocol();
-    const ev = feedAll(p, [
-      '%beg',
-      'in 1 2 f\nhel',
-      'lo\n%end 1 2 ',
-      'f\n',
-    ]);
+    const ev = feedAll(p, ['%beg', 'in 1 2 f\nhel', 'lo\n%end 1 2 ', 'f\n']);
     const blocks = blockEvents(ev);
     expect(blocks).toHaveLength(1);
     const b = blocks[0]!;
@@ -104,10 +95,7 @@ describe('ControlProtocol chunk splitting', () => {
 
   test('chunks split mid-%end do not terminate early', () => {
     const p = new ControlProtocol();
-    const ev = feedAll(p, [
-      '%begin 1 5 f\nbody\n%en',
-      'd 1 999 f\n%end 1 5 f\n',
-    ]);
+    const ev = feedAll(p, ['%begin 1 5 f\nbody\n%en', 'd 1 999 f\n%end 1 5 f\n']);
     const blocks = blockEvents(ev);
     expect(blocks).toHaveLength(1);
     const b = blocks[0]!;
@@ -171,9 +159,7 @@ describe('ControlProtocol wake classification', () => {
 describe('ControlProtocol multiple blocks', () => {
   test('two back-to-back blocks each terminate on their own tag', () => {
     const p = new ControlProtocol();
-    const ev = p.feed(
-      '%begin 1 1 f\na\n%end 1 1 f\n%begin 1 2 f\nb\n%end 1 2 f\n',
-    );
+    const ev = p.feed('%begin 1 1 f\na\n%end 1 1 f\n%begin 1 2 f\nb\n%end 1 2 f\n');
     const blocks = blockEvents(ev);
     expect(blocks).toHaveLength(2);
     expect((blocks[0] as { body: string }).body).toBe('a');

--- a/src/tmux/control-protocol.ts
+++ b/src/tmux/control-protocol.ts
@@ -1,0 +1,128 @@
+// tmux control-mode framing: a PURE incremental state machine that turns a
+// byte stream into ProtocolEvents. No I/O, no timers — just feed(chunk) ->
+// events. Chunks may split anywhere (mid-line, mid-%end); CRLF and LF both
+// terminate lines. Ported from snirt/tmux-agents-mon src/tmux.rs read_block.
+//
+// tmux control-mode framing:
+//   %begin <time> <num> <flags>
+//   ...body lines...
+//   %end <time> <num> <flags>      (or %error <time> <num> <flags>)
+//
+// The <num> tag MUST match between %begin and %end/%error — a body line that
+// literally contains "%end <t> <wrongnum> <f>" (e.g. pane content echoed into
+// the pipe) must NOT terminate the block. Pane content is never piped here in
+// fleet (capturePane routes it through a buffer+file), but the guard is kept
+// for defense in depth.
+
+export type ProtocolEvent =
+  | { kind: 'block'; tag: string; body: string; isError: boolean }
+  | { kind: 'wake'; reason: string }
+  | { kind: 'exit' }
+  | { kind: 'notification'; line: string };
+
+// Notifications that signal a focus/layout change and should wake the poll
+// loop. Everything else outside a block is emitted as 'notification' but is
+// not actionable for fleet — consumers may freely ignore (drop) them.
+const WAKE_PREFIXES = [
+  '%window-pane-changed',
+  '%session-window-changed',
+  '%session-changed',
+  '%client-session-changed',
+  '%layout-change',
+] as const;
+
+function isWakeNotification(line: string): boolean {
+  for (const p of WAKE_PREFIXES) {
+    if (line.startsWith(p)) return true;
+  }
+  return false;
+}
+
+// "%begin <time> <num> <flags>" -> <num> (the second whitespace-delimited field).
+function blockTag(rest: string): string {
+  const parts = rest.split(/\s+/);
+  // index 0 is the time, index 1 is the num tag.
+  return parts[1] ?? '';
+}
+
+function tryBegin(line: string): string | null {
+  if (!line.startsWith('%begin ')) return null;
+  return blockTag(line.slice('%begin '.length));
+}
+
+// Returns 'end' | 'error' only when the terminator's tag matches the open
+// block's tag; a mismatched %end/%error is pane content, not a terminator.
+function tryTerminator(line: string, tag: string): 'end' | 'error' | null {
+  if (line.startsWith('%end ')) {
+    return blockTag(line.slice('%end '.length)) === tag ? 'end' : null;
+  }
+  if (line.startsWith('%error ')) {
+    return blockTag(line.slice('%error '.length)) === tag ? 'error' : null;
+  }
+  return null;
+}
+
+interface OpenBlock {
+  tag: string;
+  body: string[];
+}
+
+// Pure incremental protocol decoder. Maintains a line buffer across feed()
+// calls so chunks split mid-line are reassembled before processing.
+export class ControlProtocol {
+  private buf = '';
+  private open: OpenBlock | null = null;
+
+  feed(chunk: string): ProtocolEvent[] {
+    this.buf += chunk;
+    const events: ProtocolEvent[] = [];
+    let nl: number;
+    while ((nl = this.buf.indexOf('\n')) >= 0) {
+      const raw = this.buf.slice(0, nl);
+      this.buf = this.buf.slice(nl + 1);
+      // Strip a single trailing CR (CRLF -> LF normalization).
+      const line = raw.endsWith('\r') ? raw.slice(0, -1) : raw;
+      this.processLine(line, events);
+    }
+    return events;
+  }
+
+  private processLine(line: string, out: ProtocolEvent[]): void {
+    const open = this.open;
+    if (open !== null) {
+      const term = tryTerminator(line, open.tag);
+      if (term !== null) {
+        out.push({
+          kind: 'block',
+          tag: open.tag,
+          body: open.body.join('\n'),
+          isError: term === 'error',
+        });
+        this.open = null;
+        return;
+      }
+      // Any line inside the block — including a stray "%end <t> <wrong> <f>"
+      // or a "%begin ..." — is body content, collected verbatim.
+      open.body.push(line);
+      return;
+    }
+
+    // Outside a block.
+    const tag = tryBegin(line);
+    if (tag !== null) {
+      this.open = { tag, body: [] };
+      return;
+    }
+    if (line.startsWith('%exit')) {
+      out.push({ kind: 'exit' });
+      return;
+    }
+    if (isWakeNotification(line)) {
+      out.push({ kind: 'wake', reason: line });
+      return;
+    }
+    // Non-wake notification: emitted for completeness, but fleet does not
+    // act on it. Consumers may drop these without consequence.
+    out.push({ kind: 'notification', line });
+  }
+}

--- a/src/tmux/control-router.test.ts
+++ b/src/tmux/control-router.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  flipControlDead,
+  selectReadPath,
+  shouldAttemptControl,
+  type ControlLatch,
+} from './control-router.ts';
+
+describe('selectReadPath', () => {
+  test('control only when enabled + connected + not dead', () => {
+    expect(selectReadPath({ enabled: true, connected: true, dead: false })).toBe('control');
+  });
+
+  test('fork when disabled', () => {
+    expect(selectReadPath({ enabled: false, connected: true, dead: false })).toBe('fork');
+  });
+
+  test('fork when not connected', () => {
+    expect(selectReadPath({ enabled: true, connected: false, dead: false })).toBe('fork');
+  });
+
+  test('fork when dead (permanent fallback — never retries)', () => {
+    expect(selectReadPath({ enabled: true, connected: true, dead: true })).toBe('fork');
+  });
+
+  test('dead wins over connected (latch is sticky)', () => {
+    expect(selectReadPath({ enabled: false, connected: true, dead: true })).toBe('fork');
+  });
+});
+
+describe('shouldAttemptControl', () => {
+  test('true when $TMUX set and FLEET_CONTROL_MODE is not "0"', () => {
+    expect(shouldAttemptControl({ TMUX: '/tmp/x,1,2' })).toBe(true);
+    expect(shouldAttemptControl({ TMUX: '/tmp/x,1,2', FLEET_CONTROL_MODE: '1' })).toBe(true);
+  });
+
+  test('false when FLEET_CONTROL_MODE === "0" (explicit opt-out)', () => {
+    expect(shouldAttemptControl({ TMUX: '/tmp/x,1,2', FLEET_CONTROL_MODE: '0' })).toBe(false);
+  });
+
+  test('false outside tmux (no $TMUX)', () => {
+    expect(shouldAttemptControl({})).toBe(false);
+  });
+
+  test('false when $TMUX is empty', () => {
+    expect(shouldAttemptControl({ TMUX: '' })).toBe(false);
+  });
+
+  test('false when $TMUX is undefined', () => {
+    expect(shouldAttemptControl({ TMUX: undefined })).toBe(false);
+  });
+});
+
+describe('flipControlDead', () => {
+  test('flips a live latch to dead', () => {
+    const latch: ControlLatch = { dead: false };
+    flipControlDead(latch);
+    expect(latch.dead).toBe(true);
+  });
+
+  test('idempotent — flipping a dead latch stays dead', () => {
+    const latch: ControlLatch = { dead: true };
+    flipControlDead(latch);
+    expect(latch.dead).toBe(true);
+  });
+
+  test('mutates the same object (no replacement)', () => {
+    const latch: ControlLatch = { dead: false };
+    flipControlDead(latch);
+    // The caller keeps the reference; the latch is not swapped out from under it.
+    expect(latch).toEqual({ dead: true });
+  });
+});

--- a/src/tmux/control-router.test.ts
+++ b/src/tmux/control-router.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import {
-  flipControlDead,
-  selectReadPath,
-  shouldAttemptControl,
-  type ControlLatch,
-} from './control-router.ts';
+import { flipControlDead, selectReadPath, shouldAttemptControl, type ControlLatch } from './control-router.ts';
 
 describe('selectReadPath', () => {
   test('control only when enabled + connected + not dead', () => {

--- a/src/tmux/control-router.ts
+++ b/src/tmux/control-router.ts
@@ -1,0 +1,44 @@
+// Pure decision logic for the TUI's optional control-mode fast path. The
+// TUI owns the latch (a ControlLatch object) and the live TmuxControlClient;
+// this module only answers "should this tick read via control or fork?" and
+// "an error happened — flip the latch?". No I/O, no imports of the client —
+// fully unit-testable.
+//
+// Semantics (see the integration sketch at the bottom of control.ts):
+//   - Opt-in: enabled only when $TMUX is set and FLEET_CONTROL_MODE !== '0'.
+//     TUI-only is structural — launchTui is the sole caller.
+//   - Permanent fallback: the moment a control read throws, the latch flips
+//     to dead for the rest of the session. selectReadPath() then returns
+//     'fork' forever; the caller close()s the client and never retries.
+
+export interface ControlLatch {
+  dead: boolean;
+}
+
+export interface ControlModeState {
+  /** $TMUX set and FLEET_CONTROL_MODE !== '0' (computed once at startup). */
+  enabled: boolean;
+  /** A control client connected successfully and is still referenced. */
+  connected: boolean;
+  /** The latch has been flipped by a prior error — never retries. */
+  dead: boolean;
+}
+
+export type ReadPath = 'control' | 'fork';
+
+/** control iff enabled + connected + not dead; otherwise fork. */
+export function selectReadPath(s: ControlModeState): ReadPath {
+  return s.enabled && s.connected && !s.dead ? 'control' : 'fork';
+}
+
+/** True when the TUI should attempt a control-mode connection. */
+export function shouldAttemptControl(env: Record<string, string | undefined>): boolean {
+  if (env.FLEET_CONTROL_MODE === '0') return false;
+  const tmux = env.TMUX;
+  return typeof tmux === 'string' && tmux.length > 0;
+}
+
+/** Flip the latch to dead (permanent for the session). Idempotent. */
+export function flipControlDead(latch: ControlLatch): void {
+  latch.dead = true;
+}

--- a/src/tmux/control.test.ts
+++ b/src/tmux/control.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  attachArgs,
+  captureCommands,
+  childEnv,
+  drainUntilMarker,
+  nextSyncMarker,
+  TmuxControlError,
+} from './control.ts';
+
+describe('attachArgs', () => {
+  test('no $TMUX: plain -C attach-session -f no-output', () => {
+    expect(attachArgs(undefined)).toEqual([
+      'tmux',
+      '-C',
+      'attach-session',
+      '-f',
+      'no-output',
+    ]);
+  });
+
+  test('with $TMUX: first comma-field becomes -S socket', () => {
+    expect(attachArgs('/tmp/tmux-1000/default,12345,3')).toEqual([
+      'tmux',
+      '-S',
+      '/tmp/tmux-1000/default',
+      '-C',
+      'attach-session',
+      '-f',
+      'no-output',
+    ]);
+  });
+
+  test('empty socket field is skipped (no -S "")', () => {
+    expect(attachArgs(',12345,3')).toEqual([
+      'tmux',
+      '-C',
+      'attach-session',
+      '-f',
+      'no-output',
+    ]);
+  });
+});
+
+describe('childEnv', () => {
+  test('removes TMUX, keeps everything else', () => {
+    const out = childEnv({
+      PATH: '/usr/bin',
+      TMUX: '/tmp/x,1,2',
+      HOME: '/home/me',
+      EMPTY: undefined,
+    });
+    expect(out.TMUX).toBeUndefined();
+    expect(out.PATH).toBe('/usr/bin');
+    expect(out.HOME).toBe('/home/me');
+    expect('EMPTY' in out).toBe(false);
+  });
+});
+
+describe('nextSyncMarker', () => {
+  test('is unique and monotonically tagged', () => {
+    const a = nextSyncMarker();
+    const b = nextSyncMarker();
+    expect(a).toMatch(/^fleet-sync-\d+-\d+$/);
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('captureCommands', () => {
+  test('orders capture -> save -> delete with the shared buffer and temp file', () => {
+    const [cap, save, del] = captureCommands('fleet-42', '%5', '/tmp/fleet-capture-42');
+    expect(cap).toBe('capture-pane -b fleet-42 -t %5');
+    expect(save).toBe('save-buffer -b fleet-42 /tmp/fleet-capture-42');
+    expect(del).toBe('delete-buffer -b fleet-42');
+  });
+});
+
+describe('drainUntilMarker (sync discard behavior)', () => {
+  test('discards stale blocks until the marker body comes back', async () => {
+    const bodies = ['stale-hook-output', 'another-stale', 'fleet-sync-1-1'];
+    let i = 0;
+    await drainUntilMarker(async () => bodies[i++]!, 'fleet-sync-1-1');
+    expect(i).toBe(3);
+  });
+
+  test('resolves immediately when the first block is the marker', async () => {
+    let calls = 0;
+    await drainUntilMarker(async () => {
+      calls++;
+      return 'fleet-sync-2-1';
+    }, 'fleet-sync-2-1');
+    expect(calls).toBe(1);
+  });
+
+  test('body must match the marker EXACTLY (no trailing newline slip)', async () => {
+    // A body with extra whitespace is NOT the marker — keep draining.
+    const bodies = ['fleet-sync-3-1\n', 'fleet-sync-3-1'];
+    let i = 0;
+    await drainUntilMarker(async () => bodies[i++]!, 'fleet-sync-3-1');
+    expect(i).toBe(2);
+  });
+});
+
+describe('TmuxControlError', () => {
+  test('carries a kind discriminator', () => {
+    const e = new TmuxControlError('boom', 'error');
+    expect(e.message).toBe('boom');
+    expect(e.kind).toBe('error');
+    expect(e.name).toBe('TmuxControlError');
+    expect(e).toBeInstanceOf(Error);
+  });
+});

--- a/src/tmux/control.test.ts
+++ b/src/tmux/control.test.ts
@@ -10,13 +10,7 @@ import {
 
 describe('attachArgs', () => {
   test('no $TMUX: plain -C attach-session -f no-output', () => {
-    expect(attachArgs(undefined)).toEqual([
-      'tmux',
-      '-C',
-      'attach-session',
-      '-f',
-      'no-output',
-    ]);
+    expect(attachArgs(undefined)).toEqual(['tmux', '-C', 'attach-session', '-f', 'no-output']);
   });
 
   test('with $TMUX: first comma-field becomes -S socket', () => {
@@ -32,13 +26,7 @@ describe('attachArgs', () => {
   });
 
   test('empty socket field is skipped (no -S "")', () => {
-    expect(attachArgs(',12345,3')).toEqual([
-      'tmux',
-      '-C',
-      'attach-session',
-      '-f',
-      'no-output',
-    ]);
+    expect(attachArgs(',12345,3')).toEqual(['tmux', '-C', 'attach-session', '-f', 'no-output']);
   });
 });
 

--- a/src/tmux/control.ts
+++ b/src/tmux/control.ts
@@ -140,9 +140,7 @@ export class TmuxControlClient {
    */
   sync(): Promise<void> {
     const marker = nextSyncMarker();
-    return this.serialize(() =>
-      drainUntilMarker(() => this.runSerialized(`display-message -p ${marker}`), marker),
-    );
+    return this.serialize(() => drainUntilMarker(() => this.runSerialized(`display-message -p ${marker}`), marker));
   }
 
   /**

--- a/src/tmux/control.ts
+++ b/src/tmux/control.ts
@@ -1,0 +1,324 @@
+// Persistent tmux control-mode client. One long-lived `tmux -C attach-session`
+// child replaces one fork per command. Ported from snirt/tmux-agents-mon
+// src/tmux.rs; pane content is never piped (capturePane uses buffer+file).
+//
+// This module is NEW FILES ONLY — it is not yet wired into the TUI loop. See
+// the integration sketch at the bottom of this file.
+
+import { unlink } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { ControlProtocol, type ProtocolEvent } from './control-protocol.ts';
+
+/** Typed error raised on %error blocks, %exit, or child death. */
+export class TmuxControlError extends Error {
+  override readonly name = 'TmuxControlError';
+  readonly kind: 'error' | 'exit' | 'dead';
+  constructor(message: string, kind: 'error' | 'exit' | 'dead') {
+    super(message);
+    this.kind = kind;
+  }
+}
+
+/**
+ * Build the argv for `tmux -C attach-session -f no-output`. When $TMUX is set
+ * ("socket_path,pid,session") the first comma-field is passed as `-S <socket>`
+ * so we stay on the pane's server; the var itself is stripped from the child
+ * env (see childEnv) — a control client is not a nested session.
+ */
+export function attachArgs(tmuxEnv: string | undefined): string[] {
+  const args = ['tmux'];
+  if (tmuxEnv) {
+    const sock = tmuxEnv.split(',')[0];
+    if (sock) args.push('-S', sock);
+  }
+  args.push('-C', 'attach-session', '-f', 'no-output');
+  return args;
+}
+
+/** Copy `env` without TMUX (a control client must not look nested). */
+export function childEnv(env: Record<string, string | undefined>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(env)) {
+    if (k === 'TMUX') continue;
+    if (v !== undefined) out[k] = v;
+  }
+  return out;
+}
+
+let syncCounter = 0;
+/** Unique marker for the self-healing sync() barrier. */
+export function nextSyncMarker(): string {
+  return `fleet-sync-${process.pid}-${++syncCounter}`;
+}
+
+/** The three capturePane tmux commands, in order, using buffer `buf` + file. */
+export function captureCommands(buf: string, paneId: string, tempFile: string): readonly [string, string, string] {
+  return [
+    `capture-pane -b ${buf} -t ${paneId}`,
+    `save-buffer -b ${buf} ${tempFile}`,
+    `delete-buffer -b ${buf}`,
+  ] as const;
+}
+
+/** Drive `nextBlock()` until a body exactly equal to `marker` comes back. */
+export async function drainUntilMarker(nextBlock: () => Promise<string>, marker: string): Promise<void> {
+  while (true) {
+    const body = await nextBlock();
+    if (body === marker) return;
+    // stale/unsolicited block — discard and keep reading.
+  }
+}
+
+export interface TmuxControlClientOptions {
+  /** Invoked (debounced) when a wake-worthy notification arrives. */
+  onWake?: () => void;
+  /** Debounce window for onWake. Default 100ms. */
+  wakeDebounceMs?: number;
+}
+
+interface PendingSlot {
+  resolve: (body: string) => void;
+  reject: (err: unknown) => void;
+}
+
+export class TmuxControlClient {
+  private proc: Bun.Subprocess<'pipe', 'pipe', 'ignore'> | null = null;
+  private readonly protocol = new ControlProtocol();
+  private readonly queue: PendingSlot[] = [];
+  private dead = false;
+  /** Serializes run()/sync()/capturePane() so each command pairs with its block. */
+  private chain: Promise<unknown> = Promise.resolve();
+
+  private readonly onWake?: () => void;
+  private readonly wakeDebounceMs: number;
+  private wakeTimer: ReturnType<typeof setTimeout> | null = null;
+
+  private readonly bufferName: string;
+  private readonly tempFile: string;
+
+  constructor(opts: TmuxControlClientOptions = {}) {
+    this.onWake = opts.onWake;
+    this.wakeDebounceMs = opts.wakeDebounceMs ?? 100;
+    this.bufferName = `fleet-${process.pid}`;
+    this.tempFile = `${tmpdir()}/fleet-capture-${process.pid}`;
+  }
+
+  /** Spawn the control client, consume the greeting block, run a sync probe. */
+  async connect(): Promise<void> {
+    const args = attachArgs(process.env.TMUX);
+    const env = childEnv(process.env as Record<string, string | undefined>);
+    const proc = Bun.spawn({
+      cmd: args,
+      stdin: 'pipe',
+      stdout: 'pipe',
+      stderr: 'ignore',
+      env,
+    });
+    this.proc = proc;
+
+    this.startReader();
+    // attach emits an unsolicited %begin/%end greeting — consume it so the
+    // first real run() does not pair with the wrong block.
+    await this.awaitNextBlock();
+    // Probe + resync barrier: confirms the pipe is aligned before first use.
+    await this.sync();
+  }
+
+  /**
+   * Send one tmux command, return its response body (lines joined by \n).
+   * Strictly serialized; rejects with TmuxControlError on %error, %exit, or
+   * spawn death.
+   */
+  run(cmd: string): Promise<string> {
+    return this.serialize(() => this.runSerialized(cmd));
+  }
+
+  /**
+   * Self-healing resync barrier: send `display-message -p <marker>` and
+   * discard response blocks until one's body is exactly the marker. Any
+   * stale/unsolicited blocks queued ahead of it are drained.
+   */
+  sync(): Promise<void> {
+    const marker = nextSyncMarker();
+    return this.serialize(() =>
+      drainUntilMarker(() => this.runSerialized(`display-message -p ${marker}`), marker),
+    );
+  }
+
+  /**
+   * Capture pane content WITHOUT piping it through control mode (a pane
+   * displaying literal "%end <t> <num>" would desync the pipe). Routes the
+   * screen through a tmux buffer + temp file. The buffer is always deleted,
+   * even on error; the temp file is reused across calls and unlinked in
+   * close().
+   */
+  async capturePane(paneId: string): Promise<string> {
+    const [cap, save, del] = captureCommands(this.bufferName, paneId, this.tempFile);
+    try {
+      await this.run(cap);
+      await this.run(save);
+      return await Bun.file(this.tempFile).text();
+    } finally {
+      // delete-buffer on every path — never leak the named buffer.
+      await this.run(del).catch(() => {});
+    }
+  }
+
+  /** Detach and reap the child; unlink the reusable temp file. */
+  async close(): Promise<void> {
+    const proc = this.proc;
+    if (!proc) return;
+    this.proc = null;
+    this.dead = true;
+    this.clearWakeTimer();
+    try {
+      proc.stdin.write('detach-client\n');
+      await proc.stdin.flush();
+    } catch {
+      // pipe already broken — fall through to reap.
+    }
+    try {
+      await proc.exited;
+    } catch {
+      try {
+        proc.kill();
+      } catch {
+        // already dead.
+      }
+      try {
+        await proc.exited;
+      } catch {
+        // give up.
+      }
+    }
+    try {
+      await unlink(this.tempFile);
+    } catch {
+      // file never created or already gone.
+    }
+    const drained = this.queue.splice(0);
+    for (const s of drained) s.reject(new TmuxControlError('tmux exited', 'exit'));
+  }
+
+  // --- internals ---------------------------------------------------------
+
+  private serialize<T>(task: () => Promise<T>): Promise<T> {
+    const next = this.chain.then(() => task());
+    // Keep the chain alive regardless of rejection so a failure in one
+    // command does not poison every later command.
+    this.chain = next.then(
+      () => {},
+      () => {},
+    );
+    return next as Promise<T>;
+  }
+
+  private runSerialized(cmd: string): Promise<string> {
+    if (this.dead || this.proc === null) {
+      return Promise.reject(new TmuxControlError('tmux exited', 'dead'));
+    }
+    const proc = this.proc;
+    const p = this.awaitNextBlock();
+    try {
+      proc.stdin.write(`${cmd}\n`);
+      void proc.stdin.flush();
+    } catch (e) {
+      this.handleExit(e instanceof Error ? e : new Error(String(e)));
+    }
+    return p;
+  }
+
+  private awaitNextBlock(): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+      this.queue.push({ resolve, reject });
+    });
+  }
+
+  private startReader(): void {
+    const proc = this.proc;
+    if (!proc) return;
+    const reader = proc.stdout.getReader();
+    const decoder = new TextDecoder();
+    (async () => {
+      try {
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          const text = decoder.decode(value, { stream: true });
+          const events = this.protocol.feed(text);
+          for (const ev of events) this.dispatch(ev);
+        }
+        this.handleExit(new Error('tmux stdout closed'));
+      } catch (e) {
+        this.handleExit(e instanceof Error ? e : new Error(String(e)));
+      }
+    })();
+  }
+
+  private dispatch(ev: ProtocolEvent): void {
+    switch (ev.kind) {
+      case 'block': {
+        const slot = this.queue.shift();
+        if (!slot) return; // stale/unsolicited block with no pending command — drop.
+        if (ev.isError) slot.reject(new TmuxControlError(ev.body, 'error'));
+        else slot.resolve(ev.body);
+        return;
+      }
+      case 'exit':
+        this.handleExit(new Error('tmux exited'));
+        return;
+      case 'wake':
+        this.scheduleWake();
+        return;
+      case 'notification':
+        // Non-wake notifications are not actionable for fleet — dropped.
+        return;
+    }
+  }
+
+  private scheduleWake(): void {
+    if (!this.onWake) return;
+    if (this.wakeTimer !== null) return;
+    this.wakeTimer = setTimeout(() => {
+      this.wakeTimer = null;
+      this.onWake?.();
+    }, this.wakeDebounceMs);
+  }
+
+  private clearWakeTimer(): void {
+    if (this.wakeTimer !== null) {
+      clearTimeout(this.wakeTimer);
+      this.wakeTimer = null;
+    }
+  }
+
+  private handleExit(reason: Error): void {
+    if (this.dead) return;
+    this.dead = true;
+    this.clearWakeTimer();
+    const err = new TmuxControlError(reason.message, 'exit');
+    const drained = this.queue.splice(0);
+    for (const s of drained) s.reject(err);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Integration sketch (follow-up task — DO NOT wire in here).
+//
+// The TUI poll loop gains an OPTIONAL control-mode fast path:
+//
+//   1. Opt-in: constructed only when FLEET_CONTROL_MODE is NOT "0". The
+//      existing fork path in src/tmux/ipc.ts remains the permanent fallback
+//      — on ANY TmuxControlError from connect()/run()/sync()/capturePane()
+//      the client is closed() and the loop reverts to ipc.ts for the rest of
+//      the process. No partial control-mode state survives an error.
+//   2. Lifecycle: connect() once at startup (after tmux availability check);
+//      close() on exit/shutdown. The reader loop is driven by the existing
+//      async tick; onWake is the debounced signal to skip the scan interval
+//      and re-render immediately (focus/layout changed).
+//   3. Usage: scan() replaces `tmux list-panes` + per-pane capture-pane forks
+//      with `client.run(list-panes ...)` + `client.capturePane(id)`; send-keys
+//      stays on ipc.ts (fire-and-forget, no response needed).
+//   4. Boundaries: control.ts must NOT import the TUI; the loop imports it.
+//      sessions.ts / scraper.ts / ipc.ts / index.ts are untouched in phase 1.
+// ---------------------------------------------------------------------------

--- a/src/tmux/sessions.test.ts
+++ b/src/tmux/sessions.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from 'bun:test';
-import { listPanes, parsePanesOutput } from './sessions.ts';
+import {
+  listPanes,
+  listPanesArgs,
+  listPanesCommand,
+  parsePanesOutput,
+  processCaptureOutput,
+} from './sessions.ts';
 
 describe('listPanes', () => {
   test('returns array (may be empty if not in tmux)', () => {
@@ -78,5 +84,46 @@ describe('parsePanesOutput', () => {
     expect(panes[0]!.focused).toBe(true);
     expect(panes[1]!.windowId).toBe('@2');
     expect(panes[1]!.focused).toBe(false);
+  });
+});
+
+describe('listPanesArgs / listPanesCommand', () => {
+  test('fork argv carries PANE_FORMAT as a single literal arg', () => {
+    const args = listPanesArgs();
+    expect(args).toEqual(['list-panes', '-a', '-F', expect.any(String)]);
+    // The format is one arg — tabs ride inside it, not as separate tokens.
+    expect(args).toHaveLength(4);
+    expect(args[3]!.includes('\t')).toBe(true);
+  });
+
+  test('control command single-quotes the format so tabs are not split', () => {
+    const cmd = listPanesCommand();
+    expect(cmd.startsWith("list-panes -a -F '")).toBe(true);
+    expect(cmd.endsWith("'")).toBe(true);
+    // The embedded tabs ride INSIDE the quoted argument.
+    expect(cmd.includes('\t')).toBe(true);
+    // Exactly two single quotes — the wrapping pair — so the format body has no
+    // stray quote that would prematurely close the argument.
+    expect(cmd.split("'").length - 1).toBe(2);
+  });
+});
+
+describe('processCaptureOutput', () => {
+  test('strips trailing whitespace per line, drops trailing blanks, keeps the bottom window', () => {
+    const out = processCaptureOutput('a   \nb\n\n\n', 2);
+    expect(out).toEqual(['a', 'b']);
+  });
+
+  test('slices to the last maxLines', () => {
+    const out = processCaptureOutput('1\n2\n3\n4', 2);
+    expect(out).toEqual(['3', '4']);
+  });
+
+  test('handles output shorter than maxLines', () => {
+    expect(processCaptureOutput('only\n', 50)).toEqual(['only']);
+  });
+
+  test('empty input -> empty array', () => {
+    expect(processCaptureOutput('', 50)).toEqual([]);
   });
 });

--- a/src/tmux/sessions.test.ts
+++ b/src/tmux/sessions.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import {
-  listPanes,
-  listPanesArgs,
-  listPanesCommand,
-  parsePanesOutput,
-  processCaptureOutput,
-} from './sessions.ts';
+import { listPanes, listPanesArgs, listPanesCommand, parsePanesOutput, processCaptureOutput } from './sessions.ts';
 
 describe('listPanes', () => {
   test('returns array (may be empty if not in tmux)', () => {

--- a/src/tmux/sessions.ts
+++ b/src/tmux/sessions.ts
@@ -19,7 +19,7 @@ export interface PaneInfo {
 
 // Fields are inserted BEFORE pane_title so it stays LAST: a stray tab in a pane
 // title then lands in trailing (ignored) parts instead of shifting a field.
-const PANE_FORMAT =
+export const PANE_FORMAT =
   '#{pane_id}\t#{session_name}\t#{window_name}\t#{window_id}\t#{window_index}\t#{pane_current_path}\t#{pane_pid}\t#{pane_active}\t#{window_active}\t#{session_attached}\t#{pane_title}';
 
 export interface ListPanesResult {
@@ -54,8 +54,21 @@ export function parsePanesOutput(stdout: string): PaneInfo[] {
   return panes;
 }
 
+// Argv the fork path feeds to `tmux` (one literal arg, tabs preserved).
+export function listPanesArgs(): string[] {
+  return ['list-panes', '-a', '-F', PANE_FORMAT];
+}
+
+// The same scan as a single control-mode command line. PANE_FORMAT contains
+// literal tab separators, so it MUST be single-quoted — tmux's command parser
+// splits an unquoted argument on whitespace (tabs included) and the format
+// would be broken across tokens. PANE_FORMAT has no single-quote chars.
+export function listPanesCommand(): string {
+  return `list-panes -a -F '${PANE_FORMAT}'`;
+}
+
 export function listPanesResult(): ListPanesResult {
-  const result = tmux(['list-panes', '-a', '-F', PANE_FORMAT]);
+  const result = tmux(listPanesArgs());
   if (result.exitCode !== 0) return { ok: false, panes: [] };
   return { ok: true, panes: parsePanesOutput(result.stdout) };
 }
@@ -64,14 +77,22 @@ export function listPanes(): PaneInfo[] {
   return listPanesResult().panes;
 }
 
-export function capturePane(paneId: string, maxLines: number): string[] {
-  const output = tmuxOrThrow(['capture-pane', '-e', '-p', '-t', paneId], 'capture-pane failed');
+// Shared post-processing for capture-pane output (fork `-p` text and control
+// save-buffer text alike): strip trailing whitespace per line, drop trailing
+// blank lines, then keep only the bottom `maxLines` window. Extracted so the
+// control-mode adapter produces byte-identical line arrays to the fork path.
+export function processCaptureOutput(output: string, maxLines: number): string[] {
   const lines = output.split('\n').map((line) => line.replace(/[\s ]+$/, ''));
   while (lines.length > 0 && lines[lines.length - 1] === '') {
     lines.pop();
   }
   const start = Math.max(0, lines.length - maxLines);
   return lines.slice(start);
+}
+
+export function capturePane(paneId: string, maxLines: number): string[] {
+  const output = tmuxOrThrow(['capture-pane', '-e', '-p', '-t', paneId], 'capture-pane failed');
+  return processCaptureOutput(output, maxLines);
 }
 
 export function currentSessionName(): string | null {


### PR DESCRIPTION
Five infrastructure improvements to fleet's hot loop, notifications, and hook-less detection.

## 1. Broader Claude detection + real-capture fixture corpus

- Five new `permit.*` rules in `CLAUDE_MANIFEST` covering real Claude Code dialogs the hook-less path misread as IDLE: `waiting for permission`, `do you want to allow this connection?`, `tab to amend`, `ctrl+e to explain`, `run a dynamic workflow?`. Plus a codex `busy.esc-interrupt` fallback.
- `src/state/fixtures/`: real captured terminal frames (`<agent>-<expected>[-n].txt` + optional `.title` sidecars) with a filename-driven sweep test (`fixtures.test.ts`) — every future rule change is proven against real screens. `codex-idle` was deliberately dropped: codex's `›` composer has no stable idle marker (documented in the test header).

## 2. Multi-client focus model for notification suppression

`applySuppression` previously knew one active pane — a second attached client viewing an agent still got toasted for it. New `src/tmux/clients.ts` considers all clients: control-mode clients ignored, the `focused` flag trusted when `focus-events` is on, conservative (every selected pane counts) otherwise. `fleet doctor` now advises `set -g focus-events on`.

## 3. Statusline segment cache

`status-format[1]`'s `#(fleet status --statusline)` cold-booted Bun **and** recomputed full agent state every status-interval. The running TUI now writes the rendered segment to an atomic cache file each tick; the CLI serves it while fresh (<6s) with zero tmux forks or state reads, byte-identical via the shared renderer, falling back to live compute when the TUI isn't running.

## 4. Click-to-jump macOS notifications

- `scripts/notifier/FleetNotifier.swift` + `scripts/install-notifier.sh`: a `FleetNotifier.app` helper assembled into `~/Applications` (registered location — macOS ≥26 won't grant notification permission to temp-dir binaries), LSUIElement, ad-hoc signed, posting through `UNUserNotificationCenter`. Permission denial is authoritative — no AppleScript end-run.
- Clicking the notification runs `fleet notification-open`, which revalidates the pane, activates the terminal **first**, then jumps tmux to the exact pane. Stale targets are silent no-ops.
- `deliver.ts` gains a delivery ladder (helper → today's silent osascript → notify-send) and an ANSI/OSC-sanitizing payload builder. Installed best-effort by `fleet install`; Linux behavior unchanged.

## 5. Persistent tmux control-mode client

- `src/tmux/control-protocol.ts`: pure incremental protocol state machine — tag-matched `%begin`/`%end` framing (a pane printing literal `%end` text cannot desync it), `%error`/`%exit` handling, wake classification for the five focus/layout notification types.
- `src/tmux/control.ts`: serialized `run()`, `sync()` resync barrier, and buffer-routed `capturePane` (`capture-pane -b` + `save-buffer` — pane content never rides the pipe).
- The TUI routes its hot loop (list-panes every 500ms, per-pane captures every 5s) through one persistent pipe instead of forking, with a sticky fall-back-to-fork latch on any error — never retried, never crashes the TUI. tmux notifications (`%window-pane-changed` etc.) now trigger immediate ticks instead of waiting for the next interval. One-shot CLI commands keep the fork path unconditionally. Opt out with `FLEET_CONTROL_MODE=0`.

## Verification

- 732 tests pass (was 607), typecheck + lint clean, standalone binary builds, Swift helper compiles.
- Cached/live statusline outputs share one renderer (byte-identical by construction).
- Worth a manual pass: run the TUI inside tmux and watch the control-mode path + wake-triggered ticks — the only parts unit tests can't fully prove.
