### PR TITLE
fix(release): update Homebrew for Linux ARM64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,6 +124,7 @@ jobs:
           SHA_ARM64=$(shasum -a 256 fleet-darwin-arm64.tar.gz | cut -d' ' -f1)
           SHA_X86_64=$(shasum -a 256 fleet-darwin-x86_64.tar.gz | cut -d' ' -f1)
           SHA_LINUX=$(shasum -a 256 fleet-linux-x86_64.tar.gz | cut -d' ' -f1)
+          SHA_LINUX_ARM64=$(shasum -a 256 fleet-linux-arm64.tar.gz | cut -d' ' -f1)
           cd tap
           sed -i "s/version \".*\"/version \"${VER}\"/" Formula/fleet.rb
           python3 -c "
@@ -134,6 +135,7 @@ jobs:
               'fleet-darwin-arm64.tar.gz': '${SHA_ARM64}',
               'fleet-darwin-x86_64.tar.gz': '${SHA_X86_64}',
               'fleet-linux-x86_64.tar.gz': '${SHA_LINUX}',
+              'fleet-linux-arm64.tar.gz': '${SHA_LINUX_ARM64}',
           }
           for asset, sha in shas.items():
               pattern = r'(' + re.escape(asset) + r'.*\n\s*sha256 \")([a-fA-F0-9]+|PLACEHOLDER_\w+)(\")'

--- a/Formula/fleet.rb
+++ b/Formula/fleet.rb
@@ -15,8 +15,13 @@ class Fleet < Formula
   end
 
   on_linux do
-    url "https://github.com/nicknisi/fleet/releases/download/v#{version}/fleet-linux-x86_64.tar.gz"
-    sha256 "PLACEHOLDER_LINUX"
+    if Hardware::CPU.arm?
+      url "https://github.com/nicknisi/fleet/releases/download/v#{version}/fleet-linux-arm64.tar.gz"
+      sha256 "PLACEHOLDER_LINUX_ARM64"
+    else
+      url "https://github.com/nicknisi/fleet/releases/download/v#{version}/fleet-linux-x86_64.tar.gz"
+      sha256 "PLACEHOLDER_LINUX"
+    end
   end
 
   def install

--- a/e2e/release-matrix.test.ts
+++ b/e2e/release-matrix.test.ts
@@ -10,6 +10,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const WORKFLOW = join(import.meta.dir, '..', '.github', 'workflows', 'release.yml');
+const FORMULA = join(import.meta.dir, '..', 'Formula', 'fleet.rb');
 
 // bun compile target -> published tarball basename. Every platform we ship
 // lives here; arm64 keeps the `arm64` token (like darwin-arm64) so mise's
@@ -32,6 +33,42 @@ function parseMatrix(): Record<string, string> {
   return pairs;
 }
 
+// Tarball basenames the canonical formula points its download URLs at.
+function parseFormulaAssets(): Set<string> {
+  const rb = readFileSync(FORMULA, 'utf8');
+  const assets = new Set<string>();
+  const re = /url "[^"]*\/(fleet-[a-z0-9_-]+\.tar\.gz)"/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(rb)) !== null) {
+    assets.add(m[1]!);
+  }
+  return assets;
+}
+
+// asset filename -> the shell var the release job substitutes into the tap.
+function parseChecksumMap(): Record<string, string> {
+  const yml = readFileSync(WORKFLOW, 'utf8');
+  const map: Record<string, string> = {};
+  const re = /'(fleet-[a-z0-9_-]+\.tar\.gz)':\s*'\$\{(SHA_\w+)\}'/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(yml)) !== null) {
+    map[m[1]!] = m[2]!;
+  }
+  return map;
+}
+
+// shell var -> the asset it is computed from via `shasum -a 256 <asset>`.
+function parseChecksumSources(): Record<string, string> {
+  const yml = readFileSync(WORKFLOW, 'utf8');
+  const src: Record<string, string> = {};
+  const re = /(SHA_\w+)=\$\(shasum -a 256 (fleet-[a-z0-9_-]+\.tar\.gz)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(yml)) !== null) {
+    src[m[1]!] = m[2]!;
+  }
+  return src;
+}
+
 describe('release build matrix', () => {
   test('covers exactly the expected targets with the expected artifact names', () => {
     expect(parseMatrix()).toEqual(EXPECTED);
@@ -41,5 +78,26 @@ describe('release build matrix', () => {
     const matrix = parseMatrix();
     expect(matrix['bun-linux-arm64']).toBe('fleet-linux-arm64');
     expect(matrix['bun-linux-arm64']).toContain('arm64');
+  });
+});
+
+describe('formula/artifact parity', () => {
+  test('canonical formula ships exactly the built artifacts', () => {
+    const built = new Set(Object.values(parseMatrix()).map((a) => `${a}.tar.gz`));
+    expect(parseFormulaAssets()).toEqual(built);
+  });
+
+  test('release job maps every formula asset to its own checksum, exactly once', () => {
+    const assets = parseFormulaAssets();
+    const map = parseChecksumMap();
+    const sources = parseChecksumSources();
+
+    // The tap substitution must cover exactly the formula's assets.
+    expect(new Set(Object.keys(map))).toEqual(assets);
+
+    // No cross-wiring: each asset's checksum var is computed from that same asset.
+    for (const [asset, shaVar] of Object.entries(map)) {
+      expect(sources[shaVar]).toBe(asset);
+    }
   });
 });


### PR DESCRIPTION
Completes Homebrew Linux ARM64 support for `fleet-linux-arm64.tar.gz`. Follows #68 (which published the Linux ARM64 binaries and added build-matrix/e2e coverage).

## Changes
- **`Formula/fleet.rb`**: add a `Hardware::CPU.arm?` branch under `on_linux`, using `PLACEHOLDER_LINUX_ARM64` for the ARM URL/checksum while preserving the existing Linux x86_64 branch. This in-repo formula is canonical; the release job copies it into the tap.
- **`.github/workflows/release.yml`**: compute `SHA_LINUX_ARM64` and add `fleet-linux-arm64.tar.gz` to the checksum map. All four assets are matched by exact filename through the existing exactly-one-substitution validation (`count != 1` raises).
- **`e2e/release-matrix.test.ts`**: minimal additions guarding formula/artifact parity (formula URLs cover exactly the built artifacts) and exact checksum mapping (each asset's substituted SHA var is computed from that same asset, no cross-wiring).

## Verification
- lint (oxlint): clean
- format:check (oxfmt): clean
- typecheck (tsc --noEmit): clean
- test (bun test): 907 pass, incl. release-matrix parity/mapping guards
- build (--compile): ok, `fleet 0.22.1`
- Simulated the workflow python substitution against the canonical formula: all four assets substituted exactly once with correct mapping.

## Related
- Tap counterpart: nicknisi/homebrew-formulae#1
- Follows #68

Do not merge until the tap PR and CI are green.
