### PR TITLE
chore: add anti-slop oxlint plugin and migrate to its rules

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -2,10 +2,27 @@
   "$schema": "./node_modules/oxlint/configuration_schema.json",
   "plugins": null,
   "categories": {},
-  "rules": {},
+  "rules": {
+    "anti-slop/no-chained-type-assertions": "error",
+    "anti-slop/no-conditional-empty-object-spread": "error",
+    "anti-slop/no-known-value-widening": "error",
+    "anti-slop/no-module-mocking": "error",
+    "anti-slop/no-object-parameters": "error",
+    "anti-slop/no-reflect-apply": "error",
+    "anti-slop/no-reflect-get": "error",
+    "anti-slop/no-runtime-typeof": ["error", { "allowInTypeGuards": true }],
+    "anti-slop/no-shape-in-symbol-names": "error",
+    "anti-slop/no-unknown-parameters": "error",
+    "anti-slop/no-unknown-returns": "error",
+    "anti-slop/no-unknown-type-aliases": "error",
+    "anti-slop/no-unsafe-dictionary-type": "error",
+    "anti-slop/no-widen-then-assert": "error",
+    "anti-slop/require-safety-comment-for-type-assertion": "error"
+  },
   "env": {
     "builtin": true
   },
   "globals": {},
-  "ignorePatterns": ["dist/**"]
+  "ignorePatterns": ["dist/**", ".claude-plugin/**", ".pi/**", ".superpowers/**", "tools/oxlint/anti-slop/**"],
+  "jsPlugins": [{ "name": "anti-slop", "specifier": "./tools/oxlint/anti-slop/index.ts" }]
 }

--- a/bun.lock
+++ b/bun.lock
@@ -5,9 +5,10 @@
     "": {
       "name": "fleet",
       "devDependencies": {
+        "@oxlint/plugins": "1.79.0",
         "@types/bun": "latest",
         "oxfmt": "^0.47.0",
-        "oxlint": "^1.62.0",
+        "oxlint": "1.79.0",
       },
       "peerDependencies": {
         "typescript": "^5",
@@ -15,96 +16,98 @@
     },
   },
   "packages": {
-    "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.47.0", "", { "os": "android", "cpu": "arm" }, "sha512-KrMQRdMi/upr81qT4ijK6X6BNp6jqpMY7FwILQnwIy9QLc3qpnhUx5rsCLGzn4ewsCQ0CNAspN2ogmP1GXLyLw=="],
+    "@oxfmt/binding-android-arm-eabi": ["@oxfmt/binding-android-arm-eabi@0.47.0", "https://registry.npmjs.org/@oxfmt/binding-android-arm-eabi/-/binding-android-arm-eabi-0.47.0.tgz", { "os": "android", "cpu": "arm" }, "sha512-KrMQRdMi/upr81qT4ijK6X6BNp6jqpMY7FwILQnwIy9QLc3qpnhUx5rsCLGzn4ewsCQ0CNAspN2ogmP1GXLyLw=="],
 
-    "@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.47.0", "", { "os": "android", "cpu": "arm64" }, "sha512-r4ixS/PeUpAFKgrpDoZ5pSkthjZzVzKd95525Aazj+aOv9H4ulK5zYHGb7wFY5n5kZxHK8TbOJUZgoEb1ohddQ=="],
+    "@oxfmt/binding-android-arm64": ["@oxfmt/binding-android-arm64@0.47.0", "https://registry.npmjs.org/@oxfmt/binding-android-arm64/-/binding-android-arm64-0.47.0.tgz", { "os": "android", "cpu": "arm64" }, "sha512-r4ixS/PeUpAFKgrpDoZ5pSkthjZzVzKd95525Aazj+aOv9H4ulK5zYHGb7wFY5n5kZxHK8TbOJUZgoEb1ohddQ=="],
 
-    "@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.47.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-CLWxiKpMl+195cm09CuaWEhJK0CirRkoMa07aR9+9AFPat2LfIKtwx1JqxZM0MTvcMe6+adlJNdVL6jdInvq3g=="],
+    "@oxfmt/binding-darwin-arm64": ["@oxfmt/binding-darwin-arm64@0.47.0", "https://registry.npmjs.org/@oxfmt/binding-darwin-arm64/-/binding-darwin-arm64-0.47.0.tgz", { "os": "darwin", "cpu": "arm64" }, "sha512-CLWxiKpMl+195cm09CuaWEhJK0CirRkoMa07aR9+9AFPat2LfIKtwx1JqxZM0MTvcMe6+adlJNdVL6jdInvq3g=="],
 
-    "@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.47.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-Xq5fjTYDC50faUeLSm0rZdBqoTgleXEdD7NpJdARtQIczkCJn3xNjMUSQQkUmh4CtxkKTNL68lytcOK3e/osgg=="],
+    "@oxfmt/binding-darwin-x64": ["@oxfmt/binding-darwin-x64@0.47.0", "https://registry.npmjs.org/@oxfmt/binding-darwin-x64/-/binding-darwin-x64-0.47.0.tgz", { "os": "darwin", "cpu": "x64" }, "sha512-Xq5fjTYDC50faUeLSm0rZdBqoTgleXEdD7NpJdARtQIczkCJn3xNjMUSQQkUmh4CtxkKTNL68lytcOK3e/osgg=="],
 
-    "@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.47.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-QOU9ZIJ52p5askcEC0QJvvr8trHAWoonul8bgISo6gYUL3s50zkqafBYcNAr9LJZQbsZtPfIWHk9+5+nUp1qJQ=="],
+    "@oxfmt/binding-freebsd-x64": ["@oxfmt/binding-freebsd-x64@0.47.0", "https://registry.npmjs.org/@oxfmt/binding-freebsd-x64/-/binding-freebsd-x64-0.47.0.tgz", { "os": "freebsd", "cpu": "x64" }, "sha512-QOU9ZIJ52p5askcEC0QJvvr8trHAWoonul8bgISo6gYUL3s50zkqafBYcNAr9LJZQbsZtPfIWHk9+5+nUp1qJQ=="],
 
-    "@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.47.0", "", { "os": "linux", "cpu": "arm" }, "sha512-oJxDM1aBhPvz9gmElBv8UpxyiqhwfjcbrSxT5F0xtuUzY6dQI27/AQPIt3eu3Z5Yvn0kQl5R7MA3Z+MbnRvCBw=="],
+    "@oxfmt/binding-linux-arm-gnueabihf": ["@oxfmt/binding-linux-arm-gnueabihf@0.47.0", "https://registry.npmjs.org/@oxfmt/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.47.0.tgz", { "os": "linux", "cpu": "arm" }, "sha512-oJxDM1aBhPvz9gmElBv8UpxyiqhwfjcbrSxT5F0xtuUzY6dQI27/AQPIt3eu3Z5Yvn0kQl5R7MA3Z+MbnRvCBw=="],
 
-    "@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.47.0", "", { "os": "linux", "cpu": "arm" }, "sha512-g8Lh50VS4ibGz2q6v7r9UZY4D0dM16SdrFYOMzhqIoCwGcai8VMIRUAcqn1/jlCsOOzUXJ741+kCeJt0cofakQ=="],
+    "@oxfmt/binding-linux-arm-musleabihf": ["@oxfmt/binding-linux-arm-musleabihf@0.47.0", "https://registry.npmjs.org/@oxfmt/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.47.0.tgz", { "os": "linux", "cpu": "arm" }, "sha512-g8Lh50VS4ibGz2q6v7r9UZY4D0dM16SdrFYOMzhqIoCwGcai8VMIRUAcqn1/jlCsOOzUXJ741+kCeJt0cofakQ=="],
 
-    "@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.47.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-YrNT1vQ0asaXoRbrvYENPqmBfOQ9Xr8enPNOULeYfg44VjCcrUowFy5QZr+WawE0zyP8cH9e9Gxxg0fDEFzhcg=="],
+    "@oxfmt/binding-linux-arm64-gnu": ["@oxfmt/binding-linux-arm64-gnu@0.47.0", "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.47.0.tgz", { "os": "linux", "cpu": "arm64" }, "sha512-YrNT1vQ0asaXoRbrvYENPqmBfOQ9Xr8enPNOULeYfg44VjCcrUowFy5QZr+WawE0zyP8cH9e9Gxxg0fDEFzhcg=="],
 
-    "@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.47.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-IxtQC/sbBi4ubbY+MdwdanRWrG9InQJVZqyMsBa5IUaQcnSg86gQme574HxXMC1p4bo4YhV99zQ+wNnGCvEgzw=="],
+    "@oxfmt/binding-linux-arm64-musl": ["@oxfmt/binding-linux-arm64-musl@0.47.0", "https://registry.npmjs.org/@oxfmt/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.47.0.tgz", { "os": "linux", "cpu": "arm64" }, "sha512-IxtQC/sbBi4ubbY+MdwdanRWrG9InQJVZqyMsBa5IUaQcnSg86gQme574HxXMC1p4bo4YhV99zQ+wNnGCvEgzw=="],
 
-    "@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.47.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-EWXEhOMbWO0q6eJSbu0QLkU8cKi0ljlYLngeDs2Ocu/pm1rrLwyQiYzlFbdnMRURI4w9ndr1sI9rSbhlJ5o23Q=="],
+    "@oxfmt/binding-linux-ppc64-gnu": ["@oxfmt/binding-linux-ppc64-gnu@0.47.0", "https://registry.npmjs.org/@oxfmt/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.47.0.tgz", { "os": "linux", "cpu": "ppc64" }, "sha512-EWXEhOMbWO0q6eJSbu0QLkU8cKi0ljlYLngeDs2Ocu/pm1rrLwyQiYzlFbdnMRURI4w9ndr1sI9rSbhlJ5o23Q=="],
 
-    "@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.47.0", "", { "os": "linux", "cpu": "none" }, "sha512-tZrjS11TUiDuEpRaqdk8K9F9xETRyKXfuZKmdeW+Gj7coBnm7+8sBEfyt033EAFEQSlkniAXvBLh+Qja2ioGBQ=="],
+    "@oxfmt/binding-linux-riscv64-gnu": ["@oxfmt/binding-linux-riscv64-gnu@0.47.0", "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.47.0.tgz", { "os": "linux", "cpu": "none" }, "sha512-tZrjS11TUiDuEpRaqdk8K9F9xETRyKXfuZKmdeW+Gj7coBnm7+8sBEfyt033EAFEQSlkniAXvBLh+Qja2ioGBQ=="],
 
-    "@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.47.0", "", { "os": "linux", "cpu": "none" }, "sha512-KBFy+2CFKUCZzYwX2ZOPQKck1vjQbz+hextuc19G4r0WRJwadfAeuQMQRQvB+Ivc8brlbOVg7et8K7E467440g=="],
+    "@oxfmt/binding-linux-riscv64-musl": ["@oxfmt/binding-linux-riscv64-musl@0.47.0", "https://registry.npmjs.org/@oxfmt/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.47.0.tgz", { "os": "linux", "cpu": "none" }, "sha512-KBFy+2CFKUCZzYwX2ZOPQKck1vjQbz+hextuc19G4r0WRJwadfAeuQMQRQvB+Ivc8brlbOVg7et8K7E467440g=="],
 
-    "@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.47.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-REUPFKVGSiK99B+9eaPhluEVglzaoj/SMykNC5SUiV2RSsBfV5lWN7Y0iCIc251Wz3GaeAGZsJ/zj3gjarxdFg=="],
+    "@oxfmt/binding-linux-s390x-gnu": ["@oxfmt/binding-linux-s390x-gnu@0.47.0", "https://registry.npmjs.org/@oxfmt/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.47.0.tgz", { "os": "linux", "cpu": "s390x" }, "sha512-REUPFKVGSiK99B+9eaPhluEVglzaoj/SMykNC5SUiV2RSsBfV5lWN7Y0iCIc251Wz3GaeAGZsJ/zj3gjarxdFg=="],
 
-    "@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.47.0", "", { "os": "linux", "cpu": "x64" }, "sha512-KVftVSVEDeIfRW3TIeLe3aNI/iY4m1fu5mDwHcisKMZSCMKLkrhFsjowC7o9RoqNPxbbglm2+/6KAKBIts2t0Q=="],
+    "@oxfmt/binding-linux-x64-gnu": ["@oxfmt/binding-linux-x64-gnu@0.47.0", "https://registry.npmjs.org/@oxfmt/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.47.0.tgz", { "os": "linux", "cpu": "x64" }, "sha512-KVftVSVEDeIfRW3TIeLe3aNI/iY4m1fu5mDwHcisKMZSCMKLkrhFsjowC7o9RoqNPxbbglm2+/6KAKBIts2t0Q=="],
 
-    "@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.47.0", "", { "os": "linux", "cpu": "x64" }, "sha512-DTsmGEaA2860Aq5VUyDO8/MT9NFxwVL93RnRYmpMwK6DsSkThmvEpqoUDDljziEpAedMRG19SCogrNbINSbLUQ=="],
+    "@oxfmt/binding-linux-x64-musl": ["@oxfmt/binding-linux-x64-musl@0.47.0", "https://registry.npmjs.org/@oxfmt/binding-linux-x64-musl/-/binding-linux-x64-musl-0.47.0.tgz", { "os": "linux", "cpu": "x64" }, "sha512-DTsmGEaA2860Aq5VUyDO8/MT9NFxwVL93RnRYmpMwK6DsSkThmvEpqoUDDljziEpAedMRG19SCogrNbINSbLUQ=="],
 
-    "@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.47.0", "", { "os": "none", "cpu": "arm64" }, "sha512-8r5BDro7fLOBoq1JXHLVSs55OlrxQhEso4HVo0TcY7OXJUPYfjPoOaYL5us+yIwqyP9rQwN+rxuiNFSmaxSuOQ=="],
+    "@oxfmt/binding-openharmony-arm64": ["@oxfmt/binding-openharmony-arm64@0.47.0", "https://registry.npmjs.org/@oxfmt/binding-openharmony-arm64/-/binding-openharmony-arm64-0.47.0.tgz", { "os": "none", "cpu": "arm64" }, "sha512-8r5BDro7fLOBoq1JXHLVSs55OlrxQhEso4HVo0TcY7OXJUPYfjPoOaYL5us+yIwqyP9rQwN+rxuiNFSmaxSuOQ=="],
 
-    "@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.47.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-qtz/gzm8IjSPUlseZ0ofW8zyHLoZsuP5HTfcGGkWkUblB89JT8GNYH3ICqjbDsqsGqXum0/ZndXTFplSdXFIcg=="],
+    "@oxfmt/binding-win32-arm64-msvc": ["@oxfmt/binding-win32-arm64-msvc@0.47.0", "https://registry.npmjs.org/@oxfmt/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.47.0.tgz", { "os": "win32", "cpu": "arm64" }, "sha512-qtz/gzm8IjSPUlseZ0ofW8zyHLoZsuP5HTfcGGkWkUblB89JT8GNYH3ICqjbDsqsGqXum0/ZndXTFplSdXFIcg=="],
 
-    "@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.47.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-5vIcdcIDE7nCx+MXN6sm8kbC4zajDB31E86rez4i45iHNH/2NjdKlJ720xcHTr3eeiMcttCGPHPhE1TjtBDGZw=="],
+    "@oxfmt/binding-win32-ia32-msvc": ["@oxfmt/binding-win32-ia32-msvc@0.47.0", "https://registry.npmjs.org/@oxfmt/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.47.0.tgz", { "os": "win32", "cpu": "ia32" }, "sha512-5vIcdcIDE7nCx+MXN6sm8kbC4zajDB31E86rez4i45iHNH/2NjdKlJ720xcHTr3eeiMcttCGPHPhE1TjtBDGZw=="],
 
-    "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.47.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Sr59Y5ms54ONBjxFeWhVlGyQcHXxcl9DxC23f6yXlRkcos7LXBLoO+KDfxexjHIOZh7cWqrWduzvUjJ+pHp8cQ=="],
+    "@oxfmt/binding-win32-x64-msvc": ["@oxfmt/binding-win32-x64-msvc@0.47.0", "https://registry.npmjs.org/@oxfmt/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.47.0.tgz", { "os": "win32", "cpu": "x64" }, "sha512-Sr59Y5ms54ONBjxFeWhVlGyQcHXxcl9DxC23f6yXlRkcos7LXBLoO+KDfxexjHIOZh7cWqrWduzvUjJ+pHp8cQ=="],
 
-    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.67.0", "", { "os": "android", "cpu": "arm" }, "sha512-VrSi571rDv1N8HaEDM+DEX8nmT0y9jJo8tzzW13vsOWTx59xQczCIJx68n2zWOXRT5YKZsOZXp4qkHN/10x4mw=="],
+    "@oxlint/binding-android-arm-eabi": ["@oxlint/binding-android-arm-eabi@1.79.0", "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.79.0.tgz", { "os": "android", "cpu": "arm" }, "sha512-TebFaaMklO/RXzTv7PucaCq9l3X6D1gA+C8H6K4njtjFOV+zWE9MKLpulcJZN9bzytbUbQIY0mZuz12nQ5Kv4Q=="],
 
-    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.67.0", "", { "os": "android", "cpu": "arm64" }, "sha512-l6+NdYxMoRohix5r5bbigW16LPicceCwGcQ6LKKuE1kUdjgFfQolJjrJsQYPFetIs78Gxj/G/f5TEGoTCwj9nQ=="],
+    "@oxlint/binding-android-arm64": ["@oxlint/binding-android-arm64@1.79.0", "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.79.0.tgz", { "os": "android", "cpu": "arm64" }, "sha512-KqqnOtAVgNsPPF0YSodkFZA1O80jcKoCZCTu3bgsszxA+MrMP9TLzfXitKjEj1FmrPprKDMdRDMmY3weESO9sg=="],
 
-    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.67.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-jOzXxS1AxFxhImLIRbtGIMrEwaXcgMw3gR57WB1cRk8ai+vpr6726kxXqVvlNsrXtJ/FrmOm8RxlC0m8SW24Qg=="],
+    "@oxlint/binding-darwin-arm64": ["@oxlint/binding-darwin-arm64@1.79.0", "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.79.0.tgz", { "os": "darwin", "cpu": "arm64" }, "sha512-BVC2nsMzqQzRDPc5RhixkZ+m1p7iH4bxRRvqkbwDXX0PlQKm1BPy8J8cRjnAFafOq2QzI+BfO3vE8w2GZ3CBag=="],
 
-    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.67.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-3DFAVY94OqjIZHXIPz37yGRSWwOFTAqChQ64/M69GYLawzP0KiwdhDNfqdKKYT0bTR/DNxmMnQsj3ns+8+X/Lg=="],
+    "@oxlint/binding-darwin-x64": ["@oxlint/binding-darwin-x64@1.79.0", "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.79.0.tgz", { "os": "darwin", "cpu": "x64" }, "sha512-p6Lm+snmhGuLKL1+CpCV8L6ijkE/qJzK2H2jG9+eKJT0n31RbY4FLsdhexekgP3bLpw4Kgde+9DZuDZQ4yIInA=="],
 
-    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.67.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-e4dDKZuLu8TR9DEBssWSDahlPgZBwojTTHZUvnjBRJfJJbpxYCjfjKfi0Z1+CSLMiJBwI2yCDtRM1XJQaARjmg=="],
+    "@oxlint/binding-freebsd-x64": ["@oxlint/binding-freebsd-x64@1.79.0", "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.79.0.tgz", { "os": "freebsd", "cpu": "x64" }, "sha512-qDMm0dXZnoHyRqSL4N4xUq82T4sqK5cbKSjvd/dF/YbMUXc2R1wEPf+vmA5S0qUmi0nwXfNbjXBtZaIqzQLIMg=="],
 
-    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.67.0", "", { "os": "linux", "cpu": "arm" }, "sha512-BKytFdcQzbITV3xlnzDUDTEDtbUMCCiC4EaNTDZ4FyT8gdNvBC4gfiLucXp/sQl0XU3p7syTlorUWVVVBZab2g=="],
+    "@oxlint/binding-linux-arm-gnueabihf": ["@oxlint/binding-linux-arm-gnueabihf@1.79.0", "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.79.0.tgz", { "os": "linux", "cpu": "arm" }, "sha512-2od7s0nuKPzqyUZAWk9KkCyGg7eI9dwFPZg+20lB15fKFkVZ0c9ZFxqPfiBAyDTlTkh9stPI0t+JlPCqMbItVA=="],
 
-    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.67.0", "", { "os": "linux", "cpu": "arm" }, "sha512-XYAv0esBDX7BpTzRDjVX2Vdj+zndd8ll2dFQiaeQ6zTZr7A8GRDTN7fH3FP3jU+O0vCDx85oH/EtG7BzPgAXuw=="],
+    "@oxlint/binding-linux-arm-musleabihf": ["@oxlint/binding-linux-arm-musleabihf@1.79.0", "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.79.0.tgz", { "os": "linux", "cpu": "arm" }, "sha512-ZOQUjkzDnvlhSE3+tWC3YXx94MMl+sYMlwH+u1+YGApGHOJP/YAc8ZBRFOXZ6eOBmxtXAWuS/fBcdZr8qqNO1A=="],
 
-    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.67.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-zizRMjA0i6u/2B0evgda04iycu+MoNuf1pBy6Eh+1CjC5wMEG7qN5zdDKTCvFc0KSYSDM9QTG3gjZHirgtQuKg=="],
+    "@oxlint/binding-linux-arm64-gnu": ["@oxlint/binding-linux-arm64-gnu@1.79.0", "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.79.0.tgz", { "os": "linux", "cpu": "arm64" }, "sha512-lu158FR4nGqGeRS3BQvtG85wRgU/Fy4MD5Cxp1hzJXizGiLo6u2742wJSCDKh8cFcZntvX7fcxlq4mMmfryH1g=="],
 
-    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.67.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-zB/Tf6sUjmmvvbva9Gj3JTJ8rJ9t4I8/U0o6vSRtd0DRIsIuyegBwJAzhSUFQHdMijIRJkW0exs/yBhpw2S20w=="],
+    "@oxlint/binding-linux-arm64-musl": ["@oxlint/binding-linux-arm64-musl@1.79.0", "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.79.0.tgz", { "os": "linux", "cpu": "arm64" }, "sha512-mbpKQeE2aflTjddaHK7MP8KP/OFbUM++lt5M635ENM8IyIdK0jm2t9pb+2v9mVVIvhF6TqA4l7F79Pll1mi+uw=="],
 
-    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.67.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-kgU40Gt74CK0TCsF51KZymkIwN9U0BajKsMijB52zPqOeZU9NAHkA/NSQkZDHEaCakx42DxhXkODiAqf2b4Gug=="],
+    "@oxlint/binding-linux-ppc64-gnu": ["@oxlint/binding-linux-ppc64-gnu@1.79.0", "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.79.0.tgz", { "os": "linux", "cpu": "ppc64" }, "sha512-WpGNua7gaxaHnpSDeog2ji8IDHn/QLPl9LPzwkR/FvVv58vT5BcXjRXnU+wbu3N75cpeha8CdC7ho/U2OIsB4g=="],
 
-    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.67.0", "", { "os": "linux", "cpu": "none" }, "sha512-tOYhkk/iaG9aD3FvGpBFd1Lrw0x0RaVoJBxjUkfNzS50rC5NS5BteNCwgr8A2zCdADrIIoze6D7u6U5Ic++/iQ=="],
+    "@oxlint/binding-linux-riscv64-gnu": ["@oxlint/binding-linux-riscv64-gnu@1.79.0", "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.79.0.tgz", { "os": "linux", "cpu": "none" }, "sha512-tK1E93A5LVzISg4ngpKJnfTs7EqtIUceGI7MQ4GyDjJiLi8wPCkEyKlj2xkyKWZ1yzkDJyLHTBJ5/iFWRdnJvg=="],
 
-    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.67.0", "", { "os": "linux", "cpu": "none" }, "sha512-sEtywrPb+0b+tHYl1SDCrw903fiC4eyKoNqzP3v+f2JT3Xcv4NEYG+P8rj+eEnX7IWhqV/xj8/JmcmVj21CXaA=="],
+    "@oxlint/binding-linux-riscv64-musl": ["@oxlint/binding-linux-riscv64-musl@1.79.0", "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.79.0.tgz", { "os": "linux", "cpu": "none" }, "sha512-qhQvUIrngXivA2A9pQ+xPCychztn/5qUv7yS3gDwXv3w7Rag+eTeeXWmRyx+t7XsW5x6LuY/8AsTq36UgFIblg=="],
 
-    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.67.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-BvR8Moa0zCLxroOx4vZaZN9nUfwAUpSTwjZdxZyKy4bv3PrzrXrxKR/ZQ0L9wNSvlPhnMJeZfa3q5w6ZCTuN6Q=="],
+    "@oxlint/binding-linux-s390x-gnu": ["@oxlint/binding-linux-s390x-gnu@1.79.0", "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.79.0.tgz", { "os": "linux", "cpu": "s390x" }, "sha512-sv6AaVgU/eE6u+6WFiQVDcPPwTxP6IJMSB9k701W2r/r6Tx465e8vPvVyRxquNH4Vy6KwRNu90mVbxXJN8+5gg=="],
 
-    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.67.0", "", { "os": "linux", "cpu": "x64" }, "sha512-mm2cxM6fksOpq6l0uFws8BUGKAR4dNa/cZCn37Npq7PFbhD5HDJqWfnoIvTaeRKMy5XdS2tO0MA0qbHDrnXAAA=="],
+    "@oxlint/binding-linux-x64-gnu": ["@oxlint/binding-linux-x64-gnu@1.79.0", "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.79.0.tgz", { "os": "linux", "cpu": "x64" }, "sha512-iFZL02deziHslb3jEX9KdqlAkYoo4fGyotchKDzdfK1f5mxlIBeiQeHhvK3iFpuEJSB4ma/qeFn9oxPiwnhUPQ=="],
 
-    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.67.0", "", { "os": "linux", "cpu": "x64" }, "sha512-WmbMuLapKyDlobMkXAaAL0Y+Uczh4LETfIfQsUpbId4Ip8Ai82/jqeYTOoUCkuuhBFapgqP253+d83tLKOksJg=="],
+    "@oxlint/binding-linux-x64-musl": ["@oxlint/binding-linux-x64-musl@1.79.0", "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.79.0.tgz", { "os": "linux", "cpu": "x64" }, "sha512-3DtZR2raqObnh7wXZoFYFd0Fw7skBvcb3f7A+/lkEiDuh8hrE6vv9b/62Qxao1a9/OeHLw/FcXlXzgsW9wTRFg=="],
 
-    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.67.0", "", { "os": "none", "cpu": "arm64" }, "sha512-9g/PqxYJelzzTAOR5Y+RiRqdeydhEuXv2KxNeFcAKQ7UsvnWSY1OP4MsuPMbTO2Pf70tz7mFhl1j13H3fyh+8g=="],
+    "@oxlint/binding-openharmony-arm64": ["@oxlint/binding-openharmony-arm64@1.79.0", "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.79.0.tgz", { "os": "none", "cpu": "arm64" }, "sha512-Oatt4GuA1WJkqzk2ozx4HrWROOi7opV3AKDw/U8qDIqeTqzsjn5K2x3REJMNjU3/KU/Bkq96Zi3CknaiDTaC/Q=="],
 
-    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.67.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-2VhwE6Gatb0vJGnN0TBuQMbKCOiZlSQ/zJvVWYLK4a9d4iDiJOen/yVQkGpmsJ90MuH66fzi0kEKI0jRQMDxGA=="],
+    "@oxlint/binding-win32-arm64-msvc": ["@oxlint/binding-win32-arm64-msvc@1.79.0", "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.79.0.tgz", { "os": "win32", "cpu": "arm64" }, "sha512-NAgZr9Qp8nIA9rpo0JEvwiabTF/2UVqBNnupBG9X4kxXcQoScJUTi+qHhvabb9s/thgj5wQ4XcIaJvb+ZMgoKw=="],
 
-    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.67.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-EQ3VExXfeM1InbE5+JjufhZZTWy+kHUwgt3yZR7gQ47Je/mE0WspQPan0OJznh493L5anM210YNJtH1PXjTSFg=="],
+    "@oxlint/binding-win32-ia32-msvc": ["@oxlint/binding-win32-ia32-msvc@1.79.0", "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.79.0.tgz", { "os": "win32", "cpu": "ia32" }, "sha512-+KyXjIvcpaXmWW/j9NNY5yWjrIVxaX18VyIheQy3jwc2GSYgpCr7MGI/HxIGQ/shAL5IWEKbhsqoMpAO5Stiog=="],
 
-    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.67.0", "", { "os": "win32", "cpu": "x64" }, "sha512-bw24y+/1MHS4QDkons3YyHkPT9uCMoLHHgQhb+mb8NOjTYwub1CZ+K9Ngr8aO5DMrDrkqHwTzlTwFP2vS8Y/ZQ=="],
+    "@oxlint/binding-win32-x64-msvc": ["@oxlint/binding-win32-x64-msvc@1.79.0", "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.79.0.tgz", { "os": "win32", "cpu": "x64" }, "sha512-mEelcCMMBS57sIXh2veGMNy+pQwuGtcMxHxGIZWQ5Ba9pJ5jCCUFOZB9E2JhBaxGsURe+WGe0zJp4RVre52gpQ=="],
 
-    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+    "@oxlint/plugins": ["@oxlint/plugins@1.79.0", "https://registry.npmjs.org/@oxlint/plugins/-/plugins-1.79.0.tgz", {}, "sha512-S0uyoxakDINJ4DPgqxGlEEvrdSMeQb7Z2lKVjxoY2gwsbZbfg2Xr8Klfeo5ZeraHmmdBCELFUHkSe6KEmBpMvg=="],
 
-    "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
+    "@types/bun": ["@types/bun@1.3.14", "https://registry.npmjs.org/@types/bun/-/bun-1.3.14.tgz", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
-    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+    "@types/node": ["@types/node@25.9.1", "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
 
-    "oxfmt": ["oxfmt@0.47.0", "", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.47.0", "@oxfmt/binding-android-arm64": "0.47.0", "@oxfmt/binding-darwin-arm64": "0.47.0", "@oxfmt/binding-darwin-x64": "0.47.0", "@oxfmt/binding-freebsd-x64": "0.47.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.47.0", "@oxfmt/binding-linux-arm-musleabihf": "0.47.0", "@oxfmt/binding-linux-arm64-gnu": "0.47.0", "@oxfmt/binding-linux-arm64-musl": "0.47.0", "@oxfmt/binding-linux-ppc64-gnu": "0.47.0", "@oxfmt/binding-linux-riscv64-gnu": "0.47.0", "@oxfmt/binding-linux-riscv64-musl": "0.47.0", "@oxfmt/binding-linux-s390x-gnu": "0.47.0", "@oxfmt/binding-linux-x64-gnu": "0.47.0", "@oxfmt/binding-linux-x64-musl": "0.47.0", "@oxfmt/binding-openharmony-arm64": "0.47.0", "@oxfmt/binding-win32-arm64-msvc": "0.47.0", "@oxfmt/binding-win32-ia32-msvc": "0.47.0", "@oxfmt/binding-win32-x64-msvc": "0.47.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-OFbkbzxKCpooQEnRmpTDnuwTX8KHXzZTQ4Df/hz85fpS67Pl+lxPEFvUtin56HIIS0B1k4X8oIzTXRZPufA2CA=="],
+    "bun-types": ["bun-types@1.3.14", "https://registry.npmjs.org/bun-types/-/bun-types-1.3.14.tgz", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
-    "oxlint": ["oxlint@1.67.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.67.0", "@oxlint/binding-android-arm64": "1.67.0", "@oxlint/binding-darwin-arm64": "1.67.0", "@oxlint/binding-darwin-x64": "1.67.0", "@oxlint/binding-freebsd-x64": "1.67.0", "@oxlint/binding-linux-arm-gnueabihf": "1.67.0", "@oxlint/binding-linux-arm-musleabihf": "1.67.0", "@oxlint/binding-linux-arm64-gnu": "1.67.0", "@oxlint/binding-linux-arm64-musl": "1.67.0", "@oxlint/binding-linux-ppc64-gnu": "1.67.0", "@oxlint/binding-linux-riscv64-gnu": "1.67.0", "@oxlint/binding-linux-riscv64-musl": "1.67.0", "@oxlint/binding-linux-s390x-gnu": "1.67.0", "@oxlint/binding-linux-x64-gnu": "1.67.0", "@oxlint/binding-linux-x64-musl": "1.67.0", "@oxlint/binding-openharmony-arm64": "1.67.0", "@oxlint/binding-win32-arm64-msvc": "1.67.0", "@oxlint/binding-win32-ia32-msvc": "1.67.0", "@oxlint/binding-win32-x64-msvc": "1.67.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.22.1", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-blwwaHPdoH8piQ5/z0KHeoHFR7FZgl12WluKJfu4qFLPkZl6mK04PkLE45Fw1NxfBRSlh40Gu7MkxHUw++ociQ=="],
+    "oxfmt": ["oxfmt@0.47.0", "https://registry.npmjs.org/oxfmt/-/oxfmt-0.47.0.tgz", { "dependencies": { "tinypool": "2.1.0" }, "optionalDependencies": { "@oxfmt/binding-android-arm-eabi": "0.47.0", "@oxfmt/binding-android-arm64": "0.47.0", "@oxfmt/binding-darwin-arm64": "0.47.0", "@oxfmt/binding-darwin-x64": "0.47.0", "@oxfmt/binding-freebsd-x64": "0.47.0", "@oxfmt/binding-linux-arm-gnueabihf": "0.47.0", "@oxfmt/binding-linux-arm-musleabihf": "0.47.0", "@oxfmt/binding-linux-arm64-gnu": "0.47.0", "@oxfmt/binding-linux-arm64-musl": "0.47.0", "@oxfmt/binding-linux-ppc64-gnu": "0.47.0", "@oxfmt/binding-linux-riscv64-gnu": "0.47.0", "@oxfmt/binding-linux-riscv64-musl": "0.47.0", "@oxfmt/binding-linux-s390x-gnu": "0.47.0", "@oxfmt/binding-linux-x64-gnu": "0.47.0", "@oxfmt/binding-linux-x64-musl": "0.47.0", "@oxfmt/binding-openharmony-arm64": "0.47.0", "@oxfmt/binding-win32-arm64-msvc": "0.47.0", "@oxfmt/binding-win32-ia32-msvc": "0.47.0", "@oxfmt/binding-win32-x64-msvc": "0.47.0" }, "bin": { "oxfmt": "bin/oxfmt" } }, "sha512-OFbkbzxKCpooQEnRmpTDnuwTX8KHXzZTQ4Df/hz85fpS67Pl+lxPEFvUtin56HIIS0B1k4X8oIzTXRZPufA2CA=="],
 
-    "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
+    "oxlint": ["oxlint@1.79.0", "https://registry.npmjs.org/oxlint/-/oxlint-1.79.0.tgz", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.79.0", "@oxlint/binding-android-arm64": "1.79.0", "@oxlint/binding-darwin-arm64": "1.79.0", "@oxlint/binding-darwin-x64": "1.79.0", "@oxlint/binding-freebsd-x64": "1.79.0", "@oxlint/binding-linux-arm-gnueabihf": "1.79.0", "@oxlint/binding-linux-arm-musleabihf": "1.79.0", "@oxlint/binding-linux-arm64-gnu": "1.79.0", "@oxlint/binding-linux-arm64-musl": "1.79.0", "@oxlint/binding-linux-ppc64-gnu": "1.79.0", "@oxlint/binding-linux-riscv64-gnu": "1.79.0", "@oxlint/binding-linux-riscv64-musl": "1.79.0", "@oxlint/binding-linux-s390x-gnu": "1.79.0", "@oxlint/binding-linux-x64-gnu": "1.79.0", "@oxlint/binding-linux-x64-musl": "1.79.0", "@oxlint/binding-openharmony-arm64": "1.79.0", "@oxlint/binding-win32-arm64-msvc": "1.79.0", "@oxlint/binding-win32-ia32-msvc": "1.79.0", "@oxlint/binding-win32-x64-msvc": "1.79.0" }, "peerDependencies": { "oxlint-tsgolint": ">=7.0.2001", "vite-plus": "*" }, "optionalPeers": ["oxlint-tsgolint", "vite-plus"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-hVJ9hq9m2unPS+Of4eJJgCPdIeCC+3DHEUX3tkmrPJr3OK2hz7PhXwgC+ZP71ZcYu8cCDEtQrqLxWNvxBppBVg=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "tinypool": ["tinypool@2.1.0", "https://registry.npmjs.org/tinypool/-/tinypool-2.1.0.tgz", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
 
-    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+    "typescript": ["typescript@5.9.3", "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@7.24.6", "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
   }
 }

--- a/e2e/binary.smoke.ts
+++ b/e2e/binary.smoke.ts
@@ -18,7 +18,13 @@ let smokeHome = '';
 
 // Every case runs with tmux unreachable so the binary's degrade-gracefully
 // paths are what's exercised (and nothing depends on a live server).
-function run(args: string[]): { code: number; stdout: string; stderr: string } {
+interface ProcResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+function run(args: string[]): ProcResult {
   const proc = Bun.spawnSync({
     cmd: [BIN, ...args],
     stdout: 'pipe',

--- a/e2e/harness.e2e.ts
+++ b/e2e/harness.e2e.ts
@@ -21,6 +21,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { loadAgentDirs, type AgentDir } from '../src/agents/config.ts';
+import type { JsonObject } from '../src/json.ts';
 import { fullRefreshStates, fullRefreshStatesTui } from '../src/state/refresh.ts';
 import { TmuxControlClient } from '../src/tmux/control.ts';
 import { resolvePermitKeys } from '../src/state/permit-keys.ts';
@@ -52,7 +53,18 @@ let tmuxEnv = '';
 let dirs: AgentDir[] = [];
 const savedEnv: Record<string, string | undefined> = {};
 
-function tm(args: string[]): { code: number; stdout: string; stderr: string } {
+interface ProcResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+interface SessionInfo {
+  name: string;
+  pane: string;
+}
+
+function tm(args: string[]): ProcResult {
   const p = Bun.spawnSync({ cmd: ['tmux', '-S', sock, ...args], stdout: 'pipe', stderr: 'pipe' });
   return { code: p.exitCode ?? -1, stdout: p.stdout.toString(), stderr: p.stderr.toString() };
 }
@@ -61,7 +73,7 @@ const tmOut = (args: string[]) => tm(args).stdout.trim();
 // Spawn the compiled binary against the private server, with the temp XDG home
 // so it reads our agents.json. TMUX carries the socket in its first comma-field,
 // which is exactly how tmux resolves the server when no -L/-S is passed.
-function fleet(args: string[], env: Record<string, string> = {}): { code: number; stdout: string; stderr: string } {
+function fleet(args: string[], env: Record<string, string> = {}): ProcResult {
   const p = Bun.spawnSync({
     cmd: [BIN, ...args],
     stdout: 'pipe',
@@ -74,7 +86,7 @@ function fleet(args: string[], env: Record<string, string> = {}): { code: number
 let sessionSeq = 0;
 // Create an isolated session and return [sessionName, paneId]. Fixed geometry
 // keeps scraped screens deterministic across machines.
-function newSession(): { name: string; pane: string } {
+function newSession(): SessionInfo {
   const name = `e2e${++sessionSeq}`;
   tm(['new-session', '-d', '-s', name, '-x', '120', '-y', '40']);
   const pane = tmOut(['list-panes', '-t', name, '-F', '#{pane_id}']).split('\n')[0]!;
@@ -83,7 +95,7 @@ function newSession(): { name: string; pane: string } {
 
 // Same, but with the pane's start directory set to `dir` so pane_current_path
 // (and thus git metadata) resolves against a known worktree.
-function newSessionIn(dir: string): { name: string; pane: string } {
+function newSessionIn(dir: string): SessionInfo {
   const name = `e2e${++sessionSeq}`;
   tm(['new-session', '-d', '-s', name, '-x', '120', '-y', '40', '-c', dir]);
   const pane = tmOut(['list-panes', '-t', name, '-F', '#{pane_id}']).split('\n')[0]!;
@@ -115,7 +127,7 @@ function eventsPath(pane: string): string {
 }
 
 // Write a hook .status file keyed to a real pane id (what hooks/lib.sh writes).
-function writeStatus(pane: string, session: string, fields: Record<string, unknown> = {}): void {
+function writeStatus(pane: string, session: string, fields: JsonObject = {}): void {
   const data = { state: 'idle', pane, session, tool: '', ts: nowSec(), tmux_pid: 0, ...fields };
   writeFileSync(statusPath(pane), JSON.stringify(data) + '\n');
 }
@@ -306,6 +318,7 @@ suite('pane presence reconciliation (Present | Absent | Unknown)', () => {
     writeStatus(pane, name, { state: 'working', ts: nowSec() - 181 });
     const r = fleet(['reconcile']);
     expect(r.code).toBe(0);
+    // SAFETY: reconcile rewrote this status file above; it carries the state key.
     const updated = JSON.parse(readFileSync(statusPath(pane), 'utf-8')) as { state: string };
     expect(updated.state).toBe('idle');
   });

--- a/e2e/release-matrix.test.ts
+++ b/e2e/release-matrix.test.ts
@@ -12,19 +12,23 @@ import { join } from 'node:path';
 const WORKFLOW = join(import.meta.dir, '..', '.github', 'workflows', 'release.yml');
 const FORMULA = join(import.meta.dir, '..', 'Formula', 'fleet.rb');
 
+interface StringMap {
+  [key: string]: string;
+}
+
 // bun compile target -> published tarball basename. Every platform we ship
 // lives here; arm64 keeps the `arm64` token (like darwin-arm64) so mise's
 // github backend can match the host, while x64 is spelled `x86_64`.
-const EXPECTED: Record<string, string> = {
+const EXPECTED: StringMap = {
   'bun-darwin-arm64': 'fleet-darwin-arm64',
   'bun-darwin-x64': 'fleet-darwin-x86_64',
   'bun-linux-x64': 'fleet-linux-x86_64',
   'bun-linux-arm64': 'fleet-linux-arm64',
 };
 
-function parseMatrix(): Record<string, string> {
+function parseMatrix(): StringMap {
   const yml = readFileSync(WORKFLOW, 'utf8');
-  const pairs: Record<string, string> = {};
+  const pairs: StringMap = {};
   const re = /target:\s*(\S+)\s*\n\s*artifact:\s*(\S+)/g;
   let m: RegExpExecArray | null;
   while ((m = re.exec(yml)) !== null) {
@@ -46,9 +50,9 @@ function parseFormulaAssets(): Set<string> {
 }
 
 // asset filename -> the shell var the release job substitutes into the tap.
-function parseChecksumMap(): Record<string, string> {
+function parseChecksumMap(): StringMap {
   const yml = readFileSync(WORKFLOW, 'utf8');
-  const map: Record<string, string> = {};
+  const map: StringMap = {};
   const re = /'(fleet-[a-z0-9_-]+\.tar\.gz)':\s*'\$\{(SHA_\w+)\}'/g;
   let m: RegExpExecArray | null;
   while ((m = re.exec(yml)) !== null) {
@@ -58,9 +62,9 @@ function parseChecksumMap(): Record<string, string> {
 }
 
 // shell var -> the asset it is computed from via `shasum -a 256 <asset>`.
-function parseChecksumSources(): Record<string, string> {
+function parseChecksumSources(): StringMap {
   const yml = readFileSync(WORKFLOW, 'utf8');
-  const src: Record<string, string> = {};
+  const src: StringMap = {};
   const re = /(SHA_\w+)=\$\(shasum -a 256 (fleet-[a-z0-9_-]+\.tar\.gz)/g;
   let m: RegExpExecArray | null;
   while ((m = re.exec(yml)) !== null) {

--- a/hooks/pi/fleet-pi.test.ts
+++ b/hooks/pi/fleet-pi.test.ts
@@ -4,6 +4,19 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import piDefault, { buildPiStatusLine, fleetPiLabel, isPiQuestionTool } from './fleet-pi.ts';
 import { parseStatusFile } from '../../src/state/hooks.ts';
+import type { JsonValue } from '../../src/json.ts';
+
+// Handlers the extension registers, captured by the mock pi below so tests can
+// fire them. Event payloads are JSON-shaped (pi serializes tool args as JSON).
+interface HandlerMap {
+  [event: string]: (event?: JsonValue) => void;
+}
+
+interface SavedEnv {
+  TMUX: string | undefined;
+  TMUX_PANE: string | undefined;
+  FLEET_PI_STATUS_DIR: string | undefined;
+}
 
 describe('fleetPiLabel', () => {
   test('bash: collapses whitespace and truncates to 48 chars', () => {
@@ -67,7 +80,7 @@ describe('buildPiStatusLine', () => {
 
 describe('extension event wiring', () => {
   let statusDir: string;
-  let saved: Record<string, string | undefined>;
+  let saved: SavedEnv;
 
   beforeEach(() => {
     statusDir = mkdtempSync(join(tmpdir(), 'fleet-pi-test-'));
@@ -88,21 +101,23 @@ describe('extension event wiring', () => {
   });
 
   // Capture the handlers the extension registers so the test can fire them.
-  function loadWithTmux(pane: string): Record<string, (e?: unknown) => void> {
+  function loadWithTmux(pane: string): HandlerMap {
     process.env.TMUX = '/tmp/fake-tmux,1,0';
     process.env.TMUX_PANE = pane;
-    const handlers: Record<string, (e?: unknown) => void> = {};
+    const handlers: HandlerMap = {};
     const mockPi = {
-      on(event: string, handler: (e?: unknown) => void): void {
+      on(event: string, handler: (event?: JsonValue) => void): void {
         handlers[event] = handler;
       },
       events: {
-        on(event: string, handler: (e?: unknown) => void): void {
+        on(event: string, handler: (event?: JsonValue) => void): void {
           handlers[event] = handler;
         },
       },
     };
-    piDefault(mockPi as unknown as Parameters<typeof piDefault>[0]);
+    // SAFETY: mockPi implements only the on()/events surface piDefault touches; the
+    // captured handler type is deliberately looser than pi's per-event handler types.
+    piDefault(mockPi as Parameters<typeof piDefault>[0]);
     return handlers;
   }
 
@@ -170,13 +185,14 @@ describe('extension event wiring', () => {
   test('outside tmux: registers no handlers and writes nothing', () => {
     delete process.env.TMUX;
     process.env.TMUX_PANE = '%1';
-    const handlers: Record<string, (e?: unknown) => void> = {};
+    const handlers: HandlerMap = {};
     const mockPi = {
-      on(event: string, handler: (e?: unknown) => void): void {
+      on(event: string, handler: (event?: JsonValue) => void): void {
         handlers[event] = handler;
       },
     };
-    piDefault(mockPi as unknown as Parameters<typeof piDefault>[0]);
+    // SAFETY: mockPi implements only the on() surface piDefault touches.
+    piDefault(mockPi as Parameters<typeof piDefault>[0]);
     expect(Object.keys(handlers)).toHaveLength(0);
     // status dir stays empty
     writeFileSync(join(statusDir, 'sentinel'), 'x'); // prove the dir is otherwise empty of .status

--- a/hooks/pi/fleet-pi.ts
+++ b/hooks/pi/fleet-pi.ts
@@ -41,13 +41,28 @@ import { join } from 'node:path';
 // pi's real handler signature is (event, ctx) => void | Promise<void>; narrower
 // handlers (fewer params, void return) are assignable, so these compile against
 // pi's real `on` at load time. See pi's docs/extensions.md for the full surface.
-interface PiToolExecutionStartEvent {
-  toolName: string;
-  args: unknown;
+//
+// Local copy of fleet's JsonValue boundary type (src/json.ts): this file is
+// loaded standalone by pi and imports nothing from fleet (see header), so the
+// type is duplicated here rather than imported.
+type JsonValue = string | number | boolean | null | JsonValue[] | JsonObject;
+type JsonObject = { [key: string]: JsonValue };
+
+function isJsonObject(value: JsonValue | undefined): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
-interface PiToolEvent {
-  toolName: string;
+
+function isString(value: JsonValue | undefined): value is string {
+  return typeof value === 'string';
 }
+
+type PiToolExecutionStartEvent = {
+  toolName: string;
+  args: JsonValue;
+};
+type PiToolEvent = {
+  toolName: string;
+};
 interface PiExtensionAPI {
   on(event: 'session_start' | 'agent_start' | 'agent_end' | 'session_shutdown', handler: () => void): void;
   on(event: 'tool_execution_start', handler: (event: PiToolExecutionStartEvent) => void): void;
@@ -73,9 +88,9 @@ export function isPiQuestionTool(toolName: string): boolean {
   return normalized === 'askuserquestion' || normalized === 'ask_user_question';
 }
 
-export function fleetPiLabel(toolName: string, args: unknown): string {
-  const a = (args ?? {}) as Record<string, unknown>;
-  const str = (v: unknown): string => (typeof v === 'string' ? v : '');
+export function fleetPiLabel(toolName: string, args: JsonValue | undefined): string {
+  const a: JsonObject = isJsonObject(args) ? args : {};
+  const str = (v: JsonValue | undefined): string => (isString(v) ? v : '');
   const cap = toolName ? toolName.charAt(0).toUpperCase() + toolName.slice(1) : '';
   if (toolName === 'bash') {
     const cmd = str(a.command).replace(/\s+/g, ' ').trim().slice(0, 48);

--- a/index.ts
+++ b/index.ts
@@ -607,7 +607,7 @@ async function launchTui(): Promise<number> {
     };
 
     process.stdin.on('data', (chunk: Buffer | string) => {
-      const buf = typeof chunk === 'string' ? Buffer.from(chunk, 'utf8') : chunk;
+      const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, 'utf8');
       handleInput(buf);
       tick();
     });

--- a/package.json
+++ b/package.json
@@ -29,9 +29,10 @@
     "check:deps": "bun run scripts/check-no-runtime-deps.ts"
   },
   "devDependencies": {
+    "@oxlint/plugins": "1.79.0",
     "@types/bun": "latest",
     "oxfmt": "^0.47.0",
-    "oxlint": "^1.62.0"
+    "oxlint": "1.79.0"
   },
   "peerDependencies": {
     "typescript": "^5"

--- a/scripts/check-no-runtime-deps.ts
+++ b/scripts/check-no-runtime-deps.ts
@@ -6,6 +6,8 @@
 
 import pkg from '../package.json' with { type: 'json' };
 
+// SAFETY: pkg is this repo's own package.json via a JSON import; the guard below
+// only reads these four keys, so the manifest just needs their names.
 const manifest = pkg as {
   dependencies?: Record<string, string>;
   optionalDependencies?: Record<string, string>;

--- a/src/agents/config.test.ts
+++ b/src/agents/config.test.ts
@@ -11,8 +11,8 @@ describe('loadAgentDirs', () => {
   test('each dir has name and statusDir', () => {
     const dirs = loadAgentDirs();
     for (const dir of dirs) {
-      expect(typeof dir.name).toBe('string');
-      expect(typeof dir.statusDir).toBe('string');
+      expect(dir.name).toEqual(expect.any(String));
+      expect(dir.statusDir).toEqual(expect.any(String));
     }
   });
 });

--- a/src/agents/config.ts
+++ b/src/agents/config.ts
@@ -2,6 +2,8 @@ import { existsSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
+import { isJsonObject, isString, type JsonObject, type JsonValue } from '../json.ts';
+
 export interface AgentDir {
   name: string;
   statusDir: string;
@@ -32,19 +34,14 @@ export function loadAgentDirs(): AgentDir[] {
   const newConfig = join(configDir, 'fleet', 'agents.json');
   if (existsSync(newConfig)) {
     try {
-      const data = JSON.parse(readFileSync(newConfig, 'utf-8')) as { agents?: unknown[] };
-      if (data.agents && Array.isArray(data.agents)) {
-        if (data.agents.length === 0) return []; // deliberately empty — no fallback
+      // SAFETY: JSON.parse returns any; JsonValue is the sound type of any JSON document.
+      const parsed = JSON.parse(readFileSync(newConfig, 'utf-8')) as JsonValue;
+      if (isJsonObject(parsed) && Array.isArray(parsed.agents)) {
+        if (parsed.agents.length === 0) return []; // deliberately empty — no fallback
         // Per-entry validation: one malformed entry must not discard the whole
         // file (the catch below would silently drop every valid agent).
-        const valid = data.agents
-          .filter(
-            (a): a is AgentDir =>
-              typeof a === 'object' &&
-              a !== null &&
-              typeof (a as AgentDir).name === 'string' &&
-              typeof (a as AgentDir).statusDir === 'string',
-          )
+        const valid = parsed.agents
+          .filter((a): a is AgentDir & JsonObject => isJsonObject(a) && isString(a.name) && isString(a.statusDir))
           .map((a) => ({
             name: a.name,
             statusDir: a.statusDir.replace(/^~/, HOME),

--- a/src/agents/discovery.ts
+++ b/src/agents/discovery.ts
@@ -51,14 +51,23 @@ export function normalizeComm(comm: string): string {
 }
 
 // Parse `ps -eo pid=,ppid=,comm=` lines into pid->comm and pid->ppid maps. The
+// A discovery pass's output: the agents found plus the debounce map to persist
+// for the next tick.
+export interface DiscoveryScan {
+  agents: DiscoveredAgent[];
+  lastWorking: Map<string, number>;
+}
+
 // `=` suffixes suppress headers, so every non-blank line is a record: leading
 // pad, right-aligned pid, ppid, then comm (which may itself contain spaces or a
 // path, so it is the whole remainder of the line). comm is normalized at parse
 // time so callers compare against bare command names.
-export function parsePsTable(psTable: string[]): {
+interface PsTable {
   commByPid: Map<number, string>;
   ppidByPid: Map<number, number>;
-} {
+}
+
+export function parsePsTable(psTable: string[]): PsTable {
   const commByPid = new Map<number, string>();
   const ppidByPid = new Map<number, number>();
   for (const line of psTable) {
@@ -116,7 +125,7 @@ export function discoverAgents(
   panePids: Map<number, string>,
   captures: Map<string, string>,
   opts: DiscoveryOpts,
-): { agents: DiscoveredAgent[]; lastWorking: Map<string, number> } {
+): DiscoveryScan {
   const agents: DiscoveredAgent[] = [];
   const nextLastWorking = new Map<string, number>();
 
@@ -328,7 +337,7 @@ export function scanDiscovered(
   lastWorking: Map<string, number>,
   now: number,
   config?: DiscoveryConfig,
-): { agents: DiscoveredAgent[]; lastWorking: Map<string, number> } {
+): DiscoveryScan {
   const cfg = config ?? readDiscoveryConfig();
   if (!cfg.enabled) return { agents: [], lastWorking: new Map() };
 

--- a/src/agents/integrations.test.ts
+++ b/src/agents/integrations.test.ts
@@ -23,7 +23,7 @@ describe('integration registry', () => {
     expect(integrationKeys()).toEqual(['claude', 'codex', 'pi']);
     for (const i of INTEGRATIONS) {
       expect(i.manifestKey).toBe(i.key); // current integrations map 1:1
-      expect(typeof i.label).toBe('string');
+      expect(i.label).toEqual(expect.any(String));
       expect(i.label.length).toBeGreaterThan(0);
     }
   });

--- a/src/cli/install-codex.test.ts
+++ b/src/cli/install-codex.test.ts
@@ -30,6 +30,7 @@ interface AgentsDoc {
 }
 
 let workDir: string;
+// SAFETY: test-local helper — each call site names the shape of the file the test just wrote.
 const readJson = <T>(p: string): T => JSON.parse(readFileSync(p, 'utf8')) as T;
 
 beforeEach(() => {

--- a/src/cli/install-codex.ts
+++ b/src/cli/install-codex.ts
@@ -3,6 +3,7 @@ import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fleetPluginDir, linkPluginDir } from './install.ts';
 import { CODEX_STATUS_DIR, loadAgentDirs, type AgentDir } from '../agents/config.ts';
+import { isString } from '../json.ts';
 
 // Codex is configured entirely by editing its own files — no marketplace, no
 // `claude plugin` CLI, no $CLAUDE_PLUGIN_ROOT. `fleet install codex` is a
@@ -64,12 +65,14 @@ function codexEntry(script: string, event: string): CodexHookEntry {
 }
 
 function isFleetEntry(entry: CodexHookEntry): boolean {
-  return (entry.hooks ?? []).some((h) => typeof h.command === 'string' && h.command.includes(FLEET_HOOK_MARKER));
+  return (entry.hooks ?? []).some((h) => isString(h.command) && h.command.includes(FLEET_HOOK_MARKER));
 }
 
 // Add fleet's PreToolUse+Stop entries, preserving any the user already has.
 // Throws on malformed JSON (the caller aborts without writing — never clobber).
 export function addCodexHooks(path: string, script: string): void {
+  // SAFETY: every read below re-validates with ?? and some(); a malformed shape
+  // throws from JSON.parse or degrades to appending, never clobbering other keys.
   const doc: CodexHooksDoc = existsSync(path)
     ? (JSON.parse(readFileSync(path, 'utf8')) as CodexHooksDoc)
     : { hooks: {} };
@@ -84,6 +87,7 @@ export function addCodexHooks(path: string, script: string): void {
 // Remove exactly fleet's entries; leave the user's own hooks intact.
 export function removeCodexHooks(path: string): void {
   if (!existsSync(path)) return;
+  // SAFETY: every read below re-validates with Array.isArray before touching an entry.
   const doc = JSON.parse(readFileSync(path, 'utf8')) as CodexHooksDoc;
   if (!doc.hooks) return;
   for (const ev of CODEX_EVENTS) {
@@ -103,6 +107,7 @@ function hasAnyHookEntries(hooksJsonPath: string): boolean {
   if (!existsSync(hooksJsonPath)) return false;
   let doc: CodexHooksDoc;
   try {
+    // SAFETY: only .hooks is read, via ?? and Array.isArray re-validation below.
     doc = JSON.parse(readFileSync(hooksJsonPath, 'utf8')) as CodexHooksDoc;
   } catch {
     return true;
@@ -173,6 +178,7 @@ export function upsertAgentEntry(path: string, entry: AgentDir, seed: AgentDir[]
   let agents: AgentDir[] = [...seed];
   if (existsSync(path)) {
     try {
+      // SAFETY: only .agents is read, behind an Array.isArray re-validation.
       const doc = JSON.parse(readFileSync(path, 'utf8')) as AgentsDoc;
       if (Array.isArray(doc.agents)) agents = doc.agents;
     } catch {
@@ -190,6 +196,7 @@ export function removeAgentEntry(path: string, name: string): void {
   if (!existsSync(path)) return;
   let agents: AgentDir[];
   try {
+    // SAFETY: only .agents is read, behind an Array.isArray re-validation.
     const doc = JSON.parse(readFileSync(path, 'utf8')) as AgentsDoc;
     agents = Array.isArray(doc.agents) ? doc.agents : [];
   } catch {

--- a/src/cli/install-pi.ts
+++ b/src/cli/install-pi.ts
@@ -4,6 +4,7 @@ import { dirname, join, relative, resolve } from 'node:path';
 import { fleetPluginDir } from './install.ts';
 import { agentsJsonPath, removeAgentEntry, seededAgentDirs, upsertAgentEntry, withTilde } from './install-codex.ts';
 import { PI_STATUS_DIR } from '../agents/config.ts';
+import { isJsonObject, isString, type JsonValue } from '../json.ts';
 
 // pi (npm: @earendil-works/pi-coding-agent) has no shell-hook config; it loads
 // package extensions from `packages` in ~/.pi/agent/settings.json (see pi's
@@ -20,8 +21,8 @@ const PI_EXTENSION_LINK = join(PI_EXTENSIONS_DIR, 'fleet-pi.ts');
 const PI_STATUS_DIR_CONFIG = '~/.cache/pi-status';
 
 interface PiSettingsDoc {
-  packages?: unknown[];
-  [key: string]: unknown;
+  packages?: JsonValue[];
+  [key: string]: JsonValue | undefined;
 }
 
 function piSettingsPath(): string {
@@ -39,6 +40,8 @@ function canonicalPiPackageSource(packageDir: string): string {
 function readPiSettings(path: string): PiSettingsDoc | null {
   if (!existsSync(path)) return null;
   try {
+    // SAFETY: fleet only reads .packages (re-validated with Array.isArray at every
+    // use); all other keys pass through untouched, so unknown shapes degrade safely.
     return JSON.parse(readFileSync(path, 'utf8')) as PiSettingsDoc;
   } catch {
     return null; // malformed — leave the user's settings untouched
@@ -56,21 +59,20 @@ function writePiSettings(path: string, doc: PiSettingsDoc): void {
 // exactly `packageDir` or pi's normalized relative form. A legacy entry
 // pointing at a symlinked source is repaired by packageDirsToRemove below
 // rather than by string surgery.
-export function piPackageEntryMatches(entry: unknown, packageDir: string): boolean {
+export function piPackageEntryMatches(entry: JsonValue, packageDir: string): boolean {
   const relativeDir = canonicalPiPackageSource(packageDir);
   const matches = (source: string): boolean => source === packageDir || source === relativeDir;
-  if (typeof entry === 'string') return matches(entry);
-  if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) return false;
-  const source = (entry as { source?: unknown }).source;
-  return typeof source === 'string' && matches(source);
+  if (isString(entry)) return matches(entry);
+  if (!isJsonObject(entry)) return false;
+  return isString(entry.source) && matches(entry.source);
 }
 
-export function upsertPiPackageEntry(packages: unknown[], packageDir: string): unknown[] {
+export function upsertPiPackageEntry(packages: JsonValue[], packageDir: string): JsonValue[] {
   if (packages.some((entry) => piPackageEntryMatches(entry, packageDir))) return packages;
   return [...packages, canonicalPiPackageSource(packageDir)];
 }
 
-function removePiPackageEntry(packages: unknown[], packageDir: string): unknown[] {
+function removePiPackageEntry(packages: JsonValue[], packageDir: string): JsonValue[] {
   return packages.filter((entry) => !piPackageEntryMatches(entry, packageDir));
 }
 

--- a/src/cli/reconcile.ts
+++ b/src/cli/reconcile.ts
@@ -4,6 +4,7 @@ import { loadAgentDirs } from '../agents/config.ts';
 import { parseStatusFile, writeFileAtomic } from '../state/hooks.ts';
 import { classifyPane, isDeletable, livePaneSet } from '../state/presence.ts';
 import { listPanesResult } from '../tmux/sessions.ts';
+import { isJsonObject, type JsonValue } from '../json.ts';
 
 export function runReconcile(dryRun: boolean, verbose: boolean): number {
   const dirs = loadAgentDirs();
@@ -75,7 +76,9 @@ export function runReconcile(dryRun: boolean, verbose: boolean): number {
         if (age >= 180) {
           log(`STALE: ${path} (working for ${age}s)`);
           if (!dryRun) {
-            const data = JSON.parse(content) as Record<string, unknown>;
+            // SAFETY: JSON.parse returns any; JsonValue is the sound type of any JSON document.
+            const data = JSON.parse(content) as JsonValue;
+            if (!isJsonObject(data)) continue;
             data.state = 'idle';
             writeFileAtomic(path, JSON.stringify(data) + '\n');
           }

--- a/src/cli/schema.test.ts
+++ b/src/cli/schema.test.ts
@@ -230,7 +230,7 @@ describe('outcomeExitCode', () => {
       'stale_data',
       'unknown',
     ];
-    for (const o of outcomes) expect(typeof outcomeExitCode(o)).toBe('number');
+    for (const o of outcomes) expect(outcomeExitCode(o)).toEqual(expect.any(Number));
   });
 });
 

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -130,10 +130,12 @@ export function windowColorArgs(states: AgentState[]): string[][] {
 // whether it was a cache hit. Split out so the short-circuit is testable without
 // a real tmux/filesystem — the thin CLI shell in index.ts wires real I/O around
 // it.
-export function resolveStatusLineSegment(
-  cached: string | null,
-  computeLive: () => string,
-): { segment: string; hit: boolean } {
+export interface StatusLineResolution {
+  segment: string;
+  hit: boolean;
+}
+
+export function resolveStatusLineSegment(cached: string | null, computeLive: () => string): StatusLineResolution {
   if (cached !== null) return { segment: cached, hit: true };
   return { segment: computeLive(), hit: false };
 }

--- a/src/cli/wait.ts
+++ b/src/cli/wait.ts
@@ -22,7 +22,7 @@ export interface RunWaitOptions {
 // display labels (STATUS_DISPLAY, types.ts) and the raw enum names are accepted.
 // There is no READY enum — 'ready' is DONE's display label. SHELL/DOWN are
 // intentionally omitted: they are not meaningful orchestration targets.
-const WAIT_STATES: Record<string, AgentStatus> = {
+const WAIT_STATES = {
   // display labels (STATUS_DISPLAY)
   ready: AgentStatus.DONE, // NOTE: 'ready' is DONE's label; there is no READY enum
   waiting: AgentStatus.PERMIT,
@@ -34,10 +34,13 @@ const WAIT_STATES: Record<string, AgentStatus> = {
   permit: AgentStatus.PERMIT,
   question: AgentStatus.QUESTION,
   busy: AgentStatus.BUSY,
-};
+} satisfies Record<string, AgentStatus>;
 
 export function parseWaitState(input: string): AgentStatus | null {
-  return WAIT_STATES[input.trim().toLowerCase()] ?? null;
+  const key = input.trim().toLowerCase();
+  if (!Object.hasOwn(WAIT_STATES, key)) return null;
+  // SAFETY: the Object.hasOwn check above proves key is a member of WAIT_STATES.
+  return WAIT_STATES[key as keyof typeof WAIT_STATES];
 }
 
 export interface ParsedWaitArgs {

--- a/src/cli/watch.test.ts
+++ b/src/cli/watch.test.ts
@@ -53,13 +53,13 @@ describe('diffStates', () => {
   });
 
   test('an unchanged status emits nothing', () => {
-    const prev = new Map([['%1', AgentStatus.BUSY as string]]);
+    const prev = new Map<string, string>([['%1', AgentStatus.BUSY]]);
     const { changes } = diffStates(prev, [makeState({ paneId: '%1', status: AgentStatus.BUSY })], 10);
     expect(changes).toHaveLength(0);
   });
 
   test('a status change emits one line with from/to and the full agent view', () => {
-    const prev = new Map([['%1', AgentStatus.BUSY as string]]);
+    const prev = new Map<string, string>([['%1', AgentStatus.BUSY]]);
     const { changes } = diffStates(prev, [makeState({ paneId: '%1', status: AgentStatus.DONE })], 20);
     expect(changes).toHaveLength(1);
     expect(changes[0]!.from).toBe(AgentStatus.BUSY);
@@ -93,7 +93,7 @@ describe('diffStates', () => {
   });
 
   test('a disappearance emits to: null with a null agent view', () => {
-    const prev = new Map([['%1', AgentStatus.BUSY as string]]);
+    const prev = new Map<string, string>([['%1', AgentStatus.BUSY]]);
     const { changes, next } = diffStates(prev, [], 30);
     expect(changes).toHaveLength(1);
     expect(changes[0]!.from).toBe(AgentStatus.BUSY);
@@ -160,6 +160,7 @@ describe('runWatch', () => {
 
   test('emits a disappearance change when a pane vanishes', async () => {
     const lines = await drive([[makeState({ paneId: '%1', status: AgentStatus.BUSY })], []]);
+    // SAFETY: the find predicate above selects l.type === 'change', which is exactly ChangeLine.
     const change = lines.find((l) => l.type === 'change') as ChangeLine;
     expect(change.to).toBeNull();
     expect(change.pane).toBe('%1');

--- a/src/cli/watch.ts
+++ b/src/cli/watch.ts
@@ -52,12 +52,17 @@ export function selectAgents(states: AgentState[], selectors: string[]): AgentSt
 // Pure diff: compare the previous per-pane status map to the current agents and
 // return one change line per pane whose status changed, appeared, or vanished.
 // Returns the change lines plus the next status map to carry forward.
+export interface StatesDiff {
+  changes: ChangeLine[];
+  next: Map<string, string>;
+}
+
 export function diffStates(
   prev: Map<string, string>,
   agents: AgentState[],
   now: number,
   groupAgents: AgentState[] = agents,
-): { changes: ChangeLine[]; next: Map<string, string> } {
+): StatesDiff {
   const next = new Map<string, string>();
   const changes: ChangeLine[] = [];
   const byPane = new Map<string, AgentState>();

--- a/src/json.ts
+++ b/src/json.ts
@@ -1,0 +1,17 @@
+// Boundary types + guards for untrusted JSON input. Assert `JSON.parse` output
+// to JsonValue once at the I/O boundary (with a SAFETY comment), then narrow
+// with these guards instead of ad-hoc `typeof` checks.
+export type JsonValue = string | number | boolean | null | JsonValue[] | JsonObject;
+export type JsonObject = { [key: string]: JsonValue };
+
+export function isJsonObject(value: JsonValue | undefined): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function isString(value: JsonValue | undefined): value is string {
+  return typeof value === 'string';
+}
+
+export function isNumber(value: JsonValue | undefined): value is number {
+  return typeof value === 'number';
+}

--- a/src/notify/transitions.ts
+++ b/src/notify/transitions.ts
@@ -23,10 +23,12 @@ export interface Notification {
 // drops out naturally (no stale entries, no unbounded growth). A transition only
 // fires when the pane's prior status was BUSY — a pane first observed already
 // stopped has no BUSY predecessor and never false-fires (the arming condition).
-export function decideNotifications(
-  states: AgentState[],
-  previous: Map<string, AgentStatus>,
-): { candidates: Notification[]; previous: Map<string, AgentStatus> } {
+interface NotificationDecision {
+  candidates: Notification[];
+  previous: Map<string, AgentStatus>;
+}
+
+export function decideNotifications(states: AgentState[], previous: Map<string, AgentStatus>): NotificationDecision {
   const next = new Map<string, AgentStatus>();
   const candidates: Notification[] = [];
   for (const s of states) {

--- a/src/state/acknowledge.ts
+++ b/src/state/acknowledge.ts
@@ -9,20 +9,21 @@
 
 import { deriveStatusFromEvents } from './events.ts';
 import { AgentStatus, type EventEntry } from './types.ts';
+import type { JsonObject } from '../json.ts';
 
 const READY_HOOK_STATES = new Set(['done', 'completed']);
 
 // Given the current parsed status-file object, return the updated object that
 // marks the agent acknowledged (idle), or null if it isn't in a ready state —
 // we only clear finished turns, never a working/waiting/asking agent.
-export function acknowledgedStatus(current: Record<string, unknown>, now: number): Record<string, unknown> | null {
+export function acknowledgedStatus(current: JsonObject, now: number): JsonObject | null {
   if (!READY_HOOK_STATES.has(String(current.state))) return null;
   return { ...current, state: 'idle', ts: now };
 }
 
 export interface AckPlan {
   // Rewritten status-file object, or null when the file isn't in a ready state.
-  status: Record<string, unknown> | null;
+  status: JsonObject | null;
   // Whether to append an Acknowledged event to retire an event-derived DONE.
   appendAck: boolean;
 }
@@ -31,7 +32,7 @@ export interface AckPlan {
 // object and recent events. Either signal being ready is enough to clear it; a
 // non-DONE event stream (working/waiting/asking) leaves appendAck false, so
 // PERMIT/QUESTION agents are never dismissed.
-export function acknowledgePlan(current: Record<string, unknown>, recentEvents: EventEntry[], now: number): AckPlan {
+export function acknowledgePlan(current: JsonObject, recentEvents: EventEntry[], now: number): AckPlan {
   return {
     status: acknowledgedStatus(current, now),
     appendAck: deriveStatusFromEvents(recentEvents) === AgentStatus.DONE,

--- a/src/state/detection.ts
+++ b/src/state/detection.ts
@@ -2,6 +2,8 @@ import { existsSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
+import { isJsonObject, isNumber, isString, type JsonObject, type JsonValue } from '../json.ts';
+
 // `state` is the serialized (JSON) label; it maps 1:1 onto the subset of
 // AgentStatus values the scraper can emit (see RULE_STATE_TO_STATUS in scraper.ts).
 export type RuleState = 'PERMIT' | 'QUESTION' | 'BUSY' | 'IDLE';
@@ -87,7 +89,7 @@ function hasControlCharacters(value: string): boolean {
 // Answer-key arrays from overrides: keep only non-empty strings; an empty or
 // non-array value is treated as absent (fall through to the next default),
 // never an error.
-function validateKeys(raw: unknown): string[] | undefined {
+function validateKeys(raw: JsonValue | undefined): string[] | undefined {
   if (!Array.isArray(raw)) return undefined;
   const keys = raw.filter((k): k is string => typeof k === 'string' && k.length > 0);
   return keys.length > 0 ? keys : undefined;
@@ -110,12 +112,12 @@ function dedupeRules(rules: DetectionRule[], label: string): DetectionRule[] {
   return out;
 }
 
-function validateRules(raw: unknown[], label = 'rule'): DetectionRule[] {
+function validateRules(raw: JsonValue[], label = 'rule'): DetectionRule[] {
   const rules: DetectionRule[] = [];
   for (const r of raw) {
-    if (typeof r !== 'object' || r === null) continue;
-    const rule = r as Record<string, unknown>;
-    if (typeof rule.id !== 'string' || typeof rule.pattern !== 'string') continue;
+    if (!isJsonObject(r)) continue;
+    const rule = r;
+    if (!isString(rule.id) || !isString(rule.pattern)) continue;
     if (
       rule.id.length === 0 ||
       rule.id.length > MAX_RULE_ID_LENGTH ||
@@ -125,8 +127,8 @@ function validateRules(raw: unknown[], label = 'rule'): DetectionRule[] {
       warn(`detection: rejecting ${label} with unsafe id or oversized pattern`);
       continue;
     }
-    if (typeof rule.state !== 'string' || !VALID_STATES.has(rule.state)) continue;
-    const flags = typeof rule.flags === 'string' ? rule.flags : undefined;
+    if (!isString(rule.state) || !VALID_STATES.has(rule.state)) continue;
+    const flags = isString(rule.flags) ? rule.flags : undefined;
     // Cached RegExp objects must be stateless across ticks. Global/sticky flags
     // mutate lastIndex on test(), causing alternating matches; reject all flags
     // outside the safe, non-stateful set (and duplicate flag strings).
@@ -140,10 +142,11 @@ function validateRules(raw: unknown[], label = 'rule'): DetectionRule[] {
       id: rule.id,
       pattern: rule.pattern,
       flags,
+      // SAFETY: VALID_STATES membership was checked above; its elements are exactly RuleState.
       state: rule.state as RuleState,
-      ...(approveKeys ? { approveKeys } : {}),
-      ...(denyKeys ? { denyKeys } : {}),
     };
+    if (approveKeys) candidate.approveKeys = approveKeys;
+    if (denyKeys) candidate.denyKeys = denyKeys;
     // Drop bad-regex rules at load with one warning (not once per scrape).
     if (getCompiledRegex(candidate) === null) continue;
     rules.push(candidate);
@@ -151,22 +154,26 @@ function validateRules(raw: unknown[], label = 'rule'): DetectionRule[] {
   return dedupeRules(rules, label);
 }
 
-function validateManifest(raw: unknown, agent: string): DetectionManifest {
-  if (typeof raw !== 'object' || raw === null) throw new Error('manifest is not an object');
-  const m = raw as Record<string, unknown>;
+function validateManifest(raw: JsonValue, agent: string): DetectionManifest {
+  if (!isJsonObject(raw)) throw new Error('manifest is not an object');
+  const m = raw;
   if (!Array.isArray(m.rules)) throw new Error('manifest.rules must be an array');
 
-  return {
+  // titleRules is optional; a non-array value is treated as absent, not an error.
+  const titleRules = Array.isArray(m.titleRules) ? validateRules(m.titleRules) : undefined;
+  const approveKeys = validateKeys(m.approveKeys);
+  const denyKeys = validateKeys(m.denyKeys);
+  const manifest: DetectionManifest = {
     agent,
     linesFromBottom:
-      typeof m.linesFromBottom === 'number' && m.linesFromBottom > 0 ? m.linesFromBottom : DEFAULT_LINES_FROM_BOTTOM,
-    promptMarker: typeof m.promptMarker === 'string' ? m.promptMarker : '',
+      isNumber(m.linesFromBottom) && m.linesFromBottom > 0 ? m.linesFromBottom : DEFAULT_LINES_FROM_BOTTOM,
+    promptMarker: isString(m.promptMarker) ? m.promptMarker : '',
     rules: validateRules(m.rules),
-    // titleRules is optional; a non-array value is treated as absent, not an error.
-    ...(Array.isArray(m.titleRules) ? { titleRules: validateRules(m.titleRules) } : {}),
-    ...(validateKeys(m.approveKeys) ? { approveKeys: validateKeys(m.approveKeys) } : {}),
-    ...(validateKeys(m.denyKeys) ? { denyKeys: validateKeys(m.denyKeys) } : {}),
   };
+  if (titleRules) manifest.titleRules = titleRules;
+  if (approveKeys) manifest.approveKeys = approveKeys;
+  if (denyKeys) manifest.denyKeys = denyKeys;
+  return manifest;
 }
 
 // Braille block U+2800–U+28FF: the animated progress glyph a harness paints only
@@ -207,12 +214,7 @@ interface RuleOpKeys {
 // id, appendRules adds to the end. Unknown target ids for replace/disable warn
 // and are skipped (never throw). The combined result is de-duplicated so an
 // appended id colliding with a base id can't shadow ordering.
-function applyRuleOps(
-  base: DetectionRule[],
-  m: Record<string, unknown>,
-  keys: RuleOpKeys,
-  label: string,
-): DetectionRule[] {
+function applyRuleOps(base: DetectionRule[], m: JsonObject, keys: RuleOpKeys, label: string): DetectionRule[] {
   let rules = [...base];
 
   const replaceRaw = m[keys.replace];
@@ -245,7 +247,7 @@ function applyRuleOps(
 
 // Resolve a `schemaVersion:1` envelope against the built-ins. Returns null when
 // the schema is unrecognized so the caller falls back to the built-in.
-function resolveSchemaOverride(m: Record<string, unknown>, agent: string): DetectionManifest | null {
+function resolveSchemaOverride(m: JsonObject, agent: string): DetectionManifest | null {
   if (m.schemaVersion !== SUPPORTED_SCHEMA_VERSION) {
     warn(
       `detection: unknown schemaVersion ${JSON.stringify(m.schemaVersion)} in override for "${agent}" — using built-in`,
@@ -257,7 +259,7 @@ function resolveSchemaOverride(m: Record<string, unknown>, agent: string): Detec
   // An unknown target warns and falls back to the agent's own built-in.
   let baseAgent = agent;
   if (m.extends !== undefined) {
-    if (typeof m.extends === 'string' && BUILTINS[m.extends]) {
+    if (isString(m.extends) && builtinFor(m.extends)) {
       baseAgent = m.extends;
     } else {
       warn(
@@ -265,8 +267,8 @@ function resolveSchemaOverride(m: Record<string, unknown>, agent: string): Detec
       );
     }
   }
-  const base: DetectionManifest = BUILTINS[baseAgent] ??
-    BUILTINS[agent] ?? { agent, linesFromBottom: DEFAULT_LINES_FROM_BOTTOM, promptMarker: '', rules: [] };
+  const base: DetectionManifest = builtinFor(baseAgent) ??
+    builtinFor(agent) ?? { agent, linesFromBottom: DEFAULT_LINES_FROM_BOTTOM, promptMarker: '', rules: [] };
 
   const rules = applyRuleOps(
     base.rules,
@@ -284,16 +286,16 @@ function resolveSchemaOverride(m: Record<string, unknown>, agent: string): Detec
   const approveKeys = validateKeys(m.approveKeys) ?? base.approveKeys;
   const denyKeys = validateKeys(m.denyKeys) ?? base.denyKeys;
 
-  return {
+  const resolved: DetectionManifest = {
     agent,
-    linesFromBottom:
-      typeof m.linesFromBottom === 'number' && m.linesFromBottom > 0 ? m.linesFromBottom : base.linesFromBottom,
-    promptMarker: typeof m.promptMarker === 'string' ? m.promptMarker : base.promptMarker,
+    linesFromBottom: isNumber(m.linesFromBottom) && m.linesFromBottom > 0 ? m.linesFromBottom : base.linesFromBottom,
+    promptMarker: isString(m.promptMarker) ? m.promptMarker : base.promptMarker,
     rules,
-    ...(titleRules.length > 0 ? { titleRules } : {}),
-    ...(approveKeys ? { approveKeys } : {}),
-    ...(denyKeys ? { denyKeys } : {}),
   };
+  if (titleRules.length > 0) resolved.titleRules = titleRules;
+  if (approveKeys) resolved.approveKeys = approveKeys;
+  if (denyKeys) resolved.denyKeys = denyKeys;
+  return resolved;
 }
 
 // --- the embedded built-in `claude` manifest ---
@@ -451,30 +453,37 @@ export const PI_MANIFEST: DetectionManifest = {
 };
 
 // --- loader: built-in, replaced wholesale by a valid override ---
-const BUILTINS: Record<string, DetectionManifest> = {
+const BUILTINS = {
   claude: CLAUDE_MANIFEST,
   codex: CODEX_MANIFEST,
   pi: PI_MANIFEST,
   opencode: OPENCODE_MANIFEST,
-};
+} satisfies Record<string, DetectionManifest>;
+
+function builtinFor(agent: string): DetectionManifest | undefined {
+  if (!Object.hasOwn(BUILTINS, agent)) return undefined;
+  // SAFETY: the Object.hasOwn check above proves agent is a key of BUILTINS.
+  return BUILTINS[agent as keyof typeof BUILTINS];
+}
 const manifestCache = new Map<string, DetectionManifest>();
 
 export function loadDetectionManifest(agent: string): DetectionManifest {
   const cached = manifestCache.get(agent);
   if (cached) return cached;
 
-  const builtin = BUILTINS[agent] ?? null;
+  const builtin = builtinFor(agent) ?? null;
   const configDir = process.env.XDG_CONFIG_HOME ?? join(homedir(), '.config');
   const overridePath = join(configDir, 'fleet', 'detection', `${agent}.json`);
 
   let resolved: DetectionManifest | null = builtin;
   if (existsSync(overridePath)) {
     try {
-      const parsed: unknown = JSON.parse(readFileSync(overridePath, 'utf-8'));
-      if (typeof parsed === 'object' && parsed !== null && 'schemaVersion' in parsed) {
+      // SAFETY: JSON.parse returns any; JsonValue is the sound type of any JSON document.
+      const parsed = JSON.parse(readFileSync(overridePath, 'utf-8')) as JsonValue;
+      if (isJsonObject(parsed) && 'schemaVersion' in parsed) {
         // schemaVersion:1 envelope — INHERIT the built-in and apply operations.
         // An unrecognized schema returns null; fall back to the built-in.
-        resolved = resolveSchemaOverride(parsed as Record<string, unknown>, agent) ?? builtin;
+        resolved = resolveSchemaOverride(parsed, agent) ?? builtin;
       } else {
         resolved = validateManifest(parsed, agent); // legacy override REPLACES built-in wholesale
       }

--- a/src/state/events.ts
+++ b/src/state/events.ts
@@ -1,4 +1,5 @@
 import { openSync, readSync, closeSync, statSync } from 'node:fs';
+import { isJsonObject, type JsonValue } from '../json.ts';
 import { AgentStatus, type EventEntry } from './types.ts';
 
 const TAIL_BYTES = 8192;
@@ -8,7 +9,9 @@ export function parseEventLog(content: string): EventEntry[] {
   for (const line of content.split('\n')) {
     if (line.length === 0) continue;
     try {
-      const data = JSON.parse(line) as Record<string, unknown>;
+      // SAFETY: JSON.parse returns any; JsonValue is the sound type of any JSON document.
+      const data = JSON.parse(line) as JsonValue;
+      if (!isJsonObject(data)) continue;
       entries.push({
         event: String(data.event ?? ''),
         ts: Number(data.ts ?? 0),

--- a/src/state/fixtures.test.ts
+++ b/src/state/fixtures.test.ts
@@ -24,12 +24,12 @@ import { AgentStatus } from './types.ts';
 
 const FIXTURES_DIR = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
 
-const EXPECTED_TO_STATUS: Record<string, AgentStatus> = {
+const EXPECTED_TO_STATUS = {
   permit: AgentStatus.PERMIT,
   question: AgentStatus.QUESTION,
   busy: AgentStatus.BUSY,
   idle: AgentStatus.IDLE,
-};
+} satisfies Record<string, AgentStatus>;
 
 interface FixtureCase {
   file: string;
@@ -45,8 +45,11 @@ function discoverFixtures(): FixtureCase[] {
     const parts = stem.split('-');
     const agent = parts[0]!;
     const expectedSlug = parts[1]!;
-    const expected = EXPECTED_TO_STATUS[expectedSlug];
-    if (!expected) throw new Error(`fixture "${file}" has no recognized expected state in its name`);
+    if (!Object.hasOwn(EXPECTED_TO_STATUS, expectedSlug)) {
+      throw new Error(`fixture "${file}" has no recognized expected state in its name`);
+    }
+    // SAFETY: the Object.hasOwn check above proves expectedSlug is a key of EXPECTED_TO_STATUS.
+    const expected = EXPECTED_TO_STATUS[expectedSlug as keyof typeof EXPECTED_TO_STATUS];
     cases.push({ file, agent, expected });
   }
   return cases;

--- a/src/state/git-metadata.ts
+++ b/src/state/git-metadata.ts
@@ -168,7 +168,12 @@ export function parseNumstat(stdout: string): GitDiffstat {
 
 // --- Bounded git spawns ---------------------------------------------------
 
-function git(cwd: string, args: string[]): { ok: boolean; stdout: string } {
+interface GitResult {
+  ok: boolean;
+  stdout: string;
+}
+
+function git(cwd: string, args: string[]): GitResult {
   try {
     const proc = Bun.spawnSync({
       cmd: ['git', '-c', 'core.fsmonitor=false', '-c', 'core.hooksPath=/dev/null', '-C', cwd, ...args],

--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -1,6 +1,7 @@
 import { readdirSync, readFileSync, existsSync, statSync, watch, writeFileSync, renameSync } from 'node:fs';
 import { join } from 'node:path';
 import type { HookStatus, ResolvedHookStatus } from './types.ts';
+import { isJsonObject, type JsonValue } from '../json.ts';
 import type { AgentDir } from '../agents/config.ts';
 
 // The `.status` / `.events.jsonl` filename convention, named once. Keyed by the
@@ -27,7 +28,10 @@ export function writeFileAtomic(path: string, content: string): void {
 
 export function parseStatusFile(content: string): HookStatus | null {
   try {
-    const data = JSON.parse(content) as Record<string, unknown>;
+    // SAFETY: JSON.parse returns any; JsonValue is the sound type of any JSON document.
+    const parsed = JSON.parse(content) as JsonValue;
+    if (!isJsonObject(parsed)) return null;
+    const data = parsed;
     return {
       state: String(data.state ?? 'idle'),
       pane: String(data.pane ?? ''),

--- a/src/state/permit-keys.ts
+++ b/src/state/permit-keys.ts
@@ -7,7 +7,7 @@ export type PermitAction = 'approve' | 'deny';
 // last resort so unknown agents and user overrides without key specs behave
 // exactly as before: correct for genuine [y/n] prompts, a no-op for menu
 // dialogs.
-const FALLBACK_KEYS: Record<PermitAction, string[]> = { approve: ['y'], deny: ['n'] };
+const FALLBACK_KEYS = { approve: ['y'], deny: ['n'] } satisfies Record<PermitAction, string[]>;
 
 // Resolve the tmux send-keys key names that answer the permission dialog on
 // screen. Precedence: matched PERMIT rule's own keys > manifest defaults >

--- a/src/state/refresh.ts
+++ b/src/state/refresh.ts
@@ -10,6 +10,7 @@ import { fuseState, hookStateForStatus } from './engine.ts';
 import { readAllStatusDirs, statusFilePath, eventsFilePath, writeFileAtomic } from './hooks.ts';
 import { readLastEvents, deriveStatusFromEvents } from './events.ts';
 import { acknowledgePlan } from './acknowledge.ts';
+import { isJsonObject, type JsonObject, type JsonValue } from '../json.ts';
 import {
   detectFromPaneContent,
   detectFromTitle,
@@ -185,9 +186,12 @@ export function acknowledgePane(paneId: string, statusDirs: string[]): void {
   const now = Math.floor(Date.now() / 1000);
   for (const dir of statusDirs) {
     const statusFile = statusFilePath(dir, paneId);
-    let current: Record<string, unknown>;
+    let current: JsonObject;
     try {
-      current = JSON.parse(readFileSync(statusFile, 'utf-8')) as Record<string, unknown>;
+      // SAFETY: JSON.parse returns any; JsonValue is the sound type of any JSON document.
+      const parsed = JSON.parse(readFileSync(statusFile, 'utf-8')) as JsonValue;
+      if (!isJsonObject(parsed)) continue;
+      current = parsed;
     } catch {
       continue;
     }

--- a/src/state/rename.ts
+++ b/src/state/rename.ts
@@ -2,6 +2,8 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 
+import { isJsonObject, isString, type JsonValue } from '../json.ts';
+
 // Rename store lives under the XDG cache root (mirrors the ~/.cache/<name>-status
 // convention in config.ts) so a user rename survives a fleet restart.
 export function renamesPath(): string {
@@ -15,10 +17,11 @@ export function loadRenames(path: string = renamesPath()): Map<string, string> {
   const out = new Map<string, string>();
   if (!existsSync(path)) return out;
   try {
-    const data = JSON.parse(readFileSync(path, 'utf-8')) as Record<string, unknown>;
-    if (data && typeof data === 'object' && !Array.isArray(data)) {
+    // SAFETY: JSON.parse returns any; JsonValue is the sound type of any JSON document.
+    const data = JSON.parse(readFileSync(path, 'utf-8')) as JsonValue;
+    if (isJsonObject(data)) {
       for (const [k, v] of Object.entries(data)) {
-        if (typeof v === 'string' && v.length > 0) out.set(k, v);
+        if (isString(v) && v.length > 0) out.set(k, v);
       }
     }
   } catch {

--- a/src/state/segment-cache.ts
+++ b/src/state/segment-cache.ts
@@ -30,7 +30,7 @@ export function tmuxSocketId(): string {
 }
 
 export function cacheFilePath(): string {
-  const uid = typeof process.getuid === 'function' ? process.getuid() : 0;
+  const uid = process.getuid?.() ?? 0;
   return join(tmpdir(), `fleet-statusline-${uid}-${tmuxSocketId()}.cache`);
 }
 

--- a/src/state/snapshot-cache.ts
+++ b/src/state/snapshot-cache.ts
@@ -1,6 +1,7 @@
 import { chmodSync, lstatSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { isJsonObject, isString, type JsonValue } from '../json.ts';
 import { tmuxSocketId } from './segment-cache.ts';
 import { AgentStatus, type AgentState } from './types.ts';
 
@@ -10,7 +11,7 @@ let lastPayload = '';
 let lastWriteMs = 0;
 
 function cacheDirPath(): string {
-  const uid = typeof process.getuid === 'function' ? process.getuid() : 0;
+  const uid = process.getuid?.() ?? 0;
   return join(tmpdir(), `fleet-${uid}`);
 }
 
@@ -19,7 +20,7 @@ function ensurePrivateCacheDir(): boolean {
     const dir = cacheDirPath();
     mkdirSync(dir, { recursive: true, mode: 0o700 });
     const stat = lstatSync(dir);
-    const uid = typeof process.getuid === 'function' ? process.getuid() : stat.uid;
+    const uid = process.getuid?.() ?? stat.uid;
     if (!stat.isDirectory() || stat.uid !== uid) return false;
     chmodSync(dir, 0o700);
     return true;
@@ -51,15 +52,15 @@ export function writeAgentSnapshot(states: AgentState[], now = Date.now()): void
   }
 }
 
-function isAgentState(value: unknown): value is AgentState {
-  if (typeof value !== 'object' || value === null) return false;
-  const state = value as Partial<AgentState>;
+function isAgentState(value: JsonValue | undefined): value is AgentState & JsonValue {
+  if (!isJsonObject(value)) return false;
   return (
-    typeof state.paneId === 'string' &&
-    typeof state.session === 'string' &&
-    typeof state.window === 'string' &&
-    typeof state.agentType === 'string' &&
-    Object.values(AgentStatus).includes(state.status as AgentStatus)
+    isString(value.paneId) &&
+    isString(value.session) &&
+    isString(value.window) &&
+    isString(value.agentType) &&
+    // SAFETY: includes() only reads membership; a non-AgentStatus value returns false.
+    Object.values(AgentStatus).includes(value.status as AgentStatus)
   );
 }
 
@@ -71,11 +72,13 @@ export function readFreshAgentSnapshot(maxAgeSecs = 300): AgentState[] | null {
     if (!ensurePrivateCacheDir()) return null;
     const path = snapshotCacheFilePath();
     const stat = lstatSync(path);
-    const uid = typeof process.getuid === 'function' ? process.getuid() : stat.uid;
+    const uid = process.getuid?.() ?? stat.uid;
     if (!stat.isFile() || stat.uid !== uid) return null;
     const ageSecs = (Date.now() - stat.mtimeMs) / 1000;
     if (ageSecs > maxAgeSecs) return null;
-    const parsed = JSON.parse(readFileSync(path, 'utf8')) as { version?: unknown; states?: unknown };
+    // SAFETY: JSON.parse returns any; JsonValue is the sound type of any JSON document.
+    const parsed = JSON.parse(readFileSync(path, 'utf8')) as JsonValue;
+    if (!isJsonObject(parsed)) return null;
     if (parsed.version !== CACHE_VERSION || !Array.isArray(parsed.states)) return null;
     if (!parsed.states.every(isAgentState)) return null;
     return parsed.states;

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -26,7 +26,7 @@ export const SIDEBAR_RANGE = '__sidebar__';
 // (working, needs nothing from you), then idle, shells, and dead panes. Keeping
 // every attention state above BUSY means "needs you" is always sorted, tinted,
 // and surfaced ahead of quiet background work.
-const PRIORITY: Record<AgentStatus, number> = {
+const PRIORITY = {
   [AgentStatus.PERMIT]: 0,
   [AgentStatus.QUESTION]: 1,
   [AgentStatus.DONE]: 2,
@@ -34,7 +34,7 @@ const PRIORITY: Record<AgentStatus, number> = {
   [AgentStatus.IDLE]: 4,
   [AgentStatus.SHELL]: 5,
   [AgentStatus.DOWN]: 6,
-};
+} satisfies Record<AgentStatus, number>;
 
 export function statusPriority(status: AgentStatus): number {
   return PRIORITY[status];
@@ -74,7 +74,7 @@ export function formatAgeDelta(deltaSecs: number): string {
 // terminal's own palette so they stay readable on light and dark themes alike.
 // The in-app TUI ignores this field and colors state via getStateColor()/the C
 // palette instead.
-export const STATUS_DISPLAY: Record<AgentStatus, { icon: string; label: string; color: string }> = {
+export const STATUS_DISPLAY = {
   [AgentStatus.PERMIT]: { icon: '⚠', label: 'waiting', color: 'yellow' },
   [AgentStatus.QUESTION]: { icon: '?', label: 'asking', color: 'magenta' },
   [AgentStatus.DONE]: { icon: '●', label: 'ready', color: 'green' },
@@ -82,7 +82,7 @@ export const STATUS_DISPLAY: Record<AgentStatus, { icon: string; label: string; 
   [AgentStatus.IDLE]: { icon: '●', label: 'idle', color: 'blue' },
   [AgentStatus.SHELL]: { icon: '■', label: 'shell', color: 'brightblack' },
   [AgentStatus.DOWN]: { icon: '○', label: 'down', color: 'brightblack' },
-};
+} satisfies Record<AgentStatus, { icon: string; label: string; color: string }>;
 
 import type { GitMetadata } from './git-metadata.ts';
 

--- a/src/terminal/colors.ts
+++ b/src/terminal/colors.ts
@@ -18,7 +18,16 @@ export type StateColorKey = 'permit' | 'question' | 'done' | 'busy' | 'idle' | '
 export type AnsiColor = { kind: 'ansi'; code: number };
 export type RgbColor = { kind: 'rgb'; r: number; g: number; b: number };
 export type ThemeColor = AnsiColor | RgbColor;
-export type StatePalette = Record<StateColorKey, ThemeColor>;
+// Named owner contract for a complete palette: one ThemeColor per agent state.
+export interface StatePalette {
+  permit: ThemeColor;
+  question: ThemeColor;
+  done: ThemeColor;
+  busy: ThemeColor;
+  idle: ThemeColor;
+  shell: ThemeColor;
+  down: ThemeColor;
+}
 
 const rgb = (r: number, g: number, b: number): RgbColor => ({ kind: 'rgb', r, g, b });
 

--- a/src/terminal/input.ts
+++ b/src/terminal/input.ts
@@ -8,10 +8,15 @@ export type KeyEvent =
   | { type: 'ctrl'; char: string }
   | { type: 'unknown' };
 
+interface ParsedKey {
+  event: KeyEvent;
+  next: number;
+}
+
 // Parse one key event starting at `offset`, returning the event and the offset
 // just past its bytes — so a read that coalesced several keystrokes (fast
 // typing, SSH batching, paste) yields every key instead of only the first.
-function parseOneKey(data: Buffer, offset: number): { event: KeyEvent; next: number } {
+function parseOneKey(data: Buffer, offset: number): ParsedKey {
   const first = data[offset]!;
 
   // Escape sequence (arrows, other CSI)

--- a/src/terminal/terminal.test.ts
+++ b/src/terminal/terminal.test.ts
@@ -5,6 +5,7 @@ import { clearPaneTitle, restore, setPaneTitle } from './terminal.ts';
 function captureWrites(fn: () => void): string[] {
   const writes: string[] = [];
   const original = process.stdout.write.bind(process.stdout);
+  // SAFETY: the wrapper implements the single-argument write() call shape used under test.
   process.stdout.write = ((chunk: string | Uint8Array) => {
     writes.push(String(chunk));
     return true;

--- a/src/terminal/theme.test.ts
+++ b/src/terminal/theme.test.ts
@@ -136,8 +136,7 @@ describe('custom state palettes', () => {
 
   for (const key of Object.keys(paletteSource.colors)) {
     test(`rejects a palette missing ${key}`, () => {
-      const colors = { ...paletteSource.colors } as Record<string, unknown>;
-      delete colors[key];
+      const colors = Object.fromEntries(Object.entries(paletteSource.colors).filter(([k]) => k !== key));
       expect(() => parseStatePalette({ colors })).toThrow(`missing color "${key}"`);
     });
   }

--- a/src/terminal/theme.ts
+++ b/src/terminal/theme.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { getTmuxOption } from '../tmux/ipc.ts';
+import { isJsonObject, isString, type JsonValue } from '../json.ts';
 import type { StateColorKey, StatePalette, ThemeColor } from './colors.ts';
 
 export type ThemeMode = 'light' | 'dark';
@@ -15,7 +16,7 @@ export interface Rgb {
 
 const STATE_COLOR_KEYS = ['permit', 'question', 'done', 'busy', 'idle', 'shell', 'down'] as const;
 
-const ANSI_FOREGROUND_CODES: Record<string, number> = {
+const ANSI_FOREGROUND_CODES = {
   black: 30,
   red: 31,
   green: 32,
@@ -32,11 +33,17 @@ const ANSI_FOREGROUND_CODES: Record<string, number> = {
   'bright-magenta': 95,
   'bright-cyan': 96,
   'bright-white': 97,
-};
+} satisfies Record<string, number>;
 
-export function parseThemeColor(value: unknown): ThemeColor {
-  if (typeof value !== 'string') throw new Error('color values must be strings');
-  const ansiCode = ANSI_FOREGROUND_CODES[value];
+function ansiForegroundCode(name: string): number | undefined {
+  if (!Object.hasOwn(ANSI_FOREGROUND_CODES, name)) return undefined;
+  // SAFETY: the Object.hasOwn check above proves name is a key of ANSI_FOREGROUND_CODES.
+  return ANSI_FOREGROUND_CODES[name as keyof typeof ANSI_FOREGROUND_CODES];
+}
+
+export function parseThemeColor(value: JsonValue | undefined): ThemeColor {
+  if (!isString(value)) throw new Error('color values must be strings');
+  const ansiCode = ansiForegroundCode(value);
   if (ansiCode !== undefined) return { kind: 'ansi', code: ansiCode };
   if (/^#[0-9a-fA-F]{6}$/.test(value)) {
     return {
@@ -49,7 +56,7 @@ export function parseThemeColor(value: unknown): ThemeColor {
   throw new Error(`unsupported color ${JSON.stringify(value)}`);
 }
 
-function parsePaletteColor(key: StateColorKey, value: unknown): ThemeColor {
+function parsePaletteColor(key: StateColorKey, value: JsonValue | undefined): ThemeColor {
   try {
     return parseThemeColor(value);
   } catch (error) {
@@ -58,18 +65,17 @@ function parsePaletteColor(key: StateColorKey, value: unknown): ThemeColor {
   }
 }
 
-export function parseStatePalette(value: unknown): StatePalette {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+export function parseStatePalette(value: JsonValue): StatePalette {
+  if (!isJsonObject(value) || !isJsonObject(value.colors)) {
     throw new Error('theme must contain a [colors] table');
   }
-  const colors = (value as Record<string, unknown>).colors;
-  if (typeof colors !== 'object' || colors === null || Array.isArray(colors)) {
-    throw new Error('theme must contain a [colors] table');
-  }
-  const colorValues = colors as Record<string, unknown>;
+  const colorValues = value.colors;
   for (const key of Object.keys(colorValues)) {
+    // SAFETY: includes() only reads membership; a non-member key simply returns false.
     if (!STATE_COLOR_KEYS.includes(key as StateColorKey)) throw new Error(`unknown color key ${JSON.stringify(key)}`);
   }
+  // SAFETY: the loop below assigns every STATE_COLOR_KEYS member, which is exactly
+  // StatePalette's key set, before palette escapes this function.
   const palette = {} as StatePalette;
   for (const key of STATE_COLOR_KEYS) {
     if (!(key in colorValues)) throw new Error(`missing color ${JSON.stringify(key)}`);
@@ -97,7 +103,10 @@ export function loadCustomStatePalette(options: ThemeLoaderOptions = {}): StateP
   const path = options.path ?? resolveThemePath(env, options.home ?? homedir());
   if (!(options.exists ?? existsSync)(path)) return null;
   try {
-    return parseStatePalette(Bun.TOML.parse((options.read ?? ((file) => readFileSync(file, 'utf8')))(path)));
+    // SAFETY: Bun.TOML.parse returns any; JsonValue covers every TOML value a palette file can hold.
+    return parseStatePalette(
+      Bun.TOML.parse((options.read ?? ((file) => readFileSync(file, 'utf8')))(path)) as JsonValue,
+    );
   } catch (error) {
     const reason = error instanceof Error ? error.message : String(error);
     (options.warn ?? ((message) => process.stderr.write(`${message}\n`)))(

--- a/src/tmux/control-protocol.test.ts
+++ b/src/tmux/control-protocol.test.ts
@@ -162,7 +162,9 @@ describe('ControlProtocol multiple blocks', () => {
     const ev = p.feed('%begin 1 1 f\na\n%end 1 1 f\n%begin 1 2 f\nb\n%end 1 2 f\n');
     const blocks = blockEvents(ev);
     expect(blocks).toHaveLength(2);
+    // SAFETY: blockEvents() above selects only block events, whose shape carries body.
     expect((blocks[0] as { body: string }).body).toBe('a');
+    // SAFETY: same — blockEvents() returns only block events.
     expect((blocks[1] as { body: string }).body).toBe('b');
   });
 });

--- a/src/tmux/control-router.ts
+++ b/src/tmux/control-router.ts
@@ -35,7 +35,7 @@ export function selectReadPath(s: ControlModeState): ReadPath {
 export function shouldAttemptControl(env: Record<string, string | undefined>): boolean {
   if (env.FLEET_CONTROL_MODE === '0') return false;
   const tmux = env.TMUX;
-  return typeof tmux === 'string' && tmux.length > 0;
+  return tmux !== undefined && tmux.length > 0;
 }
 
 /** Flip the latch to dead (permanent for the session). Idempotent. */

--- a/src/tmux/control.ts
+++ b/src/tmux/control.ts
@@ -35,9 +35,19 @@ export function attachArgs(tmuxEnv: string | undefined): string[] {
   return args;
 }
 
+/** Environment map as read from process.env. */
+export interface EnvMap {
+  [key: string]: string | undefined;
+}
+
+/** Environment map with no undefined values. */
+export interface CleanEnv {
+  [key: string]: string;
+}
+
 /** Copy `env` without TMUX (a control client must not look nested). */
-export function childEnv(env: Record<string, string | undefined>): Record<string, string> {
-  const out: Record<string, string> = {};
+export function childEnv(env: EnvMap): CleanEnv {
+  const out: CleanEnv = {};
   for (const [k, v] of Object.entries(env)) {
     if (k === 'TMUX') continue;
     if (v !== undefined) out[k] = v;
@@ -78,7 +88,7 @@ export interface TmuxControlClientOptions {
 
 interface PendingSlot {
   resolve: (body: string) => void;
-  reject: (err: unknown) => void;
+  reject: (err: TmuxControlError) => void;
 }
 
 export class TmuxControlClient {
@@ -106,7 +116,7 @@ export class TmuxControlClient {
   /** Spawn the control client, consume the greeting block, run a sync probe. */
   async connect(): Promise<void> {
     const args = attachArgs(process.env.TMUX);
-    const env = childEnv(process.env as Record<string, string | undefined>);
+    const env = childEnv(process.env);
     const proc = Bun.spawn({
       cmd: args,
       stdin: 'pipe',
@@ -208,7 +218,7 @@ export class TmuxControlClient {
       () => {},
       () => {},
     );
-    return next as Promise<T>;
+    return next;
   }
 
   private runSerialized(cmd: string): Promise<string> {

--- a/src/tmux/send.test.ts
+++ b/src/tmux/send.test.ts
@@ -3,12 +3,12 @@ import { sendKeys, sendRawKey } from './send.ts';
 
 describe('sendKeys', () => {
   test('function is exported', () => {
-    expect(typeof sendKeys).toBe('function');
+    expect(sendKeys).toBeFunction();
   });
 });
 
 describe('sendRawKey', () => {
   test('function is exported', () => {
-    expect(typeof sendRawKey).toBe('function');
+    expect(sendRawKey).toBeFunction();
   });
 });

--- a/src/tmux/send.ts
+++ b/src/tmux/send.ts
@@ -24,32 +24,33 @@ export function sendKeyNames(paneId: string, keys: string[]): void {
   }
 }
 
-const SPECIAL_KEY_MAP: Record<number, string> = {
-  0x0d: 'Enter',
-  0x7f: 'BSpace',
-  0x09: 'Tab',
-  0x1b: 'Escape',
-};
+const SPECIAL_KEY_MAP = new Map<number, string>([
+  [0x0d, 'Enter'],
+  [0x7f, 'BSpace'],
+  [0x09, 'Tab'],
+  [0x1b, 'Escape'],
+]);
+
+const ARROW_NAMES = new Map<number, string>([
+  [0x41, 'Up'],
+  [0x42, 'Down'],
+  [0x43, 'Right'],
+  [0x44, 'Left'],
+]);
 
 export function sendRawKey(paneId: string, data: Buffer): void {
   const first = data[0];
   if (first === undefined) return;
 
   if (first === 0x1b && data.length >= 3 && data[1] === 0x5b) {
-    const arrows: Record<number, string> = {
-      0x41: 'Up',
-      0x42: 'Down',
-      0x43: 'Right',
-      0x44: 'Left',
-    };
-    const arrow = data[2] !== undefined ? arrows[data[2]] : undefined;
+    const arrow = data[2] !== undefined ? ARROW_NAMES.get(data[2]) : undefined;
     if (arrow) {
       tmuxOrThrow(['send-keys', '-t', paneId, arrow], 'send-keys arrow failed');
       return;
     }
   }
 
-  const special = SPECIAL_KEY_MAP[first];
+  const special = SPECIAL_KEY_MAP.get(first);
   if (special) {
     tmuxOrThrow(['send-keys', '-t', paneId, special], `send-keys ${special} failed`);
     return;

--- a/src/tui/app.test.ts
+++ b/src/tui/app.test.ts
@@ -58,9 +58,9 @@ describe('TuiApp', () => {
 
   test('mode transitions', () => {
     const app = new TuiApp();
-    expect(app.mode).toBe(TuiMode.DASHBOARD);
+    expect<TuiMode>(app.mode).toBe(TuiMode.DASHBOARD);
     app.mode = TuiMode.PREVIEW;
-    expect(app.mode).toBe(TuiMode.PREVIEW);
+    expect<TuiMode>(app.mode).toBe(TuiMode.PREVIEW);
   });
 
   test('selection clamps to range', () => {
@@ -107,35 +107,35 @@ describe('TuiApp', () => {
     const app = new TuiApp();
     app.mode = TuiMode.PREVIEW;
     app.enterPassthrough();
-    expect(app.mode as string).toBe('PASSTHROUGH');
+    expect<TuiMode>(app.mode).toBe(TuiMode.PASSTHROUGH);
     app.exitPassthrough();
-    expect(app.mode as string).toBe('PREVIEW');
+    expect<TuiMode>(app.mode).toBe(TuiMode.PREVIEW);
   });
 
   test('enterSend from preview restores to preview', () => {
     const app = new TuiApp();
     app.mode = TuiMode.PREVIEW;
     app.enterSend();
-    expect(app.mode as string).toBe('SEND');
+    expect<TuiMode>(app.mode).toBe(TuiMode.SEND);
     app.exitSend();
-    expect(app.mode as string).toBe('PREVIEW');
+    expect<TuiMode>(app.mode).toBe(TuiMode.PREVIEW);
   });
 
   test('enterKillConfirm / exitKillConfirm restores the prior mode from dashboard', () => {
     const app = new TuiApp();
     app.enterKillConfirm();
-    expect(app.mode as string).toBe('CONFIRM_KILL');
+    expect<TuiMode>(app.mode).toBe(TuiMode.CONFIRM_KILL);
     app.exitKillConfirm();
-    expect(app.mode as string).toBe('DASHBOARD');
+    expect<TuiMode>(app.mode).toBe(TuiMode.DASHBOARD);
   });
 
   test('enterKillConfirm from preview restores to preview', () => {
     const app = new TuiApp();
     app.mode = TuiMode.PREVIEW;
     app.enterKillConfirm();
-    expect(app.mode as string).toBe('CONFIRM_KILL');
+    expect<TuiMode>(app.mode).toBe(TuiMode.CONFIRM_KILL);
     app.exitKillConfirm();
-    expect(app.mode as string).toBe('PREVIEW');
+    expect<TuiMode>(app.mode).toBe(TuiMode.PREVIEW);
   });
 });
 

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -37,6 +37,11 @@ const DEFAULT_SPLIT = 0.45;
 // (the mouse "jump to agent" gesture, mirroring Enter).
 const DOUBLE_CLICK_MS = 400;
 
+interface GroupLabel {
+  label: string;
+  isRepo: boolean;
+}
+
 export class TuiApp {
   private states: AgentState[] = [];
   private filter: string = '';
@@ -83,7 +88,7 @@ export class TuiApp {
 
   // Display label + whether this is a repo group, derived from a group's first
   // (most-urgent) member.
-  private groupLabel(member: AgentState): { label: string; isRepo: boolean } {
+  private groupLabel(member: AgentState): GroupLabel {
     if (this.repoGroupMode && member.git) {
       return { label: repoLabelFromId(member.git.repoId), isRepo: true };
     }

--- a/src/tui/decision.ts
+++ b/src/tui/decision.ts
@@ -12,7 +12,7 @@ function enumOrNone(s: AgentStatus | null): string {
   return s ?? 'none';
 }
 
-function safeText(value: unknown, maxLength = 240): string {
+function safeText(value: string | null | undefined, maxLength = 240): string {
   const clean = Array.from(stripAnsi(String(value ?? '')), (char) => {
     const code = char.charCodeAt(0);
     return code < 32 || code === 127 ? ' ' : char;

--- a/src/tui/kill.ts
+++ b/src/tui/kill.ts
@@ -4,7 +4,12 @@ import { AgentStatus, whereLabel, type AgentState } from '../state/types.ts';
 // Killing is destructive, so it gets the same state gating as send: refuse the
 // states where the agent is mid-thought or blocked on you. You can still reap
 // anything that's finished, idle, or already dead.
-export function canKillSession(state: AgentState): { ok: boolean; reason: string } {
+interface KillCheck {
+  ok: boolean;
+  reason: string;
+}
+
+export function canKillSession(state: AgentState): KillCheck {
   switch (state.status) {
     case AgentStatus.IDLE:
     case AgentStatus.DONE:

--- a/src/tui/send.ts
+++ b/src/tui/send.ts
@@ -2,7 +2,12 @@ import { C } from '../terminal/colors.ts';
 import { AgentStatus, type AgentState } from '../state/types.ts';
 import { truncateAnsi } from '../terminal/ansi.ts';
 
-export function canSendTo(state: AgentState): { ok: boolean; reason: string } {
+interface SendCheck {
+  ok: boolean;
+  reason: string;
+}
+
+export function canSendTo(state: AgentState): SendCheck {
   switch (state.status) {
     case AgentStatus.IDLE:
     case AgentStatus.DONE:

--- a/tools/oxlint/anti-slop/index.ts
+++ b/tools/oxlint/anti-slop/index.ts
@@ -1,0 +1,41 @@
+import { eslintCompatPlugin } from '@oxlint/plugins';
+
+import { noChainedTypeAssertionsRule } from './rules/no-chained-type-assertions.ts';
+import { noConditionalEmptyObjectSpreadRule } from './rules/no-conditional-empty-object-spread.ts';
+import { noKnownValueWideningRule } from './rules/no-known-value-widening.ts';
+import { noModuleMockingRule } from './rules/no-module-mocking.ts';
+import { noObjectParametersRule } from './rules/no-object-parameters.ts';
+import { noReflectApplyRule } from './rules/no-reflect-apply.ts';
+import { noReflectGetRule } from './rules/no-reflect-get.ts';
+import { noRuntimeTypeofRule } from './rules/no-runtime-typeof.ts';
+import { noForbiddenTermInSymbolNamesRule } from './rules/no-shape-in-symbol-names.ts';
+import { noUnknownParametersRule } from './rules/no-unknown-parameters.ts';
+import { noUnknownReturnsRule } from './rules/no-unknown-returns.ts';
+import { noUnknownTypeAliasesRule } from './rules/no-unknown-type-aliases.ts';
+import { noUnsafeDictionaryTypeRule } from './rules/no-unsafe-dictionary-type.ts';
+import { noWidenThenAssertRule } from './rules/no-widen-then-assert.ts';
+import { requireSafetyCommentForTypeAssertionRule } from './rules/require-safety-comment-for-type-assertion.ts';
+
+/** Generic Oxlint rules that reject low-evidence and low-signal implementation patterns. */
+const antiSlopPlugin = eslintCompatPlugin({
+  meta: { name: 'anti-slop' },
+  rules: {
+    'no-chained-type-assertions': noChainedTypeAssertionsRule,
+    'no-conditional-empty-object-spread': noConditionalEmptyObjectSpreadRule,
+    'no-known-value-widening': noKnownValueWideningRule,
+    'no-module-mocking': noModuleMockingRule,
+    'no-object-parameters': noObjectParametersRule,
+    'no-reflect-apply': noReflectApplyRule,
+    'no-reflect-get': noReflectGetRule,
+    'no-runtime-typeof': noRuntimeTypeofRule,
+    'no-unsafe-dictionary-type': noUnsafeDictionaryTypeRule,
+    'no-shape-in-symbol-names': noForbiddenTermInSymbolNamesRule,
+    'no-unknown-parameters': noUnknownParametersRule,
+    'no-unknown-returns': noUnknownReturnsRule,
+    'no-unknown-type-aliases': noUnknownTypeAliasesRule,
+    'no-widen-then-assert': noWidenThenAssertRule,
+    'require-safety-comment-for-type-assertion': requireSafetyCommentForTypeAssertionRule,
+  },
+});
+
+export default antiSlopPlugin;

--- a/tools/oxlint/anti-slop/rules/no-chained-type-assertions.ts
+++ b/tools/oxlint/anti-slop/rules/no-chained-type-assertions.ts
@@ -1,0 +1,76 @@
+import { defineRule } from '@oxlint/plugins';
+import type { ESTree } from '@oxlint/plugins';
+
+type TypeAssertionExpression = ESTree.TSAsExpression | ESTree.TSTypeAssertion;
+
+function isTypeAssertionExpression(node: ESTree.Node): node is TypeAssertionExpression {
+  return node.type === 'TSAsExpression' || node.type === 'TSTypeAssertion';
+}
+
+function unwrapParenthesizedExpression(expression: ESTree.Expression): ESTree.Expression {
+  let current = expression;
+  while (current.type === 'ParenthesizedExpression') {
+    current = current.expression;
+  }
+  return current;
+}
+
+function isConstAssertion(node: TypeAssertionExpression): boolean {
+  const { typeAnnotation } = node;
+  return (
+    typeAnnotation.type === 'TSTypeReference' &&
+    typeAnnotation.typeName.type === 'Identifier' &&
+    typeAnnotation.typeName.name === 'const'
+  );
+}
+
+function isOutermostAssertionInChain(node: TypeAssertionExpression): boolean {
+  let current: ESTree.Expression = node;
+  let parent = node.parent;
+
+  while (parent.type === 'ParenthesizedExpression' && parent.expression === current) {
+    current = parent;
+    parent = parent.parent;
+  }
+
+  return !isTypeAssertionExpression(parent) || parent.expression !== current;
+}
+
+function isForbiddenAssertionChain(node: TypeAssertionExpression): boolean {
+  let assertionCount = 0;
+  let hasNonConstAssertion = false;
+  let current: ESTree.Expression = node;
+
+  while (isTypeAssertionExpression(current)) {
+    assertionCount += 1;
+    hasNonConstAssertion ||= !isConstAssertion(current);
+    current = unwrapParenthesizedExpression(current.expression);
+  }
+
+  return assertionCount > 1 && hasNonConstAssertion;
+}
+
+/** Disallow nested TypeScript type assertions, while permitting chains made only of const assertions. */
+export const noChainedTypeAssertionsRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow chained TypeScript as and angle-bracket assertions, including parenthesized chains.',
+    },
+    messages: {
+      chained:
+        'This assertion chain discards type evidence. Keep the original precise type, or parse untrusted input at its boundary before narrowing it.',
+    },
+  },
+  createOnce(context) {
+    const checkTypeAssertion = (node: TypeAssertionExpression) => {
+      if (!isOutermostAssertionInChain(node) || !isForbiddenAssertionChain(node)) return;
+      context.report({ node, messageId: 'chained' });
+    };
+
+    return {
+      TSAsExpression: checkTypeAssertion,
+      TSTypeAssertion: checkTypeAssertion,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-conditional-empty-object-spread.ts
+++ b/tools/oxlint/anti-slop/rules/no-conditional-empty-object-spread.ts
@@ -1,0 +1,47 @@
+import { defineRule } from '@oxlint/plugins';
+import type { ESTree } from '@oxlint/plugins';
+
+function unwrapParentheses(node: ESTree.Expression): ESTree.Expression {
+  let current = node;
+  while (current.type === 'ParenthesizedExpression') {
+    current = current.expression;
+  }
+  return current;
+}
+
+function isEmptyObjectExpression(node: ESTree.Expression): boolean {
+  return node.type === 'ObjectExpression' && node.properties.length === 0;
+}
+
+function isConditionalEmptyObjectSpread(node: ESTree.Expression): boolean {
+  const conditional = unwrapParentheses(node);
+  return (
+    conditional.type === 'ConditionalExpression' &&
+    (isEmptyObjectExpression(conditional.consequent) || isEmptyObjectExpression(conditional.alternate))
+  );
+}
+
+/** Ban conditional empty-object spreads without changing their omission semantics. */
+export const noConditionalEmptyObjectSpreadRule = defineRule({
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: 'Disallow object spreads that conditionally spread an empty object to omit fields.',
+    },
+    messages: {
+      avoid:
+        'This conditional spread hides property omission behind an empty object. Build the object in separate statements and add the property only when present.',
+    },
+  },
+  createOnce(context) {
+    return {
+      SpreadElement(node) {
+        if (node.parent.type !== 'ObjectExpression') return;
+
+        if (isConditionalEmptyObjectSpread(node.argument)) {
+          context.report({ node, messageId: 'avoid' });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-known-value-widening.ts
+++ b/tools/oxlint/anti-slop/rules/no-known-value-widening.ts
@@ -1,0 +1,214 @@
+import { defineRule } from '@oxlint/plugins';
+
+import {
+  classifyWideningTarget,
+  createTypeEnvironment,
+  isKnownEvidenceExpression,
+  type TypeEnvironment,
+  type WideningTarget,
+} from '../shared/dictionary-types.ts';
+
+import type { ESTree, Scope, SourceCode, Variable } from '@oxlint/plugins';
+
+type FunctionExpression = ESTree.ArrowFunctionExpression | ESTree.Function;
+
+function unwrapExpression(expression: ESTree.Expression): ESTree.Expression {
+  let current = expression;
+  while (
+    current.type === 'ParenthesizedExpression' ||
+    current.type === 'TSAsExpression' ||
+    current.type === 'TSSatisfiesExpression' ||
+    current.type === 'TSTypeAssertion' ||
+    current.type === 'TSNonNullExpression'
+  ) {
+    current = current.expression;
+  }
+  return current;
+}
+
+function resolveVariable(sourceCode: SourceCode, identifier: ESTree.IdentifierReference): Variable | null {
+  let scope: Scope | null = sourceCode.getScope(identifier);
+  while (scope !== null) {
+    const variable = scope.set.get(identifier.name);
+    if (variable !== undefined) return variable;
+    scope = scope.upper;
+  }
+  return null;
+}
+
+function variableDeclarator(variable: Variable): ESTree.VariableDeclarator | null {
+  if (variable.defs.length !== 1) return null;
+  const [definition] = variable.defs;
+  return definition?.type === 'Variable' && definition.node.type === 'VariableDeclarator' ? definition.node : null;
+}
+
+function isStableConstVariable(variable: Variable, declarator: ESTree.VariableDeclarator): boolean {
+  return (
+    declarator.parent.type === 'VariableDeclaration' &&
+    declarator.parent.kind === 'const' &&
+    variable.references.every((reference) => reference.init || !reference.isWrite())
+  );
+}
+
+function hasKnownEvidence(
+  sourceCode: SourceCode,
+  expression: ESTree.Expression,
+  visitedVariables = new Set<Variable>(),
+): boolean {
+  if (isKnownEvidenceExpression(expression)) return true;
+  const unwrapped = unwrapExpression(expression);
+  if (unwrapped.type !== 'Identifier') return false;
+  const variable = resolveVariable(sourceCode, unwrapped);
+  if (variable === null || visitedVariables.has(variable)) return false;
+  const declarator = variableDeclarator(variable);
+  if (declarator === null || declarator.init === null || !isStableConstVariable(variable, declarator)) {
+    return false;
+  }
+  visitedVariables.add(variable);
+  return hasKnownEvidence(sourceCode, declarator.init, visitedVariables);
+}
+
+function annotationTarget(
+  annotation: ESTree.TSTypeAnnotation | null | undefined,
+  environment: TypeEnvironment,
+): WideningTarget | null {
+  return annotation === null || annotation === undefined
+    ? null
+    : classifyWideningTarget(annotation.typeAnnotation, environment);
+}
+
+function enclosingFunction(node: ESTree.Node): FunctionExpression | null {
+  let current: ESTree.Node | null = node.parent;
+  while (current !== null && current.type !== 'Program') {
+    if (
+      current.type === 'ArrowFunctionExpression' ||
+      current.type === 'FunctionDeclaration' ||
+      current.type === 'FunctionExpression'
+    ) {
+      return current;
+    }
+    current = current.parent;
+  }
+  return null;
+}
+
+function sourceKeyName(sourceCode: SourceCode, key: ESTree.PropertyKey): string {
+  if (key.type === 'Identifier' || key.type === 'PrivateIdentifier') return key.name;
+  if (key.type === 'Literal') return String(key.value);
+  return sourceCode.getText(key);
+}
+
+function functionName(sourceCode: SourceCode, owner: FunctionExpression | null): string {
+  if (owner === null) return 'anonymous function';
+  if (owner.id !== null) return owner.id.name;
+  const parent = owner.parent;
+  if (parent.type === 'VariableDeclarator' && parent.id.type === 'Identifier') return parent.id.name;
+  if (parent.type === 'MethodDefinition') return sourceKeyName(sourceCode, parent.key);
+  return 'anonymous function';
+}
+
+function isEmptyObjectExpression(expression: ESTree.Expression): boolean {
+  const unwrapped = unwrapExpression(expression);
+  return unwrapped.type === 'ObjectExpression' && unwrapped.properties.length === 0;
+}
+
+function isDictionaryAccumulatorTarget(destination: WideningTarget): boolean {
+  return destination.kind === 'open dictionary' || destination.kind === 'generic container';
+}
+
+function hasParentAssertion(node: ESTree.Node): boolean {
+  return node.parent?.type === 'TSAsExpression' || node.parent?.type === 'TSTypeAssertion';
+}
+
+/** Detect sound syntactic cases where a known value is explicitly widened and loses evidence. */
+export const noKnownValueWideningRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow syntactically established values from flowing into explicitly broad or anonymous target types that discard useful evidence.',
+    },
+    messages: {
+      widening:
+        'The explicit {{target}} type on {{subject}} discards known type evidence. Keep inference, validate with `satisfies`, or use a named owner contract.',
+    },
+  },
+  createOnce(context) {
+    let environment: TypeEnvironment | null = null;
+
+    const reportFlow = (expression: ESTree.Expression, destination: WideningTarget | null, subject: string) => {
+      if (destination === null) return;
+      if (isDictionaryAccumulatorTarget(destination) && isEmptyObjectExpression(expression)) {
+        return;
+      }
+      if (!hasKnownEvidence(context.sourceCode, expression)) return;
+      context.report({
+        node: expression,
+        messageId: 'widening',
+        data: { subject, target: destination.kind },
+      });
+    };
+
+    const targetFromAnnotation = (annotation: ESTree.TSTypeAnnotation | null | undefined) =>
+      environment === null ? null : annotationTarget(annotation, environment);
+
+    return {
+      Program(node) {
+        environment = createTypeEnvironment(node);
+      },
+      VariableDeclarator(node) {
+        if (node.init === null || node.id.type !== 'Identifier') return;
+        reportFlow(node.init, targetFromAnnotation(node.id.typeAnnotation), `binding \`${node.id.name}\``);
+      },
+      PropertyDefinition(node) {
+        if (node.value === null) return;
+        reportFlow(
+          node.value,
+          targetFromAnnotation(node.typeAnnotation),
+          `property \`${sourceKeyName(context.sourceCode, node.key)}\``,
+        );
+      },
+      AccessorProperty(node) {
+        if (node.value === null) return;
+        reportFlow(
+          node.value,
+          targetFromAnnotation(node.typeAnnotation),
+          `property \`${sourceKeyName(context.sourceCode, node.key)}\``,
+        );
+      },
+      AssignmentExpression(node) {
+        if (node.operator !== '=' || node.left.type !== 'Identifier') return;
+        const variable = resolveVariable(context.sourceCode, node.left);
+        if (variable === null) return;
+        const declarator = variableDeclarator(variable);
+        if (declarator === null || declarator.id.type !== 'Identifier') return;
+        reportFlow(node.right, targetFromAnnotation(declarator.id.typeAnnotation), `binding \`${declarator.id.name}\``);
+      },
+      ReturnStatement(node) {
+        if (node.argument === null) return;
+        const owner = enclosingFunction(node);
+        reportFlow(
+          node.argument,
+          targetFromAnnotation(owner?.returnType),
+          `return value of \`${functionName(context.sourceCode, owner)}\``,
+        );
+      },
+      ArrowFunctionExpression(node) {
+        if (node.body.type === 'BlockStatement') return;
+        reportFlow(
+          node.body,
+          targetFromAnnotation(node.returnType),
+          `return value of \`${functionName(context.sourceCode, node)}\``,
+        );
+      },
+      TSAsExpression(node) {
+        if (environment === null || hasParentAssertion(node)) return;
+        reportFlow(node.expression, classifyWideningTarget(node.typeAnnotation, environment), 'assertion');
+      },
+      TSTypeAssertion(node) {
+        if (environment === null || hasParentAssertion(node)) return;
+        reportFlow(node.expression, classifyWideningTarget(node.typeAnnotation, environment), 'assertion');
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-module-mocking.ts
+++ b/tools/oxlint/anti-slop/rules/no-module-mocking.ts
@@ -1,0 +1,82 @@
+import { defineRule } from '@oxlint/plugins';
+
+import type { ESTree, Scope, SourceCode, Variable } from '@oxlint/plugins';
+
+const moduleMockMethods = new Set(['doMock', 'mock', 'unstable_mockModule']);
+
+function resolveVariable(sourceCode: SourceCode, identifier: ESTree.IdentifierReference): Variable | null {
+  let scope: Scope | null = sourceCode.getScope(identifier);
+  while (scope !== null) {
+    const variable = scope.set.get(identifier.name);
+    if (variable !== undefined) return variable;
+    scope = scope.upper;
+  }
+  return null;
+}
+
+function importedName(node: ESTree.Node): string | null {
+  if (node.type !== 'ImportSpecifier') return null;
+  return node.imported.type === 'Identifier' ? node.imported.name : node.imported.value;
+}
+
+function isTestFrameworkObject(
+  sourceCode: SourceCode,
+  expression: ESTree.Expression,
+): expression is ESTree.IdentifierReference {
+  if (expression.type !== 'Identifier') return false;
+  if ((expression.name === 'vi' || expression.name === 'jest') && sourceCode.isGlobalReference(expression)) {
+    return true;
+  }
+
+  const variable = resolveVariable(sourceCode, expression);
+  if (variable === null || variable.defs.length === 0) {
+    return expression.name === 'vi' || expression.name === 'jest';
+  }
+  return variable.defs.some((definition) => {
+    if (definition.type !== 'ImportBinding' || definition.parent?.type !== 'ImportDeclaration') {
+      return false;
+    }
+    const source = definition.parent.source.value;
+    const name = importedName(definition.node);
+    return (source === 'vitest' && name === 'vi') || (source === '@jest/globals' && name === 'jest');
+  });
+}
+
+function moduleMockCall(sourceCode: SourceCode, callee: ESTree.Expression): boolean {
+  if (!('property' in callee) || !('object' in callee) || !('computed' in callee)) return false;
+  if (!isTestFrameworkObject(sourceCode, callee.object)) return false;
+  const property = callee.property;
+  const method = callee.computed
+    ? property.type === 'Literal' &&
+      (property.value === 'doMock' || property.value === 'mock' || property.value === 'unstable_mockModule')
+      ? property.value
+      : null
+    : property.type === 'Identifier'
+      ? property.name
+      : null;
+  return method !== null && moduleMockMethods.has(method);
+}
+
+/** Ban test framework module mocking in favor of real dependency seams. */
+export const noModuleMockingRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow Vitest and Jest module mocking; tests must replace dependencies through real interfaces.',
+    },
+    messages: {
+      moduleMock:
+        'Replace module mocking with dependency injection through a real interface, service layer, or faithful test implementation.',
+    },
+  },
+  createOnce(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.type === 'Super' || node.callee.type === 'V8IntrinsicExpression') return;
+        if (moduleMockCall(context.sourceCode, node.callee)) {
+          context.report({ node, messageId: 'moduleMock' });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-object-parameters.ts
+++ b/tools/oxlint/anti-slop/rules/no-object-parameters.ts
@@ -1,0 +1,117 @@
+import { defineRule } from '@oxlint/plugins';
+
+import type { ESTree, SourceCode } from '@oxlint/plugins';
+
+import { lexicalTypeParameterNames } from '../shared/lexical-type-parameters.ts';
+
+type Parameter = ESTree.ParamPattern;
+type ParameterOwner =
+  | ESTree.ArrowFunctionExpression
+  | ESTree.Function
+  | ESTree.TSCallSignatureDeclaration
+  | ESTree.TSConstructSignatureDeclaration
+  | ESTree.TSConstructorType
+  | ESTree.TSFunctionType
+  | ESTree.TSMethodSignature;
+
+function parameterAnnotation(parameter: Parameter): ESTree.TSTypeAnnotation | null | undefined {
+  if (parameter.type === 'TSParameterProperty') {
+    return parameterAnnotation(parameter.parameter);
+  }
+  if (parameter.type === 'RestElement') {
+    return parameter.typeAnnotation ?? parameterAnnotation(parameter.argument);
+  }
+  if (parameter.type === 'AssignmentPattern') {
+    return parameter.typeAnnotation ?? parameter.left.typeAnnotation;
+  }
+  return parameter.typeAnnotation;
+}
+
+function parameterName(parameter: Parameter, sourceCode: SourceCode): string {
+  return parameter.type === 'Identifier'
+    ? parameter.name
+    : sourceCode.getText(parameter).replace(/\s*:\s*object\s*$/u, '');
+}
+
+/** Ban the broad object type on function inputs, including local aliases to object. */
+export const noObjectParametersRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow object function parameters; inputs must use an owner-provided type and be parsed at their boundary.',
+    },
+    messages: {
+      objectParameter:
+        'Parameter `{{parameter}}` uses the broad `object` type. Accept a named owner type; parse external input at its boundary before calling this function.',
+    },
+  },
+  createOnce(context) {
+    const aliases = new Map<string, ESTree.TSType>();
+
+    const resolvesToObject = (
+      type: ESTree.TSType,
+      shadowedAliases: ReadonlySet<string>,
+      visited = new Set<string>(),
+    ): boolean => {
+      if (type.type === 'TSObjectKeyword') return true;
+      if (type.type === 'TSParenthesizedType') return resolvesToObject(type.typeAnnotation, shadowedAliases, visited);
+      if (type.type === 'TSUnionType') {
+        return type.types.some((member) => resolvesToObject(member, shadowedAliases, visited));
+      }
+      if (
+        type.type !== 'TSTypeReference' ||
+        type.typeName.type !== 'Identifier' ||
+        (type.typeArguments !== null && type.typeArguments !== undefined && type.typeArguments.params.length > 0) ||
+        visited.has(type.typeName.name) ||
+        shadowedAliases.has(type.typeName.name)
+      ) {
+        return false;
+      }
+      const alias = aliases.get(type.typeName.name);
+      if (alias === undefined) return false;
+      const nextVisited = new Set(visited);
+      nextVisited.add(type.typeName.name);
+      return resolvesToObject(alias, shadowedAliases, nextVisited);
+    };
+
+    const checkParameters = (node: ParameterOwner) => {
+      const shadowedAliases = lexicalTypeParameterNames(node, context.sourceCode.visitorKeys);
+      for (const parameter of node.params) {
+        const annotation = parameterAnnotation(parameter);
+        if (annotation === null || annotation === undefined) continue;
+        if (!resolvesToObject(annotation.typeAnnotation, shadowedAliases)) continue;
+        context.report({
+          node: annotation.typeAnnotation,
+          messageId: 'objectParameter',
+          data: { parameter: parameterName(parameter, context.sourceCode) },
+        });
+      }
+    };
+
+    return {
+      Program(node) {
+        aliases.clear();
+        for (const statement of node.body) {
+          const declaration = statement.type === 'ExportNamedDeclaration' ? statement.declaration : statement;
+          if (
+            declaration?.type === 'TSTypeAliasDeclaration' &&
+            (declaration.typeParameters === null || declaration.typeParameters === undefined)
+          ) {
+            aliases.set(declaration.id.name, declaration.typeAnnotation);
+          }
+        }
+      },
+      ArrowFunctionExpression: checkParameters,
+      FunctionDeclaration: checkParameters,
+      FunctionExpression: checkParameters,
+      TSCallSignatureDeclaration: checkParameters,
+      TSConstructSignatureDeclaration: checkParameters,
+      TSConstructorType: checkParameters,
+      TSDeclareFunction: checkParameters,
+      TSEmptyBodyFunctionExpression: checkParameters,
+      TSFunctionType: checkParameters,
+      TSMethodSignature: checkParameters,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-reflect-apply.ts
+++ b/tools/oxlint/anti-slop/rules/no-reflect-apply.ts
@@ -1,0 +1,28 @@
+import { defineRule } from '@oxlint/plugins';
+
+import { isGlobalReflectMethodCall } from '../shared/reflect-method.ts';
+
+/** Ban Reflect.apply, which bypasses ordinary typed function calls. */
+export const noReflectApplyRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow Reflect.apply; call typed functions directly or model dynamic dispatch behind an interface.',
+    },
+    messages: {
+      reflectApply:
+        'Replace `Reflect.apply` with a typed function call. Model dynamic dispatch behind a named interface.',
+    },
+  },
+  createOnce(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.type === 'Super' || node.callee.type === 'V8IntrinsicExpression') return;
+        if (isGlobalReflectMethodCall(context.sourceCode, node.callee, 'apply')) {
+          context.report({ node, messageId: 'reflectApply' });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-reflect-get.ts
+++ b/tools/oxlint/anti-slop/rules/no-reflect-get.ts
@@ -1,0 +1,27 @@
+import { defineRule } from '@oxlint/plugins';
+
+import { isGlobalReflectMethodCall } from '../shared/reflect-method.ts';
+
+/** Ban Reflect.get, which bypasses ordinary property access and useful type evidence. */
+export const noReflectGetRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow Reflect.get; use typed property access or parse dynamic input into a domain type.',
+    },
+    messages: {
+      reflectGet:
+        'Replace `Reflect.get` with typed property access. Parse dynamic input into a named domain type before reading it.',
+    },
+  },
+  createOnce(context) {
+    return {
+      CallExpression(node) {
+        if (node.callee.type === 'Super' || node.callee.type === 'V8IntrinsicExpression') return;
+        if (isGlobalReflectMethodCall(context.sourceCode, node.callee, 'get')) {
+          context.report({ node, messageId: 'reflectGet' });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-runtime-typeof.ts
+++ b/tools/oxlint/anti-slop/rules/no-runtime-typeof.ts
@@ -1,0 +1,59 @@
+import { defineRule } from '@oxlint/plugins';
+
+import type { ESTree } from '@oxlint/plugins';
+
+type RuntimeFunction = ESTree.ArrowFunctionExpression | ESTree.Function;
+
+function isRuntimeFunction(node: ESTree.Node): node is RuntimeFunction {
+  return (
+    node.type === 'ArrowFunctionExpression' || node.type === 'FunctionDeclaration' || node.type === 'FunctionExpression'
+  );
+}
+
+function isInsideTypeGuard(node: ESTree.Node): boolean {
+  let current: ESTree.Node | null = node.parent;
+  while (current !== null && current.type !== 'Program') {
+    if (isRuntimeFunction(current)) {
+      return current.returnType?.typeAnnotation.type === 'TSTypePredicate';
+    }
+    current = current.parent;
+  }
+  return false;
+}
+
+/** Disallow runtime typeof checks that narrow unparsed values instead of decoding them. */
+export const noRuntimeTypeofRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow runtime typeof checks; external values must be decoded into meaningful types at their I/O boundary.',
+    },
+    messages: {
+      runtimeTypeof:
+        'A `typeof` check narrows a representation without establishing its contract. Parse input at its I/O boundary, then branch on the domain value.',
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          allowInTypeGuards: { type: 'boolean' },
+        },
+        additionalProperties: false,
+      },
+    ],
+    defaultOptions: [{ allowInTypeGuards: false }],
+  },
+  createOnce(context) {
+    return {
+      UnaryExpression(node) {
+        const option = context.options?.[0];
+        const allowInTypeGuards =
+          typeof option === 'object' && option !== null && !Array.isArray(option) && option.allowInTypeGuards === true;
+        if (node.operator === 'typeof' && (!allowInTypeGuards || !isInsideTypeGuard(node))) {
+          context.report({ node, messageId: 'runtimeTypeof' });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-shape-in-symbol-names.ts
+++ b/tools/oxlint/anti-slop/rules/no-shape-in-symbol-names.ts
@@ -1,0 +1,39 @@
+import { defineRule } from '@oxlint/plugins';
+import type { ESTree } from '@oxlint/plugins';
+
+const FORBIDDEN_SYMBOL_NAME = 'shape';
+
+function containsForbiddenSymbolName(name: string): boolean {
+  return name.toLowerCase().includes(FORBIDDEN_SYMBOL_NAME);
+}
+
+/** Ban the case-insensitive substring "shape" in every JavaScript and TypeScript symbol name. */
+export const noForbiddenTermInSymbolNamesRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow the case-insensitive substring "shape" in JavaScript, TypeScript, private, and JSX symbol names.',
+    },
+    messages: {
+      forbiddenSymbolName:
+        'Rename symbol "{{name}}" for its domain role; "shape" describes structure rather than ownership.',
+    },
+  },
+  createOnce(context) {
+    const reportForbiddenSymbolName = (node: ESTree.Node & { name: string }) => {
+      if (!containsForbiddenSymbolName(node.name)) return;
+      context.report({
+        node,
+        messageId: 'forbiddenSymbolName',
+        data: { name: node.name },
+      });
+    };
+
+    return {
+      Identifier: reportForbiddenSymbolName,
+      PrivateIdentifier: reportForbiddenSymbolName,
+      JSXIdentifier: reportForbiddenSymbolName,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-unknown-parameters.ts
+++ b/tools/oxlint/anti-slop/rules/no-unknown-parameters.ts
@@ -1,0 +1,81 @@
+import { defineRule } from '@oxlint/plugins';
+import type { ESTree } from '@oxlint/plugins';
+
+type Parameter = ESTree.ParamPattern;
+type ParameterOwner =
+  | ESTree.ArrowFunctionExpression
+  | ESTree.Function
+  | ESTree.TSCallSignatureDeclaration
+  | ESTree.TSConstructSignatureDeclaration
+  | ESTree.TSConstructorType
+  | ESTree.TSFunctionType
+  | ESTree.TSMethodSignature;
+
+function parameterAnnotation(parameter: Parameter): ESTree.TSTypeAnnotation | null | undefined {
+  if (parameter.type === 'TSParameterProperty') {
+    return parameterAnnotation(parameter.parameter);
+  }
+  if (parameter.type === 'RestElement') {
+    return parameter.typeAnnotation ?? parameterAnnotation(parameter.argument);
+  }
+  if (parameter.type === 'AssignmentPattern') {
+    return parameter.typeAnnotation ?? parameter.left.typeAnnotation;
+  }
+  return parameter.typeAnnotation;
+}
+
+function parameterName(parameter: Parameter, sourceText: string): string {
+  if (parameter.type === 'TSParameterProperty') {
+    return parameterName(parameter.parameter, sourceText);
+  }
+  if (parameter.type === 'AssignmentPattern') {
+    return parameterName(parameter.left, sourceText);
+  }
+  if (parameter.type === 'RestElement') {
+    return parameterName(parameter.argument, sourceText);
+  }
+  return parameter.type === 'Identifier' ? parameter.name : sourceText.replace(/\s*:\s*unknown\s*$/u, '');
+}
+
+/** Disallow unknown inputs except explicitly named error-cause enrichment. */
+export const noUnknownParametersRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow explicitly unknown function parameters except `cause`; decode unknown input at its I/O boundary instead.',
+    },
+    messages: {
+      unknownParameter:
+        'Parameter `{{parameter}}` leaves input unparsed. Accept a named domain type; run the expected schema or parser at the I/O boundary before calling this function.',
+    },
+  },
+  createOnce(context) {
+    const checkParameters = (node: ParameterOwner) => {
+      for (const parameter of node.params) {
+        const annotation = parameterAnnotation(parameter);
+        if (annotation?.typeAnnotation.type !== 'TSUnknownKeyword') continue;
+        const name = parameterName(parameter, context.sourceCode.getText(parameter));
+        if (name === 'cause') continue;
+        context.report({
+          node: annotation.typeAnnotation,
+          messageId: 'unknownParameter',
+          data: { parameter: name },
+        });
+      }
+    };
+
+    return {
+      ArrowFunctionExpression: checkParameters,
+      FunctionDeclaration: checkParameters,
+      FunctionExpression: checkParameters,
+      TSCallSignatureDeclaration: checkParameters,
+      TSConstructSignatureDeclaration: checkParameters,
+      TSConstructorType: checkParameters,
+      TSDeclareFunction: checkParameters,
+      TSEmptyBodyFunctionExpression: checkParameters,
+      TSFunctionType: checkParameters,
+      TSMethodSignature: checkParameters,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-unknown-returns.ts
+++ b/tools/oxlint/anti-slop/rules/no-unknown-returns.ts
@@ -1,0 +1,103 @@
+import { defineRule } from '@oxlint/plugins';
+
+import type { ESTree } from '@oxlint/plugins';
+
+import { lexicalTypeParameterNames } from '../shared/lexical-type-parameters.ts';
+
+type FunctionWithReturnType =
+  | ESTree.ArrowFunctionExpression
+  | ESTree.Function
+  | ESTree.TSCallSignatureDeclaration
+  | ESTree.TSConstructSignatureDeclaration
+  | ESTree.TSConstructorType
+  | ESTree.TSFunctionType
+  | ESTree.TSMethodSignature;
+
+function referencedAliasName(type: ESTree.TSType): string | null {
+  if (type.type === 'TSParenthesizedType') return referencedAliasName(type.typeAnnotation);
+  if (type.type !== 'TSTypeReference' || type.typeName.type !== 'Identifier') return null;
+  return type.typeArguments === null || type.typeArguments === undefined || type.typeArguments.params.length === 0
+    ? type.typeName.name
+    : null;
+}
+
+/** Ban function contracts that return unknown instead of a parsed domain type. */
+export const noUnknownReturnsRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow functions whose explicit return contract is unknown or Promise<unknown>.',
+    },
+    messages: {
+      unknownReturn:
+        'This function exposes `unknown` to its caller. Parse the value at its boundary and return a named domain type.',
+    },
+  },
+  createOnce(context) {
+    const aliases = new Map<string, ESTree.TSTypeAliasDeclaration>();
+
+    const resolvesToUnknown = (
+      type: ESTree.TSType,
+      shadowedAliases: ReadonlySet<string>,
+      visited = new Set<string>(),
+    ): boolean => {
+      if (type.type === 'TSUnknownKeyword') return true;
+      if (type.type === 'TSParenthesizedType') {
+        return resolvesToUnknown(type.typeAnnotation, shadowedAliases, visited);
+      }
+      if (type.type === 'TSUnionType') {
+        return type.types.some((member) => resolvesToUnknown(member, shadowedAliases, visited));
+      }
+      if (
+        type.type === 'TSTypeReference' &&
+        type.typeName.type === 'Identifier' &&
+        (type.typeName.name === 'Promise' || type.typeName.name === 'PromiseLike')
+      ) {
+        const value = type.typeArguments?.params[0];
+        return value !== undefined && resolvesToUnknown(value, shadowedAliases, visited);
+      }
+      const name = referencedAliasName(type);
+      if (name === null || visited.has(name) || shadowedAliases.has(name)) return false;
+      const alias = aliases.get(name);
+      if (alias === undefined || (alias.typeParameters !== null && alias.typeParameters !== undefined)) {
+        return false;
+      }
+      const nextVisited = new Set(visited);
+      nextVisited.add(name);
+      return resolvesToUnknown(alias.typeAnnotation, shadowedAliases, nextVisited);
+    };
+
+    const checkReturnType = (node: FunctionWithReturnType) => {
+      const annotation = node.returnType;
+      if (annotation === null || annotation === undefined) return;
+      if (
+        !resolvesToUnknown(annotation.typeAnnotation, lexicalTypeParameterNames(node, context.sourceCode.visitorKeys))
+      ) {
+        return;
+      }
+      context.report({ node: annotation.typeAnnotation, messageId: 'unknownReturn' });
+    };
+
+    return {
+      Program(node) {
+        aliases.clear();
+        for (const statement of node.body) {
+          const declaration = statement.type === 'ExportNamedDeclaration' ? statement.declaration : statement;
+          if (declaration?.type === 'TSTypeAliasDeclaration') {
+            aliases.set(declaration.id.name, declaration);
+          }
+        }
+      },
+      ArrowFunctionExpression: checkReturnType,
+      FunctionDeclaration: checkReturnType,
+      FunctionExpression: checkReturnType,
+      TSCallSignatureDeclaration: checkReturnType,
+      TSConstructSignatureDeclaration: checkReturnType,
+      TSConstructorType: checkReturnType,
+      TSDeclareFunction: checkReturnType,
+      TSEmptyBodyFunctionExpression: checkReturnType,
+      TSFunctionType: checkReturnType,
+      TSMethodSignature: checkReturnType,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-unknown-type-aliases.ts
+++ b/tools/oxlint/anti-slop/rules/no-unknown-type-aliases.ts
@@ -1,0 +1,63 @@
+import { defineRule } from '@oxlint/plugins';
+
+import type { ESTree } from '@oxlint/plugins';
+
+function referencedAliasName(type: ESTree.TSType): string | null {
+  if (type.type === 'TSParenthesizedType') return referencedAliasName(type.typeAnnotation);
+  if (type.type !== 'TSTypeReference' || type.typeName.type !== 'Identifier') return null;
+  return type.typeArguments === null || type.typeArguments === undefined || type.typeArguments.params.length === 0
+    ? type.typeName.name
+    : null;
+}
+
+/** Ban named aliases that merely conceal TypeScript's unknown top type. */
+export const noUnknownTypeAliasesRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow type aliases whose resolved type is unknown; unknown must remain visible at an allowed boundary.',
+    },
+    messages: {
+      unknownAlias:
+        'Type alias `{{alias}}` hides `unknown`. Keep `unknown` explicit at the parsing boundary or on an allowed `cause` field; otherwise use the parsed owner type.',
+    },
+  },
+  createOnce(context) {
+    const aliases = new Map<string, ESTree.TSTypeAliasDeclaration>();
+
+    const resolvesToUnknown = (type: ESTree.TSType, visited = new Set<string>()): boolean => {
+      if (type.type === 'TSUnknownKeyword') return true;
+      if (type.type === 'TSParenthesizedType') return resolvesToUnknown(type.typeAnnotation, visited);
+      const name = referencedAliasName(type);
+      if (name === null || visited.has(name)) return false;
+      const alias = aliases.get(name);
+      if (alias === undefined || (alias.typeParameters !== null && alias.typeParameters !== undefined)) {
+        return false;
+      }
+      const nextVisited = new Set(visited);
+      nextVisited.add(name);
+      return resolvesToUnknown(alias.typeAnnotation, nextVisited);
+    };
+
+    return {
+      Program(node) {
+        aliases.clear();
+        for (const statement of node.body) {
+          const declaration = statement.type === 'ExportNamedDeclaration' ? statement.declaration : statement;
+          if (declaration?.type === 'TSTypeAliasDeclaration') {
+            aliases.set(declaration.id.name, declaration);
+          }
+        }
+        for (const alias of aliases.values()) {
+          if (!resolvesToUnknown(alias.typeAnnotation, new Set([alias.id.name]))) continue;
+          context.report({
+            node: alias.id,
+            messageId: 'unknownAlias',
+            data: { alias: alias.id.name },
+          });
+        }
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-unsafe-dictionary-type.ts
+++ b/tools/oxlint/anti-slop/rules/no-unsafe-dictionary-type.ts
@@ -1,0 +1,125 @@
+import { defineRule } from '@oxlint/plugins';
+
+import {
+  classifyUnsafeDictionary,
+  classifyUnsafeDictionaryValue,
+  createTypeEnvironment,
+  type TypeEnvironment,
+} from '../shared/dictionary-types.ts';
+
+import type { ESTree } from '@oxlint/plugins';
+
+const typeNodeKinds: ReadonlySet<string> = new Set([
+  'JSDocNonNullableType',
+  'JSDocNullableType',
+  'JSDocUnknownType',
+  'TSAnyKeyword',
+  'TSArrayType',
+  'TSBigIntKeyword',
+  'TSBooleanKeyword',
+  'TSConditionalType',
+  'TSConstructorType',
+  'TSFunctionType',
+  'TSImportType',
+  'TSIndexedAccessType',
+  'TSInferType',
+  'TSIntersectionType',
+  'TSIntrinsicKeyword',
+  'TSLiteralType',
+  'TSMappedType',
+  'TSNamedTupleMember',
+  'TSNeverKeyword',
+  'TSNullKeyword',
+  'TSNumberKeyword',
+  'TSObjectKeyword',
+  'TSParenthesizedType',
+  'TSStringKeyword',
+  'TSSymbolKeyword',
+  'TSTemplateLiteralType',
+  'TSThisType',
+  'TSTupleType',
+  'TSTypeLiteral',
+  'TSTypeOperator',
+  'TSTypePredicate',
+  'TSTypeQuery',
+  'TSTypeReference',
+  'TSUndefinedKeyword',
+  'TSUnionType',
+  'TSUnknownKeyword',
+  'TSVoidKeyword',
+]);
+
+function isTypeNode(node: ESTree.Node): node is ESTree.TSType {
+  return typeNodeKinds.has(node.type);
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+  return type.typeName.type === 'Identifier' ? type.typeName.name : null;
+}
+
+function isInsideTypeAliasDeclaration(node: ESTree.Node): boolean {
+  let current: ESTree.Node | null = node.parent;
+  while (current !== null && current.type !== 'Program') {
+    if (current.type === 'TSTypeAliasDeclaration') return true;
+    current = current.parent;
+  }
+  return false;
+}
+
+function isPlainAliasConsumerUse(node: ESTree.TSType, environment: TypeEnvironment): boolean {
+  if (node.type !== 'TSTypeReference' || node.typeArguments?.params.length) return false;
+  const name = typeReferenceName(node);
+  return name !== null && environment.aliases.has(name) && !isInsideTypeAliasDeclaration(node);
+}
+
+function shouldReportType(node: ESTree.TSType, environment: TypeEnvironment): boolean {
+  if (isPlainAliasConsumerUse(node, environment)) return false;
+  if (classifyUnsafeDictionary(node, environment) === null) return false;
+  let current: ESTree.Node | null = node.parent;
+  while (current !== null && current.type !== 'Program') {
+    if (isTypeNode(current) && classifyUnsafeDictionary(current, environment) !== null) return false;
+    current = current.parent;
+  }
+  return true;
+}
+
+/** Disallow object-dictionary contracts whose direct value type is an unsafe escape hatch. */
+export const noUnsafeDictionaryTypeRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow object-dictionary contracts whose direct value type is unknown, any, object, {}, or a union/alias containing one of those escape hatches.',
+    },
+    messages: {
+      unsafeDictionary:
+        "This dictionary's {{value}} value type gives callers no concrete value contract. Use an owner/schema-derived value type; parse external payloads before insertion.",
+    },
+  },
+  createOnce(context) {
+    let environment: TypeEnvironment | null = null;
+    const report = (node: ESTree.Node, value: string) => {
+      context.report({ node, messageId: 'unsafeDictionary', data: { value } });
+    };
+    const reportIfUnsafe = (node: ESTree.TSType) => {
+      if (environment === null || !shouldReportType(node, environment)) return;
+      const unsafe = classifyUnsafeDictionary(node, environment);
+      if (unsafe === null) return;
+      report(node, unsafe.unsafeValue);
+    };
+
+    return {
+      Program(node) {
+        environment = createTypeEnvironment(node);
+      },
+      TSTypeReference: reportIfUnsafe,
+      TSTypeLiteral: reportIfUnsafe,
+      TSMappedType: reportIfUnsafe,
+      TSIndexSignature(node) {
+        if (environment === null || node.typeAnnotation === null || node.parent.type === 'TSTypeLiteral') return;
+        const unsafe = classifyUnsafeDictionaryValue(node.typeAnnotation.typeAnnotation, environment);
+        if (unsafe !== null) report(node, unsafe.unsafeValue);
+      },
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/no-widen-then-assert.ts
+++ b/tools/oxlint/anti-slop/rules/no-widen-then-assert.ts
@@ -1,0 +1,342 @@
+import { defineRule } from '@oxlint/plugins';
+import type { ESTree, Variable } from '@oxlint/plugins';
+
+type BroadTypeKind = 'top' | 'object' | 'record';
+
+type KnownValueEvidence = {
+  readonly type: ESTree.TSType | null;
+};
+
+const functionBoundaryTypes = new Set([
+  'ArrowFunctionExpression',
+  'FunctionDeclaration',
+  'FunctionExpression',
+  'TSDeclareFunction',
+  'TSEmptyBodyFunctionExpression',
+]);
+
+function unwrapExpressionParentheses(expression: ESTree.Expression): ESTree.Expression {
+  let current = expression;
+  while (current.type === 'ParenthesizedExpression') current = current.expression;
+  return current;
+}
+
+function unwrapTypeParentheses(type: ESTree.TSType): ESTree.TSType {
+  let current = type;
+  while (current.type === 'TSParenthesizedType') current = current.typeAnnotation;
+  return current;
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+  return type.typeName.type === 'Identifier' ? type.typeName.name : null;
+}
+
+function isUnknownOrAnyType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  return unwrapped.type === 'TSUnknownKeyword' || unwrapped.type === 'TSAnyKeyword';
+}
+
+function isBroadRecordKeyType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  if (
+    unwrapped.type === 'TSStringKeyword' ||
+    unwrapped.type === 'TSNumberKeyword' ||
+    unwrapped.type === 'TSSymbolKeyword'
+  ) {
+    return true;
+  }
+  if (unwrapped.type === 'TSUnionType') return unwrapped.types.every(isBroadRecordKeyType);
+  return unwrapped.type === 'TSTypeReference' && typeReferenceName(unwrapped) === 'PropertyKey';
+}
+
+function isBroadRecordType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+
+  if (unwrapped.type === 'TSTypeReference') {
+    if (typeReferenceName(unwrapped) === 'Readonly') {
+      const [inner] = unwrapped.typeArguments?.params ?? [];
+      return inner !== undefined && isBroadRecordType(inner);
+    }
+
+    if (typeReferenceName(unwrapped) !== 'Record') return false;
+    const parameters = unwrapped.typeArguments?.params ?? [];
+    return (
+      parameters.length === 2 &&
+      parameters[0] !== undefined &&
+      parameters[1] !== undefined &&
+      isBroadRecordKeyType(parameters[0]) &&
+      isUnknownOrAnyType(parameters[1])
+    );
+  }
+
+  if (unwrapped.type !== 'TSTypeLiteral' || unwrapped.members.length !== 1) return false;
+  const [member] = unwrapped.members;
+  const [parameter] = member?.type === 'TSIndexSignature' ? member.parameters : [];
+  return (
+    member?.type === 'TSIndexSignature' &&
+    member.parameters.length === 1 &&
+    parameter !== undefined &&
+    isBroadRecordKeyType(parameter.typeAnnotation.typeAnnotation) &&
+    isUnknownOrAnyType(member.typeAnnotation.typeAnnotation)
+  );
+}
+
+function broadTypeKind(type: ESTree.TSType): BroadTypeKind | null {
+  const unwrapped = unwrapTypeParentheses(type);
+  if (unwrapped.type === 'TSUnknownKeyword' || unwrapped.type === 'TSAnyKeyword') return 'top';
+  if (unwrapped.type === 'TSObjectKeyword') return 'object';
+  return isBroadRecordType(unwrapped) ? 'record' : null;
+}
+
+function assertedExpression(node: ESTree.TSAsExpression | ESTree.TSTypeAssertion): ESTree.Expression {
+  return unwrapExpressionParentheses(node.expression);
+}
+
+function assertionFromExpression(expression: ESTree.Expression): ESTree.TSAsExpression | ESTree.TSTypeAssertion | null {
+  const unwrapped = unwrapExpressionParentheses(expression);
+  return unwrapped.type === 'TSAsExpression' || unwrapped.type === 'TSTypeAssertion' ? unwrapped : null;
+}
+
+function normalizedTypeText(sourceText: string, type: ESTree.TSType): string {
+  return sourceText.slice(type.start, type.end).replaceAll(/\s+/gu, '');
+}
+
+function typesHaveSameSyntax(sourceText: string, left: ESTree.TSType | null, right: ESTree.TSType): boolean {
+  return (
+    left !== null &&
+    normalizedTypeText(sourceText, unwrapTypeParentheses(left)) ===
+      normalizedTypeText(sourceText, unwrapTypeParentheses(right))
+  );
+}
+
+function isDefinitelyObjectType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  switch (unwrapped.type) {
+    case 'TSArrayType':
+    case 'TSConstructorType':
+    case 'TSFunctionType':
+    case 'TSMappedType':
+    case 'TSObjectKeyword':
+    case 'TSTupleType':
+      return true;
+    case 'TSTypeLiteral':
+      return unwrapped.members.length > 0;
+    case 'TSIntersectionType':
+      return unwrapped.types.every(isDefinitelyObjectType);
+    case 'TSTypeOperator':
+      return unwrapped.operator === 'readonly' && isDefinitelyObjectType(unwrapped.typeAnnotation);
+    default:
+      return false;
+  }
+}
+
+function isDefinitelyNarrowerRecordType(type: ESTree.TSType): boolean {
+  const unwrapped = unwrapTypeParentheses(type);
+  if (unwrapped.type === 'TSTypeLiteral') {
+    return unwrapped.members.some((member) => member.type !== 'TSIndexSignature');
+  }
+
+  if (unwrapped.type !== 'TSTypeReference') return false;
+  if (typeReferenceName(unwrapped) === 'Readonly') {
+    const [inner] = unwrapped.typeArguments?.params ?? [];
+    return inner !== undefined && isDefinitelyNarrowerRecordType(inner);
+  }
+  if (typeReferenceName(unwrapped) !== 'Record') return false;
+
+  const parameters = unwrapped.typeArguments?.params ?? [];
+  return parameters.length === 2 && parameters[1] !== undefined && !isUnknownOrAnyType(parameters[1]);
+}
+
+function functionBoundary(node: ESTree.Node): ESTree.Node | null {
+  let current = node.parent;
+  while (current !== null && current.type !== 'Program') {
+    if (functionBoundaryTypes.has(current.type)) return current;
+    current = current.parent;
+  }
+  return null;
+}
+
+function resolvedVariableForIdentifier(
+  scopes: readonly {
+    readonly references: readonly {
+      readonly identifier: ESTree.Node;
+      readonly resolved: Variable | null;
+    }[];
+  }[],
+  identifier: ESTree.IdentifierReference,
+): Variable | null {
+  for (const scope of scopes) {
+    const reference = scope.references.find(
+      (candidate) => candidate.identifier.start === identifier.start && candidate.identifier.end === identifier.end,
+    );
+    if (reference !== undefined) return reference.resolved;
+  }
+  return null;
+}
+
+function variableDeclarator(variable: Variable): ESTree.VariableDeclarator | null {
+  for (const definition of variable.defs) {
+    if (definition.type === 'Variable' && definition.node.type === 'VariableDeclarator') {
+      return definition.node;
+    }
+  }
+  return null;
+}
+
+function knownValueEvidence(
+  expression: ESTree.Expression,
+  scopes: Parameters<typeof resolvedVariableForIdentifier>[0],
+  boundary: ESTree.Node | null,
+  visitedVariables: ReadonlySet<Variable>,
+): KnownValueEvidence | null {
+  const unwrapped = unwrapExpressionParentheses(expression);
+
+  if (unwrapped.type === 'TSAsExpression' || unwrapped.type === 'TSTypeAssertion') {
+    if (broadTypeKind(unwrapped.typeAnnotation) !== null) return null;
+    return { type: unwrapped.typeAnnotation };
+  }
+
+  if (unwrapped.type === 'Literal' || unwrapped.type === 'TemplateLiteral') {
+    return { type: null };
+  }
+
+  if (
+    unwrapped.type === 'ArrayExpression' ||
+    unwrapped.type === 'ArrowFunctionExpression' ||
+    unwrapped.type === 'ClassExpression' ||
+    unwrapped.type === 'FunctionExpression' ||
+    unwrapped.type === 'NewExpression' ||
+    unwrapped.type === 'ObjectExpression'
+  ) {
+    return { type: null };
+  }
+
+  if (unwrapped.type !== 'Identifier') return null;
+  const variable = resolvedVariableForIdentifier(scopes, unwrapped);
+  if (variable === null || visitedVariables.has(variable)) return null;
+
+  const annotatedIdentifier = variable.identifiers.find(
+    (identifier) => identifier.typeAnnotation !== null && identifier.typeAnnotation !== undefined,
+  );
+  const annotation = annotatedIdentifier?.typeAnnotation?.typeAnnotation;
+  if (annotation !== undefined && annotatedIdentifier !== undefined) {
+    if (functionBoundary(annotatedIdentifier) !== boundary || broadTypeKind(annotation) !== null) {
+      return null;
+    }
+    return { type: annotation };
+  }
+
+  const declarator = variableDeclarator(variable);
+  if (
+    declarator === null ||
+    declarator.parent.type !== 'VariableDeclaration' ||
+    declarator.parent.kind !== 'const' ||
+    declarator.init === null ||
+    variable.references.some((reference) => reference.isWrite() && !reference.init) ||
+    functionBoundary(declarator) !== boundary
+  ) {
+    return null;
+  }
+
+  return knownValueEvidence(declarator.init, scopes, boundary, new Set([...visitedVariables, variable]));
+}
+
+function widenedBinding(
+  variable: Variable,
+  scopes: Parameters<typeof resolvedVariableForIdentifier>[0],
+): {
+  readonly broadKind: BroadTypeKind;
+  readonly evidence: KnownValueEvidence;
+  readonly declaredAt: number;
+  readonly boundary: ESTree.Node | null;
+} | null {
+  const declarator = variableDeclarator(variable);
+  if (
+    declarator === null ||
+    declarator.parent.type !== 'VariableDeclaration' ||
+    declarator.parent.kind !== 'const' ||
+    declarator.id.type !== 'Identifier' ||
+    declarator.init === null ||
+    variable.references.some((reference) => reference.isWrite() && !reference.init)
+  ) {
+    return null;
+  }
+
+  const boundary = functionBoundary(declarator);
+  const declaredType = declarator.id.typeAnnotation?.typeAnnotation;
+  const initializerAssertion = assertionFromExpression(declarator.init);
+  const initializerBroadKind =
+    initializerAssertion === null ? null : broadTypeKind(initializerAssertion.typeAnnotation);
+  const declaredBroadKind = declaredType === undefined ? null : broadTypeKind(declaredType);
+  const broadKind = declaredBroadKind ?? initializerBroadKind;
+  if (broadKind === null) return null;
+
+  const originalExpression =
+    initializerAssertion !== null && initializerBroadKind !== null
+      ? assertedExpression(initializerAssertion)
+      : declarator.init;
+  const evidence = knownValueEvidence(originalExpression, scopes, boundary, new Set([variable]));
+  return evidence === null ? null : { broadKind, evidence, declaredAt: declarator.end, boundary };
+}
+
+function assertionIsNarrower(
+  sourceText: string,
+  broadKind: BroadTypeKind,
+  evidence: KnownValueEvidence,
+  assertedType: ESTree.TSType,
+): boolean {
+  if (broadTypeKind(assertedType) !== null) return false;
+  if (broadKind === 'top') return true;
+  if (typesHaveSameSyntax(sourceText, evidence.type, assertedType)) return true;
+  if (broadKind === 'object') return isDefinitelyObjectType(assertedType);
+  return isDefinitelyNarrowerRecordType(assertedType);
+}
+
+/** Detect immutable local bindings that erase a known type and are later asserted back to a narrower type. */
+export const noWidenThenAssertRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow local const flows that explicitly widen a known value before asserting the widened binding to a narrower type.',
+    },
+    messages: {
+      widenThenAssert:
+        'Binding "{{name}}" discards type evidence and later recreates it with an assertion. Keep the precise type from initialization through use; parse boundary input once.',
+    },
+  },
+  createOnce(context) {
+    let scopes: Parameters<typeof resolvedVariableForIdentifier>[0] = [];
+
+    const checkAssertion = (node: ESTree.TSAsExpression | ESTree.TSTypeAssertion) => {
+      const expression = assertedExpression(node);
+      if (expression.type !== 'Identifier') return;
+
+      const variable = resolvedVariableForIdentifier(scopes, expression);
+      if (variable === null) return;
+      const widened = widenedBinding(variable, scopes);
+      if (
+        widened === null ||
+        node.start <= widened.declaredAt ||
+        functionBoundary(node) !== widened.boundary ||
+        !assertionIsNarrower(context.sourceCode.text, widened.broadKind, widened.evidence, node.typeAnnotation)
+      ) {
+        return;
+      }
+
+      context.report({
+        node,
+        messageId: 'widenThenAssert',
+        data: { name: expression.name },
+      });
+    };
+
+    return {
+      Program() {
+        scopes = context.sourceCode.scopeManager.scopes;
+      },
+      TSAsExpression: checkAssertion,
+      TSTypeAssertion: checkAssertion,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/rules/require-safety-comment-for-type-assertion.ts
+++ b/tools/oxlint/anti-slop/rules/require-safety-comment-for-type-assertion.ts
@@ -1,0 +1,61 @@
+import { defineRule } from '@oxlint/plugins';
+
+import type { ESTree, SourceCode } from '@oxlint/plugins';
+
+type TypeAssertion = ESTree.TSAsExpression | ESTree.TSTypeAssertion;
+
+const commentOwnerKinds = new Set([
+  'ExpressionStatement',
+  'PropertyDefinition',
+  'ReturnStatement',
+  'ThrowStatement',
+  'VariableDeclaration',
+]);
+
+function isConstAssertion(node: TypeAssertion): boolean {
+  return (
+    node.typeAnnotation.type === 'TSTypeReference' &&
+    node.typeAnnotation.typeName.type === 'Identifier' &&
+    node.typeAnnotation.typeName.name === 'const'
+  );
+}
+
+function hasSafetyComment(sourceCode: SourceCode, node: TypeAssertion): boolean {
+  let current: ESTree.Node = node;
+  while (true) {
+    if (
+      sourceCode
+        .getCommentsBefore(current)
+        .some((comment) => comment.end <= node.start && /\bSAFETY\s*:/u.test(comment.value))
+    ) {
+      return true;
+    }
+    if (commentOwnerKinds.has(current.type) || current.parent.type === 'Program') return false;
+    current = current.parent;
+  }
+}
+
+/** Require every non-const type assertion to state the invariant TypeScript cannot express. */
+export const requireSafetyCommentForTypeAssertionRule = defineRule({
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Require a nearby SAFETY comment for every TypeScript type assertion except const assertions.',
+    },
+    messages: {
+      missingSafetyComment:
+        'This type assertion has no `SAFETY:` justification. State the checked invariant immediately before the assertion or its containing statement.',
+    },
+  },
+  createOnce(context) {
+    const checkAssertion = (node: TypeAssertion) => {
+      if (isConstAssertion(node) || hasSafetyComment(context.sourceCode, node)) return;
+      context.report({ node, messageId: 'missingSafetyComment' });
+    };
+
+    return {
+      TSAsExpression: checkAssertion,
+      TSTypeAssertion: checkAssertion,
+    };
+  },
+});

--- a/tools/oxlint/anti-slop/shared/dictionary-types.ts
+++ b/tools/oxlint/anti-slop/shared/dictionary-types.ts
@@ -1,0 +1,441 @@
+import type { ESTree } from '@oxlint/plugins';
+
+const BUILT_INS = new Set(['Record', 'Readonly', 'Partial', 'Required', 'Pick', 'Omit', 'PropertyKey', 'NonNullable']);
+const TRANSPARENT_WRAPPERS = new Set(['Readonly', 'Partial', 'Required', 'NonNullable']);
+
+type TypeAliasEnvironment = ReadonlyMap<string, ESTree.TSType>;
+
+type ResolvedType = {
+  readonly type: ESTree.TSType;
+  readonly substitutions: TypeAliasEnvironment;
+};
+
+export type UnsafeDictionary = {
+  readonly kind: 'unsafe-dictionary';
+  readonly unsafeValue: 'any' | 'empty-object' | 'object' | 'union' | 'unknown';
+};
+
+export type WideningTargetKind = 'anonymous object' | 'generic container' | 'object' | 'open dictionary' | 'unknown';
+
+export type WideningTarget = {
+  readonly kind: WideningTargetKind;
+};
+
+export type TypeEnvironment = {
+  readonly aliases: ReadonlyMap<string, ESTree.TSTypeAliasDeclaration>;
+  readonly interfaces: ReadonlyMap<string, readonly ESTree.TSInterfaceDeclaration[]>;
+  readonly shadowedBuiltIns: ReadonlySet<string>;
+};
+
+function declaredStatement(statement: ESTree.Statement): ESTree.Node | null {
+  return statement.type === 'ExportNamedDeclaration' || statement.type === 'ExportDefaultDeclaration'
+    ? (statement.declaration ?? null)
+    : statement;
+}
+
+export function createTypeEnvironment(program: ESTree.Program): TypeEnvironment {
+  const aliases = new Map<string, ESTree.TSTypeAliasDeclaration>();
+  const interfaces = new Map<string, ESTree.TSInterfaceDeclaration[]>();
+  const shadowedBuiltIns = new Set<string>();
+
+  for (const statement of program.body) {
+    const declaration = declaredStatement(statement);
+    if (declaration?.type === 'ImportDeclaration') {
+      for (const specifier of declaration.specifiers) {
+        if (BUILT_INS.has(specifier.local.name)) shadowedBuiltIns.add(specifier.local.name);
+      }
+      continue;
+    }
+
+    if (declaration?.type === 'TSTypeAliasDeclaration') {
+      const existing = aliases.get(declaration.id.name);
+      if (existing === undefined) aliases.set(declaration.id.name, declaration);
+      else shadowedBuiltIns.add(declaration.id.name);
+      if (BUILT_INS.has(declaration.id.name)) shadowedBuiltIns.add(declaration.id.name);
+      continue;
+    }
+
+    if (declaration?.type === 'TSInterfaceDeclaration') {
+      const declarations = interfaces.get(declaration.id.name) ?? [];
+      declarations.push(declaration);
+      interfaces.set(declaration.id.name, declarations);
+      if (BUILT_INS.has(declaration.id.name)) shadowedBuiltIns.add(declaration.id.name);
+      continue;
+    }
+
+    if (declaration?.type === 'TSEnumDeclaration') {
+      if (BUILT_INS.has(declaration.id.name)) shadowedBuiltIns.add(declaration.id.name);
+      continue;
+    }
+
+    if (
+      (declaration?.type === 'ClassDeclaration' || declaration?.type === 'FunctionDeclaration') &&
+      declaration.id !== null
+    ) {
+      if (BUILT_INS.has(declaration.id.name)) shadowedBuiltIns.add(declaration.id.name);
+    }
+  }
+
+  return { aliases, interfaces, shadowedBuiltIns };
+}
+
+function typeReferenceName(type: ESTree.TSTypeReference): string | null {
+  return type.typeName.type === 'Identifier' ? type.typeName.name : null;
+}
+
+function isBuiltIn(name: string, environment: TypeEnvironment): boolean {
+  return BUILT_INS.has(name) && !environment.shadowedBuiltIns.has(name);
+}
+
+function isUnappliedReferenceTo(type: ESTree.TSType, name: string): boolean {
+  const unwrapped = unwrapTransparentType(type);
+  return (
+    unwrapped.type === 'TSTypeReference' &&
+    typeReferenceName(unwrapped) === name &&
+    (unwrapped.typeArguments === null ||
+      unwrapped.typeArguments === undefined ||
+      unwrapped.typeArguments.params.length === 0)
+  );
+}
+
+function unwrapTransparentType(type: ESTree.TSType): ESTree.TSType {
+  let current = type;
+  while (
+    current.type === 'TSParenthesizedType' ||
+    (current.type === 'TSTypeOperator' && current.operator === 'readonly')
+  ) {
+    current = current.typeAnnotation;
+  }
+  return current;
+}
+
+function isNeverType(type: ESTree.TSType): boolean {
+  return unwrapTransparentType(type).type === 'TSNeverKeyword';
+}
+
+function isEffectivelyEmptyMember(member: ESTree.TSSignature): boolean {
+  return (
+    member.type === 'TSPropertySignature' &&
+    member.optional === true &&
+    member.typeAnnotation !== null &&
+    member.typeAnnotation !== undefined &&
+    isNeverType(member.typeAnnotation.typeAnnotation)
+  );
+}
+
+function isEffectivelyEmptyTypeLiteral(type: ESTree.TSTypeLiteral): boolean {
+  return type.members.length === 0 || type.members.every(isEffectivelyEmptyMember);
+}
+
+function isEffectivelyEmptyInterface(declarations: readonly ESTree.TSInterfaceDeclaration[]): boolean {
+  if (declarations.length !== 1) return false;
+  const [type] = declarations;
+  return (
+    type !== undefined &&
+    type.extends.length === 0 &&
+    (type.body.body.length === 0 || type.body.body.every(isEffectivelyEmptyMember))
+  );
+}
+
+function resolvedSubstitutionArgument(
+  type: ESTree.TSType,
+  base: TypeAliasEnvironment,
+  resolving: ReadonlySet<string> = new Set(),
+): ESTree.TSType {
+  const unwrapped = unwrapTransparentType(type);
+  if (unwrapped.type !== 'TSTypeReference') return type;
+  const name = typeReferenceName(unwrapped);
+  if (name === null || resolving.has(name)) return type;
+  const substitution = base.get(name);
+  if (substitution === undefined) return type;
+  const nextResolving = new Set(resolving);
+  nextResolving.add(name);
+  return resolvedSubstitutionArgument(substitution, base, nextResolving);
+}
+
+function aliasSubstitution(
+  alias: ESTree.TSTypeAliasDeclaration,
+  type: ESTree.TSTypeReference,
+  base: TypeAliasEnvironment,
+): TypeAliasEnvironment | null {
+  const parameters = alias.typeParameters?.params ?? [];
+  const arguments_ = type.typeArguments?.params ?? [];
+  const next = new Map(base);
+  for (const [index, parameter] of parameters.entries()) {
+    const argument = arguments_[index] ?? parameter.default;
+    if (argument === null || argument === undefined) return null;
+    next.set(parameter.name.name, resolvedSubstitutionArgument(argument, next));
+  }
+  return next;
+}
+
+function unsafeDirectValue(
+  type: ESTree.TSType,
+  environment: TypeEnvironment,
+  substitutions: TypeAliasEnvironment,
+  resolvingAliases: ReadonlySet<string>,
+): UnsafeDictionary['unsafeValue'] | null {
+  const unwrapped = unwrapTransparentType(type);
+  if (unwrapped.type === 'TSUnknownKeyword') return 'unknown';
+  if (unwrapped.type === 'TSAnyKeyword') return 'any';
+  if (unwrapped.type === 'TSObjectKeyword') return 'object';
+  if (unwrapped.type === 'TSTypeLiteral' && isEffectivelyEmptyTypeLiteral(unwrapped)) return 'empty-object';
+  if (unwrapped.type === 'TSUnionType') {
+    return unwrapped.types.some(
+      (member) => unsafeDirectValue(member, environment, substitutions, resolvingAliases) !== null,
+    )
+      ? 'union'
+      : null;
+  }
+  if (unwrapped.type === 'TSIntersectionType') {
+    const unsafeMembers = unwrapped.types.map((member) =>
+      unsafeDirectValue(member, environment, substitutions, resolvingAliases),
+    );
+    if (unsafeMembers.includes('any')) return 'any';
+    return unsafeMembers.length > 0 && unsafeMembers.every((member) => member !== null) ? unsafeMembers[0] : null;
+  }
+  if (unwrapped.type !== 'TSTypeReference') return null;
+  const name = typeReferenceName(unwrapped);
+  if (name === null) return null;
+  if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, environment)) {
+    const wrapped = unwrapped.typeArguments?.params[0];
+    return wrapped === undefined ? null : unsafeDirectValue(wrapped, environment, substitutions, resolvingAliases);
+  }
+  const substitution = substitutions.get(name);
+  if (substitution !== undefined) {
+    return isUnappliedReferenceTo(substitution, name)
+      ? null
+      : unsafeDirectValue(substitution, environment, substitutions, resolvingAliases);
+  }
+  const interfaceDeclarations = environment.interfaces.get(name);
+  if (interfaceDeclarations !== undefined) {
+    return isEffectivelyEmptyInterface(interfaceDeclarations) ? 'empty-object' : null;
+  }
+  const alias = environment.aliases.get(name);
+  if (alias === undefined || resolvingAliases.has(name)) return null;
+  const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+  if (nextSubstitutions === null) return null;
+  const nextResolving = new Set(resolvingAliases);
+  nextResolving.add(name);
+  return unsafeDirectValue(alias.typeAnnotation, environment, nextSubstitutions, nextResolving);
+}
+
+function dictionaryValueTypes(
+  type: ESTree.TSType,
+  environment: TypeEnvironment,
+  substitutions: TypeAliasEnvironment,
+  resolvingAliases: ReadonlySet<string>,
+): readonly ResolvedType[] {
+  const unwrapped = unwrapTransparentType(type);
+
+  if (unwrapped.type === 'TSTypeLiteral') {
+    return unwrapped.members.flatMap((member): readonly ResolvedType[] =>
+      member.type === 'TSIndexSignature' && member.typeAnnotation !== null
+        ? [{ type: member.typeAnnotation.typeAnnotation, substitutions }]
+        : [],
+    );
+  }
+
+  if (unwrapped.type === 'TSMappedType') {
+    return unwrapped.typeAnnotation === null ? [] : [{ type: unwrapped.typeAnnotation, substitutions }];
+  }
+
+  if (unwrapped.type !== 'TSTypeReference') return [];
+  const name = typeReferenceName(unwrapped);
+  if (name === null) return [];
+
+  const substitution = substitutions.get(name);
+  if (substitution !== undefined) {
+    return isUnappliedReferenceTo(substitution, name)
+      ? []
+      : dictionaryValueTypes(substitution, environment, substitutions, resolvingAliases);
+  }
+
+  if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, environment)) {
+    const wrapped = unwrapped.typeArguments?.params[0];
+    return wrapped === undefined ? [] : dictionaryValueTypes(wrapped, environment, substitutions, resolvingAliases);
+  }
+
+  if (name === 'Record' && isBuiltIn(name, environment)) {
+    const value = unwrapped.typeArguments?.params[1] ?? null;
+    return value === null ? [] : [{ type: value, substitutions }];
+  }
+
+  if ((name === 'Pick' || name === 'Omit') && isBuiltIn(name, environment)) {
+    const source = unwrapped.typeArguments?.params[0];
+    return source === undefined ? [] : dictionaryValueTypes(source, environment, substitutions, resolvingAliases);
+  }
+
+  const alias = environment.aliases.get(name);
+  if (alias === undefined || resolvingAliases.has(name)) return [];
+  const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+  if (nextSubstitutions === null) return [];
+  const nextResolving = new Set(resolvingAliases);
+  nextResolving.add(name);
+  return dictionaryValueTypes(alias.typeAnnotation, environment, nextSubstitutions, nextResolving);
+}
+
+export function classifyUnsafeDictionaryValue(
+  valueType: ESTree.TSType,
+  environment: TypeEnvironment,
+): UnsafeDictionary | null {
+  const unsafeValue = unsafeDirectValue(valueType, environment, new Map(), new Set());
+  return unsafeValue === null ? null : { kind: 'unsafe-dictionary', unsafeValue };
+}
+
+export function classifyUnsafeDictionary(type: ESTree.TSType, environment: TypeEnvironment): UnsafeDictionary | null {
+  for (const valueType of dictionaryValueTypes(type, environment, new Map(), new Set())) {
+    const unsafeValue = unsafeDirectValue(valueType.type, environment, valueType.substitutions, new Set());
+    if (unsafeValue !== null) return { kind: 'unsafe-dictionary', unsafeValue };
+  }
+  return null;
+}
+
+function resolvesToDictionary(
+  type: ESTree.TSType,
+  environment: TypeEnvironment,
+  substitutions: TypeAliasEnvironment,
+  resolvingAliases: ReadonlySet<string>,
+): boolean {
+  return dictionaryValueTypes(type, environment, substitutions, resolvingAliases).length > 0;
+}
+
+export function classifyWideningTarget(type: ESTree.TSType, environment: TypeEnvironment): WideningTarget | null {
+  const unwrapped = unwrapTransparentType(type);
+  if (unwrapped.type === 'TSUnknownKeyword') return { kind: 'unknown' };
+  if (unwrapped.type === 'TSObjectKeyword') return { kind: 'object' };
+  if (unwrapped.type === 'TSTypeLiteral') {
+    return unwrapped.members.some((member) => member.type === 'TSIndexSignature')
+      ? { kind: 'open dictionary' }
+      : unwrapped.members.length > 0
+        ? { kind: 'anonymous object' }
+        : null;
+  }
+  if (unwrapped.type === 'TSMappedType') return { kind: 'open dictionary' };
+  if (unwrapped.type !== 'TSTypeReference') return null;
+  const name = typeReferenceName(unwrapped);
+  if (name === null) return null;
+  if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, environment)) {
+    const wrapped = unwrapped.typeArguments?.params[0];
+    return wrapped === undefined ? null : classifyWideningTarget(wrapped, environment);
+  }
+  if (name === 'Record' && isBuiltIn(name, environment)) return { kind: 'open dictionary' };
+  const alias = environment.aliases.get(name);
+  if (alias === undefined) return null;
+  if ((alias.typeParameters?.params.length ?? 0) > 0) {
+    const substitutions = aliasSubstitution(alias, unwrapped, new Map());
+    return substitutions !== null &&
+      resolvesToDictionary(alias.typeAnnotation, environment, substitutions, new Set([name]))
+      ? { kind: 'generic container' }
+      : null;
+  }
+  const substitutions = aliasSubstitution(alias, unwrapped, new Map());
+  if (substitutions === null) return null;
+  const resolved = classifyAliasBroadTarget(alias.typeAnnotation, environment, substitutions, new Set([name]));
+  return resolved;
+}
+
+function isBroadMappedKey(
+  type: ESTree.TSType,
+  environment: TypeEnvironment,
+  substitutions: TypeAliasEnvironment,
+): boolean {
+  const unwrapped = unwrapTransparentType(type);
+  if (
+    unwrapped.type === 'TSStringKeyword' ||
+    unwrapped.type === 'TSNumberKeyword' ||
+    unwrapped.type === 'TSSymbolKeyword'
+  ) {
+    return true;
+  }
+  if (unwrapped.type === 'TSUnionType') {
+    return unwrapped.types.every((member) => isBroadMappedKey(member, environment, substitutions));
+  }
+  if (unwrapped.type !== 'TSTypeReference') return false;
+  const name = typeReferenceName(unwrapped);
+  if (name === null) return false;
+  const substitution = substitutions.get(name);
+  if (substitution !== undefined && !isUnappliedReferenceTo(substitution, name)) {
+    return isBroadMappedKey(substitution, environment, substitutions);
+  }
+  return name === 'PropertyKey' && isBuiltIn(name, environment);
+}
+
+function classifyAliasBroadTarget(
+  type: ESTree.TSType,
+  environment: TypeEnvironment,
+  substitutions: TypeAliasEnvironment,
+  resolvingAliases: ReadonlySet<string>,
+): WideningTarget | null {
+  const unwrapped = unwrapTransparentType(type);
+  if (unwrapped.type === 'TSUnknownKeyword') return { kind: 'unknown' };
+  if (unwrapped.type === 'TSObjectKeyword') return { kind: 'object' };
+  if (unwrapped.type === 'TSTypeLiteral') {
+    return unwrapped.members.some((member) => member.type === 'TSIndexSignature') ? { kind: 'open dictionary' } : null;
+  }
+  if (unwrapped.type === 'TSMappedType') {
+    return isBroadMappedKey(unwrapped.constraint, environment, substitutions) ? { kind: 'open dictionary' } : null;
+  }
+  if (unwrapped.type !== 'TSTypeReference') return null;
+  const name = typeReferenceName(unwrapped);
+  if (name === null) return null;
+  const substitution = substitutions.get(name);
+  if (substitution !== undefined) {
+    return isUnappliedReferenceTo(substitution, name)
+      ? null
+      : classifyAliasBroadTarget(substitution, environment, substitutions, resolvingAliases);
+  }
+  if (TRANSPARENT_WRAPPERS.has(name) && isBuiltIn(name, environment)) {
+    const wrapped = unwrapped.typeArguments?.params[0];
+    return wrapped === undefined
+      ? null
+      : classifyAliasBroadTarget(wrapped, environment, substitutions, resolvingAliases);
+  }
+  if (name === 'Record' && isBuiltIn(name, environment)) {
+    return { kind: 'open dictionary' };
+  }
+  const alias = environment.aliases.get(name);
+  if (alias === undefined || resolvingAliases.has(name)) return null;
+  const nextSubstitutions = aliasSubstitution(alias, unwrapped, substitutions);
+  if (nextSubstitutions === null) return null;
+  const nextResolving = new Set(resolvingAliases);
+  nextResolving.add(name);
+  return classifyAliasBroadTarget(alias.typeAnnotation, environment, nextSubstitutions, nextResolving);
+}
+
+export function isPopulatedObjectExpression(expression: ESTree.Expression): boolean {
+  let current = expression;
+  while (
+    current.type === 'ParenthesizedExpression' ||
+    current.type === 'TSAsExpression' ||
+    current.type === 'TSTypeAssertion' ||
+    current.type === 'TSNonNullExpression'
+  ) {
+    current = current.expression;
+  }
+  return current.type === 'ObjectExpression' && current.properties.length > 0;
+}
+
+export function isKnownEvidenceExpression(expression: ESTree.Expression): boolean {
+  let current = expression;
+  while (
+    current.type === 'ParenthesizedExpression' ||
+    current.type === 'TSAsExpression' ||
+    current.type === 'TSTypeAssertion' ||
+    current.type === 'TSNonNullExpression' ||
+    current.type === 'TSSatisfiesExpression'
+  ) {
+    current = current.expression;
+  }
+  if (current.type === 'ObjectExpression') return true;
+  return (
+    current.type === 'ArrayExpression' ||
+    current.type === 'ArrowFunctionExpression' ||
+    current.type === 'ClassExpression' ||
+    current.type === 'FunctionExpression' ||
+    current.type === 'NewExpression' ||
+    current.type === 'Literal' ||
+    current.type === 'TemplateLiteral' ||
+    current.type === 'UnaryExpression'
+  );
+}

--- a/tools/oxlint/anti-slop/shared/lexical-type-parameters.ts
+++ b/tools/oxlint/anti-slop/shared/lexical-type-parameters.ts
@@ -1,0 +1,46 @@
+import type { ESTree } from '@oxlint/plugins';
+
+type VisitorKeys = Readonly<Record<string, readonly string[]>>;
+
+function isNode(value: unknown): value is ESTree.Node {
+  return typeof value === 'object' && value !== null && 'type' in value && typeof value.type === 'string';
+}
+
+function collectInferTypeParameterNames(node: ESTree.Node, visitorKeys: VisitorKeys, names: Set<string>): void {
+  if (node.type === 'TSInferType') names.add(node.typeParameter.name.name);
+  const record = node as unknown as Readonly<Record<string, unknown>>;
+  for (const key of visitorKeys[node.type] ?? []) {
+    const value = record[key];
+    if (isNode(value)) {
+      collectInferTypeParameterNames(value, visitorKeys, names);
+      continue;
+    }
+    if (!Array.isArray(value)) continue;
+    for (const child of value) {
+      if (isNode(child)) collectInferTypeParameterNames(child, visitorKeys, names);
+    }
+  }
+}
+
+/** Collect type binders that are in scope at a node and can shadow module aliases. */
+export function lexicalTypeParameterNames(node: ESTree.Node, visitorKeys: VisitorKeys): ReadonlySet<string> {
+  const names = new Set<string>();
+  let descendant: ESTree.Node = node;
+  let current: ESTree.Node | null = node;
+  while (current !== null && current.type !== 'Program') {
+    if ('typeParameters' in current) {
+      for (const parameter of current.typeParameters?.params ?? []) {
+        names.add(parameter.name.name);
+      }
+    }
+    if (current.type === 'TSMappedType' && (descendant === current.nameType || descendant === current.typeAnnotation)) {
+      names.add(current.key.name);
+    }
+    if (current.type === 'TSConditionalType' && descendant === current.trueType) {
+      collectInferTypeParameterNames(current.extendsType, visitorKeys, names);
+    }
+    descendant = current;
+    current = current.parent;
+  }
+  return names;
+}

--- a/tools/oxlint/anti-slop/shared/reflect-method.ts
+++ b/tools/oxlint/anti-slop/shared/reflect-method.ts
@@ -1,0 +1,32 @@
+import type { ESTree, Scope, SourceCode, Variable } from '@oxlint/plugins';
+
+function resolveVariable(sourceCode: SourceCode, identifier: ESTree.IdentifierReference): Variable | null {
+  let scope: Scope | null = sourceCode.getScope(identifier);
+  while (scope !== null) {
+    const variable = scope.set.get(identifier.name);
+    if (variable !== undefined) return variable;
+    scope = scope.upper;
+  }
+  return null;
+}
+
+function isGlobalReflect(sourceCode: SourceCode, expression: ESTree.Expression): boolean {
+  if (expression.type !== 'Identifier' || expression.name !== 'Reflect') return false;
+  if (sourceCode.isGlobalReference(expression)) return true;
+  const variable = resolveVariable(sourceCode, expression);
+  return variable === null || variable.defs.length === 0;
+}
+
+/** Reports whether a call target names one method on the global Reflect object. */
+export function isGlobalReflectMethodCall(
+  sourceCode: SourceCode,
+  callee: ESTree.Expression,
+  methodName: string,
+): boolean {
+  if (!('property' in callee) || !('object' in callee) || !('computed' in callee)) return false;
+  if (!isGlobalReflect(sourceCode, callee.object)) return false;
+  const property = callee.property;
+  return callee.computed
+    ? property.type === 'Literal' && property.value === methodName
+    : property.type === 'Identifier' && property.name === methodName;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,5 +21,6 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false,
     "noPropertyAccessFromIndexSignature": false
-  }
+  },
+  "exclude": ["tools/oxlint/anti-slop"]
 }


### PR DESCRIPTION
Installs the vendored anti-slop jsPlugin (tools/oxlint/anti-slop) with all 15
rules at error, and migrates owned source to pass:

- JSON boundaries assert JsonValue once (src/json.ts) and narrow with
  isJsonObject/isString/isNumber guards instead of ad-hoc typeof
- populated dictionary literals use satisfies or Map lookups
- anonymous object return types become named interfaces
- conditional empty-object spreads become conditional assignments
- every type assertion carries a SAFETY: invariant comment

no-runtime-typeof runs with allowInTypeGuards so boundary guards can
discriminate; typeof outside guards stays banned. hooks/pi/fleet-pi.ts keeps
its zero-fleet-dependency constraint with a local JsonValue copy.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>