### PR TITLE
perf: cut blocking tmux spawns and file reads on the TUI hot path

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -79,10 +79,12 @@ function handleFilterInput(
     case 'enter': {
       const selected = app.selectedState();
       if (selected) {
+        // Switch before the verify/ack spawns so the jump isn't gated on
+        // them; the writes still complete synchronously before process exit.
+        switchClient(selected.paneId);
+        finish(0);
         verifyPaneState(selected, statusDirs);
         acknowledgePane(selected.paneId, statusDirs);
-        finish(0);
-        switchClient(selected.paneId);
       }
       break;
     }
@@ -411,10 +413,10 @@ async function launchTui(): Promise<number> {
           if (sel) {
             if (app.registerClick(sel.paneId, Date.now())) {
               // Double-click → jump to the agent, mirroring the Enter handler.
+              switchClient(sel.paneId);
+              finish(0);
               verifyPaneState(sel, statusDirs);
               acknowledgePane(sel.paneId, statusDirs);
-              finish(0);
-              switchClient(sel.paneId);
               return;
             }
             const idx = app.visibleStates().findIndex((s) => s.paneId === sel.paneId);
@@ -588,10 +590,10 @@ async function launchTui(): Promise<number> {
         case 'enter': {
           const selected = app.selectedState();
           if (selected) {
+            switchClient(selected.paneId);
+            finish(0);
             verifyPaneState(selected, statusDirs);
             acknowledgePane(selected.paneId, statusDirs);
-            finish(0);
-            switchClient(selected.paneId);
             return;
           }
           break;

--- a/src/state/events.ts
+++ b/src/state/events.ts
@@ -1,4 +1,4 @@
-import { existsSync, openSync, readSync, fstatSync, closeSync } from 'node:fs';
+import { openSync, readSync, closeSync, statSync } from 'node:fs';
 import { AgentStatus, type EventEntry } from './types.ts';
 
 const TAIL_BYTES = 8192;
@@ -24,14 +24,21 @@ export function parseEventLog(content: string): EventEntry[] {
   return entries;
 }
 
+// Tail-read cache gated on (size, mtimeMs, maxLines): the fast tick tails
+// every pane's events file every 500ms; unchanged files skip open+read+parse.
+const eventsTailCache = new Map<string, { size: number; mtimeMs: number; maxLines: number; entries: EventEntry[] }>();
+
 // Read just the last `maxLines` events without parsing the whole file — reads a
 // bounded tail off the end so the hot refresh path stays cheap on long logs.
 export function readLastEvents(path: string, maxLines: number): EventEntry[] {
-  if (!existsSync(path)) return [];
   try {
+    const { size, mtimeMs } = statSync(path);
+    const hit = eventsTailCache.get(path);
+    if (hit && hit.size === size && hit.mtimeMs === mtimeMs && hit.maxLines === maxLines) {
+      return hit.entries;
+    }
     const fd = openSync(path, 'r');
     try {
-      const size = fstatSync(fd).size;
       const readBytes = Math.min(size, TAIL_BYTES);
       const buf = Buffer.alloc(readBytes);
       readSync(fd, buf, 0, readBytes, size - readBytes);
@@ -41,7 +48,9 @@ export function readLastEvents(path: string, maxLines: number): EventEntry[] {
         .filter((l) => l.length > 0);
       // If we didn't reach the start of the file, the first line may be partial.
       const usable = size > readBytes ? lines.slice(1) : lines;
-      return parseEventLog(usable.slice(-maxLines).join('\n'));
+      const entries = parseEventLog(usable.slice(-maxLines).join('\n'));
+      eventsTailCache.set(path, { size, mtimeMs, maxLines, entries });
+      return entries;
     } finally {
       closeSync(fd);
     }

--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, existsSync, watch, writeFileSync, renameSync } from 'node:fs';
+import { readdirSync, readFileSync, existsSync, statSync, watch, writeFileSync, renameSync } from 'node:fs';
 import { join } from 'node:path';
 import type { HookStatus, ResolvedHookStatus } from './types.ts';
 import type { AgentDir } from '../agents/config.ts';
@@ -41,6 +41,10 @@ export function parseStatusFile(content: string): HookStatus | null {
   }
 }
 
+// Parsed .status cache keyed by file path, gated on mtime: the fast tick
+// re-reads every status file every 500ms, and they change far less often.
+const statusCache = new Map<string, { mtimeMs: number; status: HookStatus | null }>();
+
 // Each record is stamped with its owning `agent` and source `statusDir` so the
 // caller (index.ts) knows which agent authored the status and which dir to read
 // the matching .events.jsonl from — the name travels with the data.
@@ -51,9 +55,16 @@ export function readStatusDir(dir: string, agent: string): ResolvedHookStatus[] 
     const files = readdirSync(dir);
     for (const file of files) {
       if (!file.endsWith('.status')) continue;
+      const path = join(dir, file);
       try {
-        const content = readFileSync(join(dir, file), 'utf-8');
-        const status = parseStatusFile(content);
+        const mtimeMs = statSync(path).mtimeMs;
+        const hit = statusCache.get(path);
+        if (hit && hit.mtimeMs === mtimeMs) {
+          if (hit.status) statuses.push({ ...hit.status, agent, statusDir: dir });
+          continue;
+        }
+        const status = parseStatusFile(readFileSync(path, 'utf-8'));
+        statusCache.set(path, { mtimeMs, status });
         if (status) statuses.push({ ...status, agent, statusDir: dir });
       } catch {
         // Skip unreadable files

--- a/src/tui/preview.test.ts
+++ b/src/tui/preview.test.ts
@@ -11,9 +11,10 @@ mock.module('../tmux/sessions.ts', () => ({
 }));
 
 let renderPreview: typeof import('./preview.ts').renderPreview;
+let captureForPreview: typeof import('./preview.ts').captureForPreview;
 
 beforeAll(async () => {
-  ({ renderPreview } = await import('./preview.ts'));
+  ({ renderPreview, captureForPreview } = await import('./preview.ts'));
 });
 
 const makeState = (status: AgentStatus): AgentState => ({
@@ -72,5 +73,38 @@ describe('renderPreview title', () => {
     const lines = renderPreview({ ...makeState(AgentStatus.DONE), window: 'test' }, 80, 20);
     expect(lines[0]).toContain('test · READY');
     expect(lines[0]).not.toContain('[');
+  });
+});
+
+describe('captureForPreview', () => {
+  const linesOf = (n: number) => Array.from({ length: n }, (_, i) => `l${i}`);
+
+  test('reuses the capture within the TTL', () => {
+    let calls = 0;
+    const fetch = () => {
+      calls++;
+      return ['x'];
+    };
+    captureForPreview('%t1', 10, 1000, fetch);
+    captureForPreview('%t1', 10, 1200, fetch);
+    expect(calls).toBe(1);
+  });
+
+  test('refetches after the TTL or for a larger window', () => {
+    let calls = 0;
+    const fetch = (_id: string, n: number) => {
+      calls++;
+      return linesOf(n);
+    };
+    captureForPreview('%t2', 10, 1000, fetch);
+    captureForPreview('%t2', 10, 1500, fetch); // TTL expired
+    captureForPreview('%t2', 20, 1600, fetch); // larger than the cached window
+    expect(calls).toBe(3);
+  });
+
+  test('serves a smaller window as the tail of the cached capture', () => {
+    const fetch = (_id: string, n: number) => linesOf(n);
+    captureForPreview('%t3', 10, 1000, fetch);
+    expect(captureForPreview('%t3', 3, 1100, fetch)).toEqual(['l7', 'l8', 'l9']);
   });
 });

--- a/src/tui/preview.ts
+++ b/src/tui/preview.ts
@@ -4,6 +4,29 @@ import { AgentStatus, STATUS_DISPLAY, whereLabel, type AgentState } from '../sta
 import { capturePane } from '../tmux/sessions.ts';
 import { chip } from './layouts/shared.ts';
 
+// render() runs per frame (keystrokes, mouse-motion hover, the 500ms BUSY
+// pulse), and each capturePane is a blocking tmux spawn. A short TTL caps that
+// at ~2 spawns/sec per pane; frames between refreshes reuse the last lines.
+const PREVIEW_TTL_MS = 400;
+const previewCaptureCache = new Map<string, { at: number; maxLines: number; lines: string[] }>();
+
+// TTL-gated pane capture. `now`/`fetch` injected for tests; fetch does the
+// real spawn. A cached capture larger than the request serves its tail.
+export function captureForPreview(
+  paneId: string,
+  maxLines: number,
+  now: number,
+  fetch: (paneId: string, maxLines: number) => string[] = capturePane,
+): string[] {
+  const hit = previewCaptureCache.get(paneId);
+  if (hit && now - hit.at < PREVIEW_TTL_MS && hit.maxLines >= maxLines) {
+    return hit.lines.slice(-maxLines);
+  }
+  const lines = fetch(paneId, maxLines);
+  previewCaptureCache.set(paneId, { at: now, maxLines, lines });
+  return lines;
+}
+
 export function previewActions(state: AgentState): string {
   switch (state.status) {
     case AgentStatus.PERMIT:
@@ -44,7 +67,7 @@ export function renderPreview(
 
   let paneLines: string[];
   try {
-    paneLines = capturePane(state.paneId, maxContentLines);
+    paneLines = captureForPreview(state.paneId, maxContentLines, Date.now());
   } catch {
     lines.push(`${C.gray}Preview unavailable${C.reset}`);
     return lines;


### PR DESCRIPTION
- preview: cache pane captures for 400ms instead of forking tmux
  capture-pane on every rendered frame (keystrokes, hover, BUSY pulse)
- index: switchClient before verify/ack on jump so the switch isn't
  gated on two extra spawns
- state: cache parsed .status and .events.jsonl reads by mtime+size;
  unchanged files cost one stat per 500ms tick

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>