### PR TITLE
perf: make the TUI tick paths non-blocking under load

### DIFF
--- a/src/agents/discovery.ts
+++ b/src/agents/discovery.ts
@@ -324,6 +324,18 @@ export function readPsTable(): string[] {
   }
 }
 
+// Async twin for the TUI slow tick: same table, non-blocking fork.
+export async function readPsTableAsync(): Promise<string[]> {
+  try {
+    const p = Bun.spawn({ cmd: ['ps', '-eo', 'pid=,ppid=,comm='], stdout: 'pipe', stderr: 'ignore' });
+    const [stdout, exitCode] = await Promise.all([new Response(p.stdout).text(), p.exited]);
+    if (exitCode !== 0) return [];
+    return stdout.split('\n');
+  } catch {
+    return [];
+  }
+}
+
 // Thin I/O wrapper the slow loop calls. `captures` are the per-pane lines already
 // taken for the scrape cache this tick (paneId -> captured lines), and `panePids`
 // + `psTable` come from the caller's single list-panes + ps pass, so discovery

--- a/src/state/git-metadata.ts
+++ b/src/state/git-metadata.ts
@@ -190,16 +190,29 @@ function git(cwd: string, args: string[]): GitResult {
   }
 }
 
-// Read the full metadata for a single cwd. Three bounded git spawns:
-//   rev-parse (identity + worktree root), status v2 (branch/dirty/ahead-behind),
-//   diff --numstat (diffstat). null on non-git/failure of the identity probe.
-export function readGitMetadata(cwd: string): GitMetadata | null {
-  const rp = git(cwd, ['rev-parse', '--git-common-dir', '--show-toplevel']);
-  if (!rp.ok) return null;
+// Async twin of git() for the TUI slow tick — same argv, non-blocking fork.
+async function gitAsync(cwd: string, args: string[]): Promise<GitResult> {
+  try {
+    const proc = Bun.spawn({
+      cmd: ['git', '-c', 'core.fsmonitor=false', '-c', 'core.hooksPath=/dev/null', '-C', cwd, ...args],
+      stdout: 'pipe',
+      stderr: 'ignore',
+      env: { ...process.env, GIT_OPTIONAL_LOCKS: '0' },
+    });
+    const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+    if (exitCode !== 0) return { ok: false, stdout: '' };
+    return { ok: true, stdout };
+  } catch {
+    return { ok: false, stdout: '' };
+  }
+}
+
+// Shared assembly for the sync/async reads: identity gate, then each probe
+// parsed with its failure default. null on non-git/failed identity.
+function buildGitMetadata(cwd: string, rp: GitResult, st: GitResult, nd: GitResult): GitMetadata | null {
   const identity = parseRevParse(rp.stdout, cwd);
   if (!identity) return null;
 
-  const st = git(cwd, ['status', '--porcelain=v2', '--branch']);
   const status = st.ok
     ? parseStatusV2(st.stdout)
     : {
@@ -217,7 +230,6 @@ export function readGitMetadata(cwd: string): GitMetadata | null {
 
   // Diff vs HEAD captures staged + unstaged changes. Fails (and stays zero) on
   // an unborn branch with no commits — the rest of the metadata is still valid.
-  const nd = git(cwd, ['diff', '--no-ext-diff', '--no-textconv', '--numstat', 'HEAD']);
   const diffstat = nd.ok ? parseNumstat(nd.stdout) : { files: 0, added: 0, removed: 0 };
 
   let commonDir = identity.commonDir;
@@ -243,6 +255,29 @@ export function readGitMetadata(cwd: string): GitMetadata | null {
     upstream: status.upstream,
     diffstat,
   };
+}
+
+// Read the full metadata for a single cwd. Three bounded git spawns:
+//   rev-parse (identity + worktree root), status v2 (branch/dirty/ahead-behind),
+//   diff --numstat (diffstat). null on non-git/failure of the identity probe.
+export function readGitMetadata(cwd: string): GitMetadata | null {
+  const rp = git(cwd, ['rev-parse', '--git-common-dir', '--show-toplevel']);
+  if (!rp.ok) return null;
+  const st = git(cwd, ['status', '--porcelain=v2', '--branch']);
+  const nd = git(cwd, ['diff', '--no-ext-diff', '--no-textconv', '--numstat', 'HEAD']);
+  return buildGitMetadata(cwd, rp, st, nd);
+}
+
+// Async variant for the TUI slow tick: identity probe first (non-git dirs pay
+// one spawn, not three), then status + diffstat concurrently.
+export async function readGitMetadataAsync(cwd: string): Promise<GitMetadata | null> {
+  const rp = await gitAsync(cwd, ['rev-parse', '--git-common-dir', '--show-toplevel']);
+  if (!rp.ok) return null;
+  const [st, nd] = await Promise.all([
+    gitAsync(cwd, ['status', '--porcelain=v2', '--branch']),
+    gitAsync(cwd, ['diff', '--no-ext-diff', '--no-textconv', '--numstat', 'HEAD']),
+  ]);
+  return buildGitMetadata(cwd, rp, st, nd);
 }
 
 // The branch label the legacy `state.branch` field carried: the branch name, or

--- a/src/state/refresh.test.ts
+++ b/src/state/refresh.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { AgentStatus } from './types.ts';
-import { discoveredDecision } from './refresh.ts';
+import { discoveredDecision, mapLimited } from './refresh.ts';
 
 describe('discoveredDecision', () => {
   test('attributes a rule-derived prompt to scrape', () => {
@@ -22,5 +22,32 @@ describe('discoveredDecision', () => {
     expect(decision.winner).toBe('default');
     expect(decision.candidates.scrape).toBe(AgentStatus.IDLE);
     expect(decision.reason).toContain('working glyph');
+  });
+});
+
+describe('mapLimited', () => {
+  const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+  test('preserves order and maps every item', async () => {
+    const out = await mapLimited([1, 2, 3, 4], 2, async (n) => n * 10);
+    expect(out).toEqual([10, 20, 30, 40]);
+  });
+
+  test('never exceeds the concurrency limit', async () => {
+    let active = 0;
+    let peak = 0;
+    const out = await mapLimited(Array.from({ length: 20 }, (_, i) => i), 3, async (n) => {
+      active++;
+      peak = Math.max(peak, active);
+      await delay(5);
+      active--;
+      return n;
+    });
+    expect(peak).toBe(3);
+    expect(out).toHaveLength(20);
+  });
+
+  test('empty input resolves to empty', async () => {
+    expect(await mapLimited([], 8, async (n: number) => n)).toEqual([]);
   });
 });

--- a/src/state/refresh.test.ts
+++ b/src/state/refresh.test.ts
@@ -36,13 +36,17 @@ describe('mapLimited', () => {
   test('never exceeds the concurrency limit', async () => {
     let active = 0;
     let peak = 0;
-    const out = await mapLimited(Array.from({ length: 20 }, (_, i) => i), 3, async (n) => {
-      active++;
-      peak = Math.max(peak, active);
-      await delay(5);
-      active--;
-      return n;
-    });
+    const out = await mapLimited(
+      Array.from({ length: 20 }, (_, i) => i),
+      3,
+      async (n) => {
+        active++;
+        peak = Math.max(peak, active);
+        await delay(5);
+        active--;
+        return n;
+      },
+    );
     expect(peak).toBe(3);
     expect(out).toHaveLength(20);
   });

--- a/src/state/refresh.ts
+++ b/src/state/refresh.ts
@@ -16,6 +16,7 @@ import {
   detectFromTitle,
   scrapePane,
   capturePaneLines,
+  capturePaneLinesAsync,
   capturePaneLinesVia,
 } from './scraper.ts';
 import { loadDetectionManifest } from './detection.ts';
@@ -32,18 +33,19 @@ import {
   parsePsTable,
   pruneDoneTracking,
   readPsTable,
+  readPsTableAsync,
   resolveDiscoveredStatus,
   scanDiscovered,
   type DiscoveredAgent,
   type DoneTracking,
 } from '../agents/discovery.ts';
-import { listPanesResult, type ListPanesResult, type PaneInfo } from '../tmux/sessions.ts';
-import { readGitMetadata, branchLabel, type GitMetadata } from './git-metadata.ts';
+import { listPanesResult, listPanesResultAsync, type ListPanesResult, type PaneInfo } from '../tmux/sessions.ts';
+import { readGitMetadata, readGitMetadataAsync, branchLabel, type GitMetadata } from './git-metadata.ts';
 import type { TmuxControlClient } from '../tmux/control.ts';
 import { listPanesResultVia } from '../tmux/control-adapter.ts';
 import { flipControlDead, type ControlLatch } from '../tmux/control-router.ts';
 import { tmuxOrNull } from '../tmux/ipc.ts';
-import { detectPorts } from '../tmux/ports.ts';
+import { detectPorts, detectPortsAsync, type PanePort } from '../tmux/ports.ts';
 
 export function shortenPath(path: string): string {
   const home = Bun.env.HOME ?? '';
@@ -233,46 +235,65 @@ export function refreshSlowCaches(panes: PaneInfo[], hookStatuses: ResolvedHookS
   refreshSlowCachesWithCapture(panes, hookStatuses, capturePaneLines);
 }
 
-// Same scan as refreshSlowCaches, but the per-pane capture is supplied by the
-// caller. The fork path passes capturePaneLines (sync); the control-mode TUI
-// path pre-fetches every pane via the control client, then passes a sync
-// lookup into the cache so the rest of the slow-tick work (git, ports,
-// discovery, classification) runs unchanged and shared between both paths.
-export function refreshSlowCachesWithCapture(
-  panes: PaneInfo[],
-  hookStatuses: ResolvedHookStatus[],
-  captureFn: (paneId: string) => string[],
-): void {
-  const paths = new Set<string>();
-  for (const p of panes) paths.add(p.currentPath);
-  const nowMs = Date.now();
-  if (
+// ponytail: fixed cap on concurrent slow-tick spawns — an unbounded
+// Promise.all would fire N captures + 3×paths git forks at once, spiking
+// process creation exactly when the box is already loaded. Raise only if slow
+// ticks measurably lag with many panes.
+const SLOW_SPAWN_LIMIT = 8;
+
+// Bounded parallel map. The index pull (i++) is synchronous between awaits, so
+// each item is claimed exactly once; result order matches input order.
+export async function mapLimited<T, R>(items: T[], limit: number, fn: (item: T) => Promise<R>): Promise<R[]> {
+  const out: R[] = [];
+  let i = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, async () => {
+      while (i < items.length) {
+        const idx = i++;
+        out[idx] = await fn(items[idx]!);
+      }
+    }),
+  );
+  return out;
+}
+
+// The git-cache refresh gate, shared by the sync/async slow ticks: TTL
+// expired, or the pane path set changed.
+function gitRefreshDue(paths: Set<string>, nowMs: number): boolean {
+  return (
     nowMs - gitMetadataUpdatedAt >= GIT_METADATA_REFRESH_MS ||
     paths.size !== gitMetadataCache.size ||
     [...paths].some((path) => !gitMetadataCache.has(path))
-  ) {
-    gitMetadataCache.clear();
-    for (const path of paths) gitMetadataCache.set(path, readGitMetadata(path));
-    gitMetadataUpdatedAt = nowMs;
-  }
+  );
+}
 
-  // One pane_pid map (from the caller's list-panes) and one ps pass, shared by
-  // port detection and hook-less discovery — no extra tmux/ps spawns.
+// One pane_pid map from the caller's list-panes, shared by port detection and
+// hook-less discovery — no extra tmux/ps spawns.
+function panePidMap(panes: PaneInfo[]): Map<number, string> {
   const panePids = new Map<number, string>();
   for (const p of panes) {
     if (!Number.isNaN(p.panePid)) panePids.set(p.panePid, p.paneId);
   }
-  const psTable = readPsTable();
-  const { ppidByPid } = parsePsTable(psTable);
+  return panePids;
+}
+
+// Everything after the gather: writes portCache, runs hook-less discovery,
+// classifies each capture exactly once, prunes. Shared by the sync and async
+// slow ticks so both paths produce identical cache state from the same inputs.
+function applySlowCaches(
+  panes: PaneInfo[],
+  hookStatuses: ResolvedHookStatus[],
+  gather: { psTable: string[]; ports: PanePort[]; captureCache: Map<string, string[]> },
+): void {
+  const { psTable, ports, captureCache } = gather;
+  const panePids = panePidMap(panes);
 
   const newPorts = new Map<string, number[]>();
-  try {
-    for (const pp of detectPorts(panePids, ppidByPid)) {
-      const existing = newPorts.get(pp.paneId) ?? [];
-      existing.push(pp.port);
-      newPorts.set(pp.paneId, existing);
-    }
-  } catch {}
+  for (const pp of ports) {
+    const existing = newPorts.get(pp.paneId) ?? [];
+    existing.push(pp.port);
+    newPorts.set(pp.paneId, existing);
+  }
   portCache = newPorts;
 
   // Which agent owns each pane, so the scraper picks that agent's detection
@@ -282,15 +303,6 @@ export function refreshSlowCachesWithCapture(
   for (const h of hookStatuses) {
     const prev = paneAgent.get(h.pane);
     if (!prev || h.ts > prev.ts) paneAgent.set(h.pane, { agent: h.agent, ts: h.ts });
-  }
-
-  // Layer 3: pane scraping (~50ms per pane) — slow cycle only. Capture each
-  // pane ONCE, without classifying yet: classification needs the pane's agent
-  // identity, and hook-less panes are only named by discovery below.
-  const captureCache = new Map<string, string[]>();
-  for (const p of panes) {
-    const lines = captureFn(p.paneId);
-    if (lines.length > 0) captureCache.set(p.paneId, lines);
   }
 
   // Hook-less agent discovery: map allowlisted processes with no .status file to
@@ -334,6 +346,87 @@ export function refreshSlowCachesWithCapture(
   scrapeCacheTs = Math.floor(Date.now() / 1000);
 
   pruneDoneTracking(discoveryDone, new Set(discoveryCache.keys()));
+}
+
+// Same scan as refreshSlowCaches, but the per-pane capture is supplied by the
+// caller. Used by the CLI (one-shot, blocking is fine) and exercised directly
+// by tests; the TUI slow tick uses refreshSlowCachesAsync instead.
+export function refreshSlowCachesWithCapture(
+  panes: PaneInfo[],
+  hookStatuses: ResolvedHookStatus[],
+  captureFn: (paneId: string) => string[],
+): void {
+  const paths = new Set<string>();
+  for (const p of panes) paths.add(p.currentPath);
+  const nowMs = Date.now();
+  if (gitRefreshDue(paths, nowMs)) {
+    gitMetadataCache.clear();
+    for (const path of paths) gitMetadataCache.set(path, readGitMetadata(path));
+    gitMetadataUpdatedAt = nowMs;
+  }
+
+  const psTable = readPsTable();
+  const { ppidByPid } = parsePsTable(psTable);
+
+  let ports: PanePort[] = [];
+  try {
+    ports = detectPorts(panePidMap(panes), ppidByPid);
+  } catch {}
+
+  // Layer 3: pane scraping (~50ms per pane) — slow cycle only. Capture each
+  // pane ONCE, without classifying yet: classification needs the pane's agent
+  // identity, and hook-less panes are only named by discovery below.
+  const captureCache = new Map<string, string[]>();
+  for (const p of panes) {
+    const lines = captureFn(p.paneId);
+    if (lines.length > 0) captureCache.set(p.paneId, lines);
+  }
+
+  applySlowCaches(panes, hookStatuses, { psTable, ports, captureCache });
+}
+
+// Async slow tick for the TUI: git, ps, and the per-pane captures gather
+// concurrently (bounded by SLOW_SPAWN_LIMIT) with the event loop free between
+// spawns — the fix for the every-5s input freeze under load. The shared
+// applySlowCaches tail then runs unchanged. captureFn is async: the fork path
+// passes capturePaneLinesAsync; the control-mode path a lookup into its
+// pre-fetched cache.
+export async function refreshSlowCachesAsync(
+  panes: PaneInfo[],
+  hookStatuses: ResolvedHookStatus[],
+  captureFn: (paneId: string) => Promise<string[]>,
+): Promise<void> {
+  const paths = new Set<string>();
+  for (const p of panes) paths.add(p.currentPath);
+  const nowMs = Date.now();
+
+  const gitP = gitRefreshDue(paths, nowMs)
+    ? mapLimited([...paths], SLOW_SPAWN_LIMIT, async (path) => ({ path, meta: await readGitMetadataAsync(path) }))
+    : null;
+  const psP = readPsTableAsync();
+  const capP = mapLimited(
+    panes,
+    SLOW_SPAWN_LIMIT,
+    async (p) => ({ paneId: p.paneId, lines: await captureFn(p.paneId) }),
+  );
+
+  const psTable = await psP;
+  const { ppidByPid } = parsePsTable(psTable);
+  const ports = await detectPortsAsync(panePidMap(panes), ppidByPid);
+  const caps = await capP;
+
+  if (gitP) {
+    gitMetadataCache.clear();
+    for (const { path, meta } of await gitP) gitMetadataCache.set(path, meta);
+    gitMetadataUpdatedAt = nowMs;
+  }
+
+  const captureCache = new Map<string, string[]>();
+  for (const { paneId, lines } of caps) {
+    if (lines.length > 0) captureCache.set(paneId, lines);
+  }
+
+  applySlowCaches(panes, hookStatuses, { psTable, ports, captureCache });
 }
 
 // Fast refresh: ONE tmux call + status file reads + last-line JSONL reads. No
@@ -475,11 +568,29 @@ export function refreshStates(
 }
 
 // Full refresh: one list-panes + one status-dir read feed both the slow caches
-// and the fast refresh.
+// and the fast refresh. Sync — used by one-shot CLI paths, where blocking is
+// fine. The TUI uses fullRefreshStatesAsync / fullRefreshStatesTui instead.
 export function fullRefreshStates(dirs: AgentDir[]): AgentState[] {
   const panesResult = listPanesResult();
   const hookStatuses = readAllStatusDirs(dirs);
   refreshSlowCaches(panesResult.panes, hookStatuses);
+  return refreshStates(dirs, { panesResult, hookStatuses });
+}
+
+// Async full refresh for the TUI: the whole gather (list-panes, captures, git,
+// ps, lsof) is non-blocking; the classification tail is shared with the sync
+// path. File reads stay sync — they're mtime-cached since F4.
+export async function fullRefreshStatesAsync(dirs: AgentDir[]): Promise<AgentState[]> {
+  const panesResult = await listPanesResultAsync();
+  const hookStatuses = readAllStatusDirs(dirs);
+  await refreshSlowCachesAsync(panesResult.panes, hookStatuses, capturePaneLinesAsync);
+  return refreshStates(dirs, { panesResult, hookStatuses });
+}
+
+// Fork-path fast tick: one async list-panes + cached file reads.
+async function refreshStatesForkAsync(dirs: AgentDir[]): Promise<AgentState[]> {
+  const panesResult = await listPanesResultAsync();
+  const hookStatuses = readAllStatusDirs(dirs);
   return refreshStates(dirs, { panesResult, hookStatuses });
 }
 
@@ -496,7 +607,7 @@ export async function refreshStatesTui(
   client: TmuxControlClient | null,
   latch: ControlLatch,
 ): Promise<AgentState[]> {
-  if (client === null || latch.dead) return refreshStates(dirs);
+  if (client === null || latch.dead) return refreshStatesForkAsync(dirs);
   try {
     const panesResult = await listPanesResultVia(client);
     const hookStatuses = readAllStatusDirs(dirs);
@@ -506,7 +617,7 @@ export async function refreshStatesTui(
     try {
       await client.close();
     } catch {}
-    return refreshStates(dirs);
+    return refreshStatesForkAsync(dirs);
   }
 }
 
@@ -515,28 +626,28 @@ export async function fullRefreshStatesTui(
   client: TmuxControlClient | null,
   latch: ControlLatch,
 ): Promise<AgentState[]> {
-  if (client === null || latch.dead) return fullRefreshStates(dirs);
+  if (client === null || latch.dead) return fullRefreshStatesAsync(dirs);
   try {
     // Resync barrier before the scan batch — drains any stale/unsolicited
     // blocks so the list-panes read pairs with its own response.
     await client.sync();
     const panesResult = await listPanesResultVia(client);
     const hookStatuses = readAllStatusDirs(dirs);
-    // Pre-fetch every pane's capture via the control client, then hand the
-    // cache to the shared slow-tick body so git/ports/discovery/classification
-    // run identically to the fork path.
+    // Pre-fetch every pane's capture via the control client (one child, one
+    // pipe — sequential by nature), then gather the rest (git/ps/lsof)
+    // concurrently through the shared async slow tick.
     const captureCache = new Map<string, string[]>();
     for (const p of panesResult.panes) {
       const lines = await capturePaneLinesVia(client, p.paneId);
       if (lines.length > 0) captureCache.set(p.paneId, lines);
     }
-    refreshSlowCachesWithCapture(panesResult.panes, hookStatuses, (id) => captureCache.get(id) ?? []);
+    await refreshSlowCachesAsync(panesResult.panes, hookStatuses, async (id) => captureCache.get(id) ?? []);
     return refreshStates(dirs, { panesResult, hookStatuses });
   } catch {
     flipControlDead(latch);
     try {
       await client.close();
     } catch {}
-    return fullRefreshStates(dirs);
+    return fullRefreshStatesAsync(dirs);
   }
 }

--- a/src/state/refresh.ts
+++ b/src/state/refresh.ts
@@ -404,11 +404,10 @@ export async function refreshSlowCachesAsync(
     ? mapLimited([...paths], SLOW_SPAWN_LIMIT, async (path) => ({ path, meta: await readGitMetadataAsync(path) }))
     : null;
   const psP = readPsTableAsync();
-  const capP = mapLimited(
-    panes,
-    SLOW_SPAWN_LIMIT,
-    async (p) => ({ paneId: p.paneId, lines: await captureFn(p.paneId) }),
-  );
+  const capP = mapLimited(panes, SLOW_SPAWN_LIMIT, async (p) => ({
+    paneId: p.paneId,
+    lines: await captureFn(p.paneId),
+  }));
 
   const psTable = await psP;
   const { ppidByPid } = parsePsTable(psTable);

--- a/src/state/scraper.ts
+++ b/src/state/scraper.ts
@@ -1,5 +1,6 @@
 import { AgentStatus, type DetectResult } from './types.ts';
-import { capturePane } from '../tmux/sessions.ts';
+import { capturePane, processCaptureOutput } from '../tmux/sessions.ts';
+import { tmuxAsync } from '../tmux/ipc.ts';
 import { capturePaneVia, type ControlReadClient } from '../tmux/control-adapter.ts';
 import {
   CLAUDE_MANIFEST,
@@ -74,6 +75,14 @@ export function capturePaneLines(paneId: string): string[] {
   } catch {
     return [];
   }
+}
+
+// Async twin for the TUI slow tick: same window, same empty-on-failure
+// degrade, but the fork doesn't block the event loop.
+export async function capturePaneLinesAsync(paneId: string): Promise<string[]> {
+  const result = await tmuxAsync(['capture-pane', '-e', '-p', '-t', paneId]);
+  if (result.exitCode !== 0) return [];
+  return processCaptureOutput(result.stdout, SCRAPE_LINES);
 }
 
 // Control-mode variant of capturePaneLines: same SCRAPE_LINES window and

--- a/src/tmux/ipc.ts
+++ b/src/tmux/ipc.ts
@@ -26,6 +26,28 @@ export function tmux(args: string[]): TmuxResult {
   }
 }
 
+// Async twin of tmux() for the TUI's tick paths: same TmuxResult shape, but
+// the fork doesn't block the event loop. stderr is read because tmuxOrThrow
+// callers surface it as the error message.
+export async function tmuxAsync(args: string[]): Promise<TmuxResult> {
+  try {
+    const proc = Bun.spawn({
+      cmd: ['tmux', ...args],
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: process.env,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    return { exitCode, stdout, stderr };
+  } catch (err) {
+    return { exitCode: -1, stdout: '', stderr: err instanceof Error ? err.message : String(err) };
+  }
+}
+
 export function tmuxOrNull(args: string[]): string | null {
   const result = tmux(args);
   if (result.exitCode !== 0) return null;

--- a/src/tmux/ports.ts
+++ b/src/tmux/ports.ts
@@ -5,23 +5,19 @@ export interface PanePort {
   port: number;
 }
 
-// Map listening TCP ports to the tmux pane hosting the listener. `panePids`
-// (pane_pid -> paneId) and `ppidByPid` come from the caller's single
-// list-panes + ps pass, so this adds only the one `lsof` spawn.
-export function detectPorts(panePids: Map<number, string>, ppidByPid: Map<number, number>): PanePort[] {
-  if (panePids.size === 0) return [];
+const LSOF_ARGS = ['lsof', '-iTCP', '-sTCP:LISTEN', '-n', '-P', '-F', 'pn'];
 
-  const proc = Bun.spawnSync({
-    cmd: ['lsof', '-iTCP', '-sTCP:LISTEN', '-n', '-P', '-F', 'pn'],
-    stdout: 'pipe',
-    stderr: 'pipe',
-  });
-  if (proc.exitCode !== 0) return [];
-
+// Parse lsof -F pn output into pane-port pairs (pure; shared by the sync and
+// async detectPorts).
+function parseLsofPorts(
+  stdout: string,
+  panePids: Map<number, string>,
+  ppidByPid: Map<number, number>,
+): PanePort[] {
   const results: PanePort[] = [];
   let currentPid = -1;
 
-  for (const line of proc.stdout.toString().split('\n')) {
+  for (const line of stdout.split('\n')) {
     if (line.startsWith('p')) {
       currentPid = parseInt(line.slice(1), 10);
     } else if (line.startsWith('n') && currentPid > 0) {
@@ -39,4 +35,34 @@ export function detectPorts(panePids: Map<number, string>, ppidByPid: Map<number
   }
 
   return results;
+}
+
+// Map listening TCP ports to the tmux pane hosting the listener. `panePids`
+// (pane_pid -> paneId) and `ppidByPid` come from the caller's single
+// list-panes + ps pass, so this adds only the one `lsof` spawn.
+export function detectPorts(panePids: Map<number, string>, ppidByPid: Map<number, number>): PanePort[] {
+  if (panePids.size === 0) return [];
+
+  const proc = Bun.spawnSync({ cmd: LSOF_ARGS, stdout: 'pipe', stderr: 'pipe' });
+  if (proc.exitCode !== 0) return [];
+  return parseLsofPorts(proc.stdout.toString(), panePids, ppidByPid);
+}
+
+// Async twin for the TUI slow tick: same parse, non-blocking fork. stderr is
+// ignored — the sync path pipes but never reads it, and an unconsumed pipe can
+// stall an async child.
+export async function detectPortsAsync(
+  panePids: Map<number, string>,
+  ppidByPid: Map<number, number>,
+): Promise<PanePort[]> {
+  if (panePids.size === 0) return [];
+
+  try {
+    const proc = Bun.spawn({ cmd: LSOF_ARGS, stdout: 'pipe', stderr: 'ignore' });
+    const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+    if (exitCode !== 0) return [];
+    return parseLsofPorts(stdout, panePids, ppidByPid);
+  } catch {
+    return [];
+  }
 }

--- a/src/tmux/ports.ts
+++ b/src/tmux/ports.ts
@@ -9,11 +9,7 @@ const LSOF_ARGS = ['lsof', '-iTCP', '-sTCP:LISTEN', '-n', '-P', '-F', 'pn'];
 
 // Parse lsof -F pn output into pane-port pairs (pure; shared by the sync and
 // async detectPorts).
-function parseLsofPorts(
-  stdout: string,
-  panePids: Map<number, string>,
-  ppidByPid: Map<number, number>,
-): PanePort[] {
+function parseLsofPorts(stdout: string, panePids: Map<number, string>, ppidByPid: Map<number, number>): PanePort[] {
   const results: PanePort[] = [];
   let currentPid = -1;
 

--- a/src/tmux/sessions.ts
+++ b/src/tmux/sessions.ts
@@ -1,4 +1,4 @@
-import { tmux, tmuxOrNull, tmuxOrThrow } from './ipc.ts';
+import { tmux, tmuxAsync, tmuxOrNull, tmuxOrThrow } from './ipc.ts';
 
 export interface PaneInfo {
   paneId: string;
@@ -69,6 +69,13 @@ export function listPanesCommand(): string {
 
 export function listPanesResult(): ListPanesResult {
   const result = tmux(listPanesArgs());
+  if (result.exitCode !== 0) return { ok: false, panes: [] };
+  return { ok: true, panes: parsePanesOutput(result.stdout) };
+}
+
+// Async variant for the TUI tick paths — same parse, non-blocking fork.
+export async function listPanesResultAsync(): Promise<ListPanesResult> {
+  const result = await tmuxAsync(listPanesArgs());
   if (result.exitCode !== 0) return { ok: false, panes: [] };
   return { ok: true, panes: parsePanesOutput(result.stdout) };
 }


### PR DESCRIPTION
The slow tick ran its whole gather as serial spawnSync calls (N captures +
3 git per repo + ps + lsof), freezing input for seconds on a loaded box.

- refresh: refreshSlowCachesAsync gathers git/ps/captures concurrently
  with a bounded spawner (8), lsof after ps; both sync (CLI) and async
  (TUI) paths share the same applySlowCaches classification tail
- refresh: TUI fork fallbacks now use async list-panes instead of the
  blocking CLI path
- tmux/git/ports/discovery/scraper: async twins of the spawn helpers
  (tmuxAsync, readGitMetadataAsync, detectPortsAsync, readPsTableAsync,
  capturePaneLinesAsync, listPanesResultAsync)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>