### PR TITLE
fix: stay silent when the statusline inject runs on tmux conf reloads

### DIFF
--- a/src/cli/statusline.ts
+++ b/src/cli/statusline.ts
@@ -177,17 +177,14 @@ export function isStatusLineInjected(): boolean {
 }
 
 // install.ts persists a `run-shell "fleet statusline --inject"` line so a fresh
-// tmux server gets row 2 — which also means this runs on every `source-file`,
-// where it is nearly always a no-op that only announced itself. Skip the work
-// and the message when the server already matches; --force re-applies anyway.
+// tmux server gets row 2 — which also means this runs on every `source-file`.
+// Silent even when it re-applies: tmux shows run-shell stdout in view mode, and
+// a reload that re-asserts row 2 over a conf line that reset `status` is not
+// news. Skip the work when the server already matches; --force re-applies.
 export function runStatusLineInject(force = false): number {
   if (!force && isStatusLineInjected()) return 0;
 
-  const code = runCommands(buildInjectCommands());
-  if (code === 0) {
-    process.stdout.write('Fleet status line injected. tmux will now render `fleet status --statusline` on row 2.\n');
-  }
-  return code;
+  return runCommands(buildInjectCommands());
 }
 
 export function runStatusLineRemove(): number {


### PR DESCRIPTION
## Problem

Every `source-file ~/.config/tmux/tmux.conf` popped the message "Fleet status line injected..." in tmux view mode.

Root cause: install.ts persists `run-shell "fleet statusline --inject"`, so it re-runs on every reload. The idempotence check requires `status == 2`, but a conf that sets `status on`/`off` earlier in the file (e.g. a hide-status-bar-when-one-window block) resets it before the inject line runs. The check then fails, inject re-applies, prints, and tmux surfaces run-shell stdout in view mode. Post-reload inspection always showed matching values because the inject runs last, masking the failure.

## Fix

Delete the success print from `runStatusLineInject`. The idempotence skip and `--force` re-apply still work, both now silent. Row 2 appearing is feedback enough for a manual run. `--remove` keeps its message since it is a deliberate, conf-editing op.

## Verification

- 51 tests pass (`statusline.test.ts`, `install.test.ts`), typecheck clean
- Built locally: `fleet statusline --inject --force` exits 0 with no output
- Real `tmux source-file` reload produces no view-mode popup