### PR TITLE
fix(release): publish Linux ARM64 binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,9 @@ jobs:
           - os: ubuntu-latest
             target: bun-linux-x64
             artifact: fleet-linux-x86_64
+          - os: ubuntu-latest
+            target: bun-linux-arm64
+            artifact: fleet-linux-arm64
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/e2e/release-matrix.test.ts
+++ b/e2e/release-matrix.test.ts
@@ -1,0 +1,45 @@
+// Guards the release build matrix so artifact names and target coverage can't
+// silently regress (e.g. a dropped platform or a renamed asset that mise's
+// `github:` backend would no longer recognize). Parses the actual workflow
+// rather than a copied list, so the test fails the moment the two diverge.
+//
+// Run: `bun test ./e2e/release-matrix.test.ts`
+
+import { test, expect, describe } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const WORKFLOW = join(import.meta.dir, '..', '.github', 'workflows', 'release.yml');
+
+// bun compile target -> published tarball basename. Every platform we ship
+// lives here; arm64 keeps the `arm64` token (like darwin-arm64) so mise's
+// github backend can match the host, while x64 is spelled `x86_64`.
+const EXPECTED: Record<string, string> = {
+  'bun-darwin-arm64': 'fleet-darwin-arm64',
+  'bun-darwin-x64': 'fleet-darwin-x86_64',
+  'bun-linux-x64': 'fleet-linux-x86_64',
+  'bun-linux-arm64': 'fleet-linux-arm64',
+};
+
+function parseMatrix(): Record<string, string> {
+  const yml = readFileSync(WORKFLOW, 'utf8');
+  const pairs: Record<string, string> = {};
+  const re = /target:\s*(\S+)\s*\n\s*artifact:\s*(\S+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(yml)) !== null) {
+    pairs[m[1]!] = m[2]!;
+  }
+  return pairs;
+}
+
+describe('release build matrix', () => {
+  test('covers exactly the expected targets with the expected artifact names', () => {
+    expect(parseMatrix()).toEqual(EXPECTED);
+  });
+
+  test('includes the Linux arm64 target with a mise-recognizable arm64 asset', () => {
+    const matrix = parseMatrix();
+    expect(matrix['bun-linux-arm64']).toBe('fleet-linux-arm64');
+    expect(matrix['bun-linux-arm64']).toContain('arm64');
+  });
+});


### PR DESCRIPTION
## Summary
The release pipeline builds standalone binaries with `bun build --compile --target=bun-<os>-<arch>` across a matrix, but had no Linux ARM64 target. This adds the `bun-linux-arm64` build so releases publish `fleet-linux-arm64.tar.gz` (with its `.sha256` sidecar and `SHA256SUMS` entry) alongside the existing darwin arm64/x86_64 and linux x86_64 artifacts.

The new asset name follows the existing `fleet-<os>-<arch>` convention (arm64 keeps the `arm64` token, matching `fleet-darwin-arm64`), so mise's `github:` backend recognizes it for arm64 Linux hosts. No application code or unrelated files changed.

## Changes
- `.github/workflows/release.yml`: add `bun-linux-arm64` -> `fleet-linux-arm64` matrix entry. The existing package/checksum/upload and `attach-binaries` aggregation steps are matrix/glob driven, so they pick it up automatically.
- `e2e/release-matrix.test.ts`: new test that parses the workflow and asserts exact target coverage and artifact names, so a dropped platform or renamed asset fails CI instead of silently regressing.

## Test evidence
- `bun test --max-concurrency=1`: 905 pass, 0 fail (includes the 2 new matrix tests)
- `bun run lint` (oxlint): clean
- `bun run format:check` (oxfmt): all files formatted
- `bun run typecheck` (tsc --noEmit): clean
- `bun run build`: compiles
- Local cross-compile `bun build --compile --minify --target=bun-linux-arm64`: `file` reports `ELF 64-bit LSB executable, ARM aarch64 ... for GNU/Linux`
