### PR TITLE
feat: prefer agent session names over window names for row identity

### DIFF
--- a/hooks/codex/codex-hook.sh
+++ b/hooks/codex/codex-hook.sh
@@ -14,10 +14,26 @@ EVENT="${1:-}"
 export FLEET_STATUS_DIR="${FLEET_STATUS_DIR:-${HOME}/.cache/codex-status}"
 . "$(dirname "$0")/../lib.sh" # ../ -> hooks/lib.sh; sets FLEET_STATUS_FILE etc.
 
+# Codex names every thread (auto-generated after the first prompt, renameable
+# in the TUI) and records it in session_index.jsonl — the hook payload's
+# session_id joins against it. Empty when the thread isn't named yet; lib.sh
+# then preserves whatever name an earlier write stored.
+fleet_codex_thread_name() {
+  local sid index
+  sid=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null) || return 0
+  [ -n "$sid" ] || return 0
+  index="${CODEX_HOME:-$HOME/.codex}/session_index.jsonl"
+  [ -f "$index" ] || return 0
+  # Last match wins: codex appends a fresh entry on rename rather than editing
+  # in place.
+  jq -r --arg id "$sid" 'select(.id == $id) | .thread_name // empty' "$index" 2>/dev/null | tail -n 1
+}
+FLEET_NAME=$(fleet_codex_thread_name)
+
 case "$EVENT" in
   PreToolUse)
     TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || echo "")
-    fleet_write_status "working" "$TOOL"
+    fleet_write_status "working" "$TOOL" "$FLEET_NAME"
     fleet_append_event "PreToolUse" "tool" "\"$TOOL\""
     ;;
   Stop)
@@ -26,7 +42,7 @@ case "$EVENT" in
     TOOL=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || echo "")
     fleet_append_event "Stop" "stop_reason" "\"$STOP_REASON\"" "background_tasks" "$BG_TASKS"
     if [ "$STOP_REASON" = "tool_use" ] || [ "$BG_TASKS" = "true" ]; then
-      fleet_write_status "working" "$TOOL"
+      fleet_write_status "working" "$TOOL" "$FLEET_NAME"
     else
       # Debounced done: a new turn within 3s rewrites .status with a fresh ts, so
       # the ts-equality check cancels this stale done (same guard as stop.sh).
@@ -35,7 +51,7 @@ case "$EVENT" in
         if [ -f "$FLEET_STATUS_FILE" ]; then
           CURRENT_TS=$(jq -r '.ts // 0' "$FLEET_STATUS_FILE" 2>/dev/null)
           if [ "$CURRENT_TS" = "$FLEET_TS" ]; then
-            fleet_write_status "done" "$TOOL"
+            fleet_write_status "done" "$TOOL" "$FLEET_NAME"
             fleet_notify "done" "$FLEET_SESSION" "$FLEET_PANE_ID" "$TOOL" >/dev/null 2>&1
           fi
         fi

--- a/hooks/lib.sh
+++ b/hooks/lib.sh
@@ -29,13 +29,21 @@ fleet_sanitize_label() {
 # Write via a temp file + mv (atomic within a filesystem) so the TUI's reader
 # never catches a truncate-then-write window and sees partial JSON.
 fleet_write_status() {
-  local state="$1" tool tmp="${FLEET_STATUS_FILE}.tmp.$$"
+  local state="$1" tool name tmp="${FLEET_STATUS_FILE}.tmp.$$"
   tool=$(fleet_sanitize_label "${2:-}")
+  # Optional 3rd arg: the agent's own session name (codex thread_name, pi
+  # session name). A write that doesn't carry one keeps the previously written
+  # name — the name arrives on whichever write first resolves it and must not
+  # be erased by later nameless writes. No-jq path drops it (best-effort).
+  name=$(fleet_sanitize_label "${3:-}")
   if command -v jq >/dev/null 2>&1; then
+    if [ -z "$name" ] && [ -f "$FLEET_STATUS_FILE" ]; then
+      name=$(jq -r '.name // empty' "$FLEET_STATUS_FILE" 2>/dev/null)
+    fi
     jq -cn \
       --arg state "$state" --arg pane "$FLEET_PANE_ID" --arg session "$FLEET_SESSION" \
-      --arg tool "$tool" --argjson ts "$FLEET_TS" --argjson pid "${FLEET_TMUX_PID:-0}" \
-      '{state:$state, pane:$pane, session:$session, tool:$tool, ts:$ts, tmux_pid:$pid}' \
+      --arg tool "$tool" --arg name "$name" --argjson ts "$FLEET_TS" --argjson pid "${FLEET_TMUX_PID:-0}" \
+      '{state:$state, pane:$pane, session:$session, tool:$tool, name:$name, ts:$ts, tmux_pid:$pid}' \
       > "$tmp" && mv -f "$tmp" "$FLEET_STATUS_FILE"
   else
     # jq absent: label already stripped of control chars; also drop " and \.

--- a/hooks/pi/fleet-pi.test.ts
+++ b/hooks/pi/fleet-pi.test.ts
@@ -66,9 +66,15 @@ describe('buildPiStatusLine', () => {
       pane: '%3',
       session: 'projects',
       tool: 'Bash: npm test',
+      name: null, // unnamed write: '' on the wire, null after parsing
       ts: 1783136479,
       tmux_pid: 17136,
     });
+  });
+
+  test('carries the pi session name when one is set', () => {
+    const line = buildPiStatusLine('working', '%3', 'projects', '', 1783136479, 17136, 'Refactor auth module');
+    expect(parseStatusFile(line)?.name).toBe('Refactor auth module');
   });
 
   test('escapes quotes/newlines in the label so the file stays valid JSON', () => {
@@ -101,7 +107,7 @@ describe('extension event wiring', () => {
   });
 
   // Capture the handlers the extension registers so the test can fire them.
-  function loadWithTmux(pane: string): HandlerMap {
+  function loadWithTmux(pane: string, getSessionName?: () => string | undefined): HandlerMap {
     process.env.TMUX = '/tmp/fake-tmux,1,0';
     process.env.TMUX_PANE = pane;
     const handlers: HandlerMap = {};
@@ -109,6 +115,7 @@ describe('extension event wiring', () => {
       on(event: string, handler: (event?: JsonValue) => void): void {
         handlers[event] = handler;
       },
+      getSessionName,
       events: {
         on(event: string, handler: (event?: JsonValue) => void): void {
           handlers[event] = handler;
@@ -180,6 +187,42 @@ describe('extension event wiring', () => {
     expect(existsSync(join(statusDir, '7.status'))).toBe(true);
     h.session_shutdown?.();
     expect(existsSync(join(statusDir, '7.status'))).toBe(false);
+  });
+
+  test('session_start writes idle carrying the session name', () => {
+    const h = loadWithTmux('%13', () => 'Refactor auth module');
+    h.session_start?.();
+    const s = readStatus('13');
+    expect(s?.state).toBe('idle');
+    expect(s?.name).toBe('Refactor auth module');
+  });
+
+  test('writes the pi session name and refreshes it on session_info_changed', () => {
+    let name: string | undefined;
+    const h = loadWithTmux('%11', () => name);
+
+    // Unnamed at session start: the write carries no name rather than erasing one.
+    h.agent_start?.();
+    expect(readStatus('11')?.name).toBeNull();
+
+    // The auto-name (or a /name rename) lands between lifecycle writes; the
+    // session_info_changed handler rewrites the current state carrying it.
+    name = 'Refactor auth module';
+    h.session_info_changed?.({ name });
+    expect(readStatus('11')?.name).toBe('Refactor auth module');
+    expect(readStatus('11')?.state).toBe('working');
+
+    // A cleared name (undefined from getSessionName) round-trips to null. The
+    // handler re-reads pi.getSessionName() rather than trusting the payload.
+    name = undefined;
+    h.session_info_changed?.({});
+    expect(readStatus('11')?.name).toBeNull();
+  });
+
+  test('session_info_changed writes nothing before the first lifecycle write', () => {
+    const h = loadWithTmux('%12', () => 'Refactor auth module');
+    h.session_info_changed?.({ name: 'Refactor auth module' });
+    expect(existsSync(join(statusDir, '12.status'))).toBe(false);
   });
 
   test('outside tmux: registers no handlers and writes nothing', () => {

--- a/hooks/pi/fleet-pi.ts
+++ b/hooks/pi/fleet-pi.ts
@@ -8,6 +8,7 @@
  * file). It subscribes to pi's lifecycle events and writes the
  * same status-file schema fleet's shell hooks write (see hooks/lib.sh):
  *
+ *   session_start                  -> { state: "idle" }        (carries the session name on reload/resume)
  *   agent_start                    -> { state: "working" }
  *   tool_execution_start           -> { state: "working", tool: "Bash: …" | "Edit: …" }
  *   tool_call (question tool)      -> { state: "question" }
@@ -15,6 +16,7 @@
  *   rpiv:ask-user:blocked (active)  -> { state: "question" }
  *   rpiv:ask-user:blocked (cleared) -> { state: "working" }
  *   agent_end                      -> { state: "done" }      (fleet ages done -> idle)
+ *   session_info_changed           -> rewrite current state carrying pi's session name
  *   session_shutdown               -> remove the status file (pi exited; no stale state)
  *
  * pi auto-runs its tools, so it has no interactive permission prompt. Question
@@ -67,6 +69,10 @@ interface PiExtensionAPI {
   on(event: 'session_start' | 'agent_start' | 'agent_end' | 'session_shutdown', handler: () => void): void;
   on(event: 'tool_execution_start', handler: (event: PiToolExecutionStartEvent) => void): void;
   on(event: 'tool_call' | 'tool_execution_end', handler: (event: PiToolEvent) => void): void;
+  on(event: 'session_info_changed', handler: (event: { name?: string }) => void): void;
+  // pi names sessions (auto-named after the first turn, renameable via /name);
+  // optional so the extension still loads on a pi build that predates it.
+  getSessionName?(): string | undefined;
   events?: {
     on(event: 'rpiv:ask-user:blocked', handler: (payload: { active: boolean }) => void): void;
   };
@@ -105,7 +111,8 @@ export function fleetPiLabel(toolName: string, args: JsonValue | undefined): str
 
 // Serialize a fleet status record. JSON.stringify escapes quotes/newlines in the
 // label so a status file can never be corrupted by tool input. Field names and
-// shape mirror parseStatusFile in src/state/hooks.ts exactly.
+// shape mirror parseStatusFile in src/state/hooks.ts exactly. `name` is pi's own
+// session name ('' when unnamed) — fleet prefers it over the tmux window label.
 export function buildPiStatusLine(
   state: string,
   pane: string,
@@ -113,8 +120,9 @@ export function buildPiStatusLine(
   tool: string,
   ts: number,
   tmuxPid: number,
+  name = '',
 ): string {
-  return JSON.stringify({ state, pane, session, tool, ts, tmux_pid: tmuxPid }) + '\n';
+  return JSON.stringify({ state, pane, session, tool, name, ts, tmux_pid: tmuxPid }) + '\n';
 }
 
 // --- extension entry point ----------------------------------------------------
@@ -139,12 +147,22 @@ export default function (pi: PiExtensionAPI): void {
   let session = tmuxQuery('#{session_name}');
   let tmuxPid = Number(tmuxQuery('#{pid}')) || 0;
 
+  const sessionName = (): string => {
+    try {
+      return pi.getSessionName?.() ?? '';
+    } catch {
+      return '';
+    }
+  };
+
+  let lastState = '';
   const write = (state: string, tool: string): void => {
+    lastState = state;
     try {
       mkdirSync(statusDir, { recursive: true });
       writeFileSync(
         statusFile,
-        buildPiStatusLine(state, paneId, session, tool, Math.floor(Date.now() / 1000), tmuxPid),
+        buildPiStatusLine(state, paneId, session, tool, Math.floor(Date.now() / 1000), tmuxPid, sessionName()),
       );
     } catch {
       // Never break the user's pi session over a status write.
@@ -157,6 +175,12 @@ export default function (pi: PiExtensionAPI): void {
     // tmux env is fully populated by now; backfill anything missing at load.
     if (!session) session = tmuxQuery('#{session_name}');
     if (!tmuxPid) tmuxPid = Number(tmuxQuery('#{pid}')) || 0;
+    // Write on start/reload/resume: pi names sessions out-of-band (auto-namer,
+    // /name), and an idle session fires no later lifecycle event — without this
+    // the name would never reach the status file until the next turn. Discovery
+    // already surfaces a fresh pi pane as IDLE, so this changes the label, not
+    // the visibility.
+    write('idle', '');
   });
   pi.on('agent_start', () => write('working', currentTool));
   pi.on('tool_execution_start', (event) => {
@@ -178,8 +202,15 @@ export default function (pi: PiExtensionAPI): void {
     currentTool = '';
     write('done', '');
   });
+  // The auto-name lands after the first turn, between lifecycle writes —
+  // rewrite the current state so a rename/auto-name shows up immediately
+  // instead of whenever the next write happens.
+  pi.on('session_info_changed', () => {
+    if (lastState) write(lastState, currentTool);
+  });
   pi.on('session_shutdown', () => {
     // pi is exiting — drop the status file so the pane doesn't linger as done.
+    lastState = '';
     try {
       rmSync(statusFile, { force: true });
     } catch {

--- a/src/cli/schema.ts
+++ b/src/cli/schema.ts
@@ -40,7 +40,7 @@ export interface AgentView {
   windowLabel: string; // window-first display label
   session: string; // tmux session name
   sessionLabel: string; // session:window display label
-  label: string; // primary display name (rename > claude name > session)
+  label: string; // primary display name (rename > agent session name > claude name > session)
   agentType: string; // 'claude' | 'codex' | ... | '' for a shell pane
   tracking: 'hook' | 'discovery' | 'shell';
   status: AgentStatus; // fused final state

--- a/src/cli/status.test.ts
+++ b/src/cli/status.test.ts
@@ -217,13 +217,40 @@ describe('formatStatusLine', () => {
     expect(result).toContain(' #[fg=brightblack]│ ');
   });
 
-  test('uses the window name even when claudeName is set', () => {
+  test('prefers the agent session name over the window name', () => {
     const states = [
       makeState({ status: AgentStatus.PERMIT, session: 'dotfiles', window: 'editor', claudeName: 'Fix auth bug' }),
     ];
     const result = formatStatusLine(states);
-    expect(result).toContain('editor');
+    expect(result).toContain('Fix auth bug');
+    expect(result).not.toContain('editor');
+  });
+
+  test('hook-provided agentName wins over the pane-title claudeName', () => {
+    const states = [
+      makeState({
+        status: AgentStatus.PERMIT,
+        window: 'editor',
+        claudeName: 'Fix auth bug',
+        agentName: 'Refactor auth module',
+      }),
+    ];
+    const result = formatStatusLine(states);
+    expect(result).toContain('Refactor auth module');
     expect(result).not.toContain('Fix auth bug');
+  });
+
+  test('falls back to the window name when the agent publishes no name', () => {
+    const states = [makeState({ status: AgentStatus.PERMIT, session: 'dotfiles', window: 'editor' })];
+    expect(formatStatusLine(states)).toContain('editor');
+  });
+
+  test('caps long agent session names so the chip fits the status row', () => {
+    const long = 'x'.repeat(60);
+    const states = [makeState({ status: AgentStatus.PERMIT, agentName: long })];
+    const result = formatStatusLine(states);
+    expect(result).toContain(`${'x'.repeat(29)}…`);
+    expect(result).not.toContain(long);
   });
 
   test('appends a clickable clear-all chip when a ready agent is present', () => {

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -2,6 +2,7 @@ import {
   AgentStatus,
   ACK_ALL_RANGE,
   SIDEBAR_RANGE,
+  agentSessionName,
   compareStatus,
   formatAgeDelta,
   needsAttention,
@@ -51,9 +52,15 @@ export function formatStatusLine(states: AgentState[]): string {
 
   for (const s of filtered) {
     const display = STATUS_DISPLAY[s.status];
-    // tmux re-expands format directives in #() output, so a window/session
-    // name containing '#' must be escaped ('##') or it corrupts the row.
-    const label = windowLabel(s).replace(/#/g, '##');
+    // The agent's own session name identifies the chip when the agent
+    // publishes one — several agents can share a window, so the window label
+    // can't tell them apart. Capped because generated names run long, and
+    // chips share one status row. tmux re-expands format directives in #()
+    // output, so a name containing '#' must be escaped ('##') or it corrupts
+    // the row.
+    const name = agentSessionName(s) ?? windowLabel(s);
+    const clipped = [...name].length > 30 ? [...name].slice(0, 29).join('') + '…' : name;
+    const label = clipped.replace(/#/g, '##');
     entries.push(
       `#[range=user|${s.paneId}]#[fg=${display.color}]${display.icon} #[bold]${label}#[nobold] ${formatAge(s.ts)}#[norange]`,
     );

--- a/src/state/hooks.test.ts
+++ b/src/state/hooks.test.ts
@@ -15,6 +15,19 @@ describe('parseStatusFile', () => {
     expect(status!.pane).toBe('%42');
     expect(status!.session).toBe('dotfiles');
     expect(status!.tool).toBe('Edit');
+    // No `name` in the payload -> null (pre-name schema).
+    expect(status!.name).toBeNull();
+  });
+
+  test('parses the agent-provided session name; empty string reads as null', () => {
+    const named = parseStatusFile(
+      '{"state":"working","pane":"%42","session":"s","tool":"","name":"Refactor auth module","ts":1,"tmux_pid":1}',
+    );
+    expect(named!.name).toBe('Refactor auth module');
+    const unnamed = parseStatusFile(
+      '{"state":"working","pane":"%42","session":"s","tool":"","name":"","ts":1,"tmux_pid":1}',
+    );
+    expect(unnamed!.name).toBeNull();
   });
 
   test('returns null for invalid JSON', () => {

--- a/src/state/hooks.ts
+++ b/src/state/hooks.ts
@@ -1,7 +1,7 @@
 import { readdirSync, readFileSync, existsSync, statSync, watch, writeFileSync, renameSync } from 'node:fs';
 import { join } from 'node:path';
 import type { HookStatus, ResolvedHookStatus } from './types.ts';
-import { isJsonObject, type JsonValue } from '../json.ts';
+import { isJsonObject, isString, type JsonValue } from '../json.ts';
 import type { AgentDir } from '../agents/config.ts';
 
 // The `.status` / `.events.jsonl` filename convention, named once. Keyed by the
@@ -37,6 +37,10 @@ export function parseStatusFile(content: string): HookStatus | null {
       pane: String(data.pane ?? ''),
       session: String(data.session ?? ''),
       tool: String(data.tool ?? ''),
+      // The agent's own session name (codex thread_name, pi session name).
+      // Absent/empty in older or nameless writes — callers fall back to the
+      // window label.
+      name: isString(data.name) && data.name.length > 0 ? data.name : null,
       ts: Number(data.ts ?? 0),
       tmux_pid: Number(data.tmux_pid ?? 0),
     };

--- a/src/state/refresh.ts
+++ b/src/state/refresh.ts
@@ -24,6 +24,7 @@ import { loadRenames } from './rename.ts';
 import {
   AgentStatus,
   extractClaudeName,
+  extractPiTitleName,
   type AgentState,
   type ResolvedHookStatus,
   type StateDecision,
@@ -548,6 +549,11 @@ export function refreshStates(
       window: pane.windowName,
       windowId: pane.windowId,
       claudeName: extractClaudeName(pane.paneTitle),
+      // Hook name first (codex's only channel; pi's extension writes the same
+      // value), then pi's terminal title — which needs nothing loaded into pi
+      // and covers hookless/discovered pi panes too. Gated to identified pi
+      // panes: the title parse trusts non-empty titles (see extractPiTitleName).
+      agentName: hook?.name ?? (agentType === 'pi' ? extractPiTitleName(pane.paneTitle, pane.currentPath) : null),
       customName: renameCache.get(pane.sessionName) ?? null,
       status,
       tool,

--- a/src/state/types.test.ts
+++ b/src/state/types.test.ts
@@ -4,6 +4,8 @@ import {
   statusPriority,
   compareStatus,
   extractClaudeName,
+  extractPiTitleName,
+  agentSessionName,
   displayName,
   sessionDisplay,
   sessionLabel,
@@ -79,6 +81,47 @@ describe('extractClaudeName', () => {
   test('returns null for empty name after ✳', () => {
     expect(extractClaudeName('✳ ')).toBeNull();
     expect(extractClaudeName('✳')).toBeNull();
+  });
+
+  describe('extractPiTitleName', () => {
+    // Caller gates to identified pi panes; these shapes come from pi core
+    // (`π - name - dir`, unnamed `π - dir`) and the session-name package
+    // (unnamed `π — dir`, named titleFormat like `{summary}` or `{summary} — {dir}`).
+    test("reads the name from pi's built-in title format", () => {
+      expect(extractPiTitleName('π - Diagnose GitHub issue #73 - arc', '/Users/n/dev/arc')).toBe(
+        'Diagnose GitHub issue #73',
+      );
+    });
+
+    test('unnamed titles yield null in both dash styles', () => {
+      expect(extractPiTitleName('π - arc', '/Users/n/dev/arc')).toBeNull();
+      expect(extractPiTitleName('π — arc', '/Users/n/dev/arc')).toBeNull();
+      expect(extractPiTitleName('π', '/Users/n/dev/arc')).toBeNull();
+    });
+
+    test('splits on the cwd basename so names containing the separator survive', () => {
+      expect(extractPiTitleName('π - Fix - arc - arc', '/x/arc')).toBe('Fix - arc');
+    });
+
+    test('a name equal to the dir still parses', () => {
+      expect(extractPiTitleName('π - arc - arc', '/x/arc')).toBe('arc');
+    });
+
+    test("bare {summary} titles are trusted whole (pi-pane gating is the caller's job)", () => {
+      expect(extractPiTitleName('Thermo-nuclear code quality review', '/x/riker')).toBe(
+        'Thermo-nuclear code quality review',
+      );
+      // Non-pi-looking titles too — the caller only invokes this for pi panes.
+      expect(extractPiTitleName('✳ Fix auth bug', '/x/arc')).toBe('✳ Fix auth bug');
+    });
+
+    test('the {summary} — {dir} package format strips the dir suffix', () => {
+      expect(extractPiTitleName('Fix auth — arc', '/x/arc')).toBe('Fix auth');
+    });
+
+    test('a leading braille spinner frame is stripped', () => {
+      expect(extractPiTitleName('⠋ π - Fix auth - arc', '/x/arc')).toBe('Fix auth');
+    });
   });
 
   test('trims whitespace', () => {
@@ -159,6 +202,19 @@ describe('windowLabel', () => {
   });
 });
 
+describe('agentSessionName', () => {
+  test('prefers the hook-provided agent name over the pane-title name', () => {
+    expect(agentSessionName({ ...base, agentName: 'Refactor auth module', claudeName: 'Fix auth bug' })).toBe(
+      'Refactor auth module',
+    );
+  });
+
+  test('falls back to claudeName, then null', () => {
+    expect(agentSessionName({ ...base, claudeName: 'Fix auth bug' })).toBe('Fix auth bug');
+    expect(agentSessionName(base)).toBeNull();
+  });
+});
+
 describe('displayName', () => {
   test('returns claudeName when set', () => {
     expect(displayName({ ...base, claudeName: 'Fix auth bug' })).toBe('Fix auth bug');
@@ -174,6 +230,13 @@ describe('displayName', () => {
 
   test('claudeName is used when customName is null', () => {
     expect(displayName({ ...base, customName: null, claudeName: 'Fix auth bug' })).toBe('Fix auth bug');
+  });
+
+  test('agentName wins over claudeName and session, loses to customName', () => {
+    expect(displayName({ ...base, agentName: 'Refactor auth module', claudeName: 'Fix auth bug' })).toBe(
+      'Refactor auth module',
+    );
+    expect(displayName({ ...base, customName: 'prod hotfix', agentName: 'Refactor auth module' })).toBe('prod hotfix');
   });
 });
 

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -93,6 +93,13 @@ export interface AgentState {
   window: string;
   windowId: string;
   claudeName: string | null;
+  // The agent's own session name: the hook's status file (pi extension, codex
+  // thread_name) or, for pi, the built-in `π - name - dir` pane title when the
+  // hook wrote none — the title channel needs nothing loaded into pi. Distinct
+  // from claudeName, which is scraped from the pane title; null when neither
+  // channel provided one. Optional for source compatibility with AgentState
+  // fixtures (like `tracking`); live refreshes always set it.
+  agentName?: string | null;
   customName: string | null; // user rename for this pane's session, or null
   status: AgentStatus;
   tool: string | null;
@@ -126,6 +133,42 @@ export function extractClaudeName(paneTitle: string): string | null {
   const trimmed = paneTitle.trim();
   if (!trimmed.startsWith('✳')) return null;
   const name = trimmed.slice(1).trim();
+  return name.length > 0 ? name : null;
+}
+
+// pi exposes its session name in the terminal title with zero pi-side wiring
+// (pi core's updateTerminalTitle re-applies it on every rename; tmux captures
+// it as #{pane_title}). Shapes seen in the wild: stock `π - <name> - <dir>`
+// (unnamed: `π - <dir>`), and the common session-name package's `π — <dir>`
+// unnamed with a configurable named titleFormat (`{summary}`, `{summary} —
+// {dir}`, …). Only call this for panes already identified as pi — the named
+// fallback is deliberately trusting, treating whatever remains as the name;
+// an unidentified pane's title could be anything. The dir suffix is anchored
+// on the pane's cwd basename so a name containing ' - ' survives.
+export function extractPiTitleName(paneTitle: string, cwd: string): string | null {
+  // A leading braille frame is a working spinner some setups prepend — never
+  // part of the name.
+  const t = paneTitle.trim().replace(/^[\u2800-\u28FF] /, '');
+  if (!t) return null;
+  const dir = cwd.split('/').filter(Boolean).pop() ?? '';
+
+  // Unnamed shapes: app mark + dir, both dash styles. Not a name.
+  if (t === 'π' || t === `π - ${dir}` || t === `π — ${dir}`) return null;
+
+  let rest = t;
+  if (rest.startsWith('π - ')) rest = rest.slice(4);
+  else if (rest.startsWith('π — ')) rest = rest.slice(4);
+
+  // Stock appends ` - <dir>`; the package's default format appends ` — <dir>`.
+  if (dir) {
+    for (const suffix of [` - ${dir}`, ` — ${dir}`]) {
+      if (rest !== dir && rest.endsWith(suffix)) {
+        rest = rest.slice(0, rest.length - suffix.length);
+        break;
+      }
+    }
+  }
+  const name = rest.trim();
   return name.length > 0 ? name : null;
 }
 
@@ -166,9 +209,18 @@ export function windowLabel(state: AgentState): string {
   return state.window;
 }
 
-// Precedence for a row's primary label: user rename > Claude auto-name > session.
+// The agent's own name for its session: agent-published first (codex
+// thread_name via hook; pi session name via hook or its built-in pane title),
+// then Claude's pane-title auto-name. null when the agent has published none —
+// callers fall back to the window/session label.
+export function agentSessionName(state: AgentState): string | null {
+  return state.agentName ?? state.claudeName ?? null;
+}
+
+// Precedence for a row's primary label: user rename > agent session name
+// (hook) > Claude auto-name (pane title) > session.
 export function displayName(state: AgentState): string {
-  return state.customName ?? state.claudeName ?? sessionLabel(state);
+  return state.customName ?? agentSessionName(state) ?? sessionLabel(state);
 }
 
 // Session-level display string (rename wins over the raw session name). Used by
@@ -182,6 +234,10 @@ export interface HookStatus {
   pane: string;
   session: string;
   tool: string;
+  // Agent-provided session name (codex thread_name, pi session name); null
+  // when the writer had none. Added after the shape froze, so older status
+  // files parse to null — never absent on a parsed record.
+  name: string | null;
   ts: number;
   tmux_pid: number;
 }

--- a/src/tui/app.ts
+++ b/src/tui/app.ts
@@ -1,4 +1,4 @@
-import { AgentStatus, compareStatus, windowLabel, type AgentState } from '../state/types.ts';
+import { AgentStatus, agentSessionName, compareStatus, windowLabel, type AgentState } from '../state/types.ts';
 import { repoLabelFromId } from '../state/repo-groups.ts';
 
 // A rendered dashboard line: sessions with 2+ agents get a header row followed
@@ -219,7 +219,7 @@ export class TuiApp {
       (s) =>
         s.session.toLowerCase().includes(lower) ||
         s.window.toLowerCase().includes(lower) ||
-        (s.claudeName?.toLowerCase().includes(lower) ?? false) ||
+        (agentSessionName(s)?.toLowerCase().includes(lower) ?? false) ||
         (s.customName?.toLowerCase().includes(lower) ?? false) ||
         (s.project?.toLowerCase().includes(lower) ?? false),
     );

--- a/src/tui/kill.ts
+++ b/src/tui/kill.ts
@@ -1,5 +1,5 @@
 import { C } from '../terminal/colors.ts';
-import { AgentStatus, whereLabel, type AgentState } from '../state/types.ts';
+import { AgentStatus, agentSessionName, whereLabel, type AgentState } from '../state/types.ts';
 
 // Killing is destructive, so it gets the same state gating as send: refuse the
 // states where the agent is mid-thought or blocked on you. You can still reap
@@ -29,7 +29,8 @@ export function renderKillConfirm(state: AgentState): string[] {
   const lines: string[] = [];
   const check = canKillSession(state);
   const where = whereLabel(state);
-  const label = state.claudeName ? `${where} (${state.claudeName})` : where;
+  const agentName = agentSessionName(state);
+  const label = agentName ? `${where} (${agentName})` : where;
 
   lines.push(`${C.bold}Kill ${label}?${C.reset}`);
   lines.push('');

--- a/src/tui/layouts/cards.ts
+++ b/src/tui/layouts/cards.ts
@@ -2,7 +2,15 @@ import { C } from '../../terminal/colors.ts';
 import { truncateAnsi, truncateWidth, visibleLength } from '../../terminal/ansi.ts';
 import { STATUS_DISPLAY, type AgentState } from '../../state/types.ts';
 import type { TuiApp } from '../app.ts';
-import { agentRowLabel, formatAge, getAgeColor, getStateColor, stateIcon, type LayoutLines } from './shared.ts';
+import {
+  agentNameStyle,
+  agentRowLabel,
+  formatAge,
+  getAgeColor,
+  getStateColor,
+  stateIcon,
+  type LayoutLines,
+} from './shared.ts';
 
 // Sidebar cards: every agent is a fixed 4-line block —
 //   ▌⚠ name            4s
@@ -38,7 +46,7 @@ export function buildCardLines(app: TuiApp, cols: number): LayoutLines {
     const gap = ' '.repeat(Math.max(1, nameW - visibleLength(name) + 1));
     lines.push(
       truncateAnsi(
-        `${bar} ${stateIcon(st.status, app.pulsePhase)} ${selected ? C.bold : hovered ? C.underline : ''}${name}${C.reset}${gap}${getAgeColor(st.ts)}${age}${C.reset}`,
+        `${bar} ${stateIcon(st.status, app.pulsePhase)} ${agentNameStyle(st)}${hovered ? C.underline : ''}${name}${C.reset}${gap}${getAgeColor(st.ts)}${age}${C.reset}`,
         cols,
       ),
     );
@@ -48,7 +56,9 @@ export function buildCardLines(app: TuiApp, cols: number): LayoutLines {
     lines.push(truncateAnsi(`${bar}   ${C.gray}${truncateWidth(meta, Math.max(1, cols - 4))}${C.reset}`, cols));
     states.push(st);
 
-    const detail = st.tool ?? st.claudeName ?? display.label;
+    // The agent's session name is already the card's line-1 title (via
+    // agentRowLabel), so detail falls from tool straight to the state label.
+    const detail = st.tool ?? display.label;
     lines.push(truncateAnsi(`${bar}   ${C.dim}${truncateWidth(detail, Math.max(1, cols - 4))}${C.reset}`, cols));
     states.push(st);
 

--- a/src/tui/layouts/shared.test.ts
+++ b/src/tui/layouts/shared.test.ts
@@ -1,7 +1,28 @@
 import { describe, expect, test } from 'bun:test';
-import { stateIcon, windowLines, type LayoutLines } from './shared.ts';
+import { agentRowLabel, stateIcon, windowLines, type LayoutLines } from './shared.ts';
 import { CARD_LAYOUT_MAX_COLS, pickLayout } from './index.ts';
-import { AgentStatus } from '../../state/types.ts';
+import { AgentStatus, type AgentState } from '../../state/types.ts';
+
+const agentState = (over: Partial<AgentState>): AgentState => ({
+  paneId: '%1',
+  paneNum: 1,
+  session: 'api',
+  window: 'editor',
+  windowId: '@1',
+  claudeName: null,
+  customName: null,
+  status: AgentStatus.IDLE,
+  tool: null,
+  project: '~/Developer/api',
+  branch: 'main',
+  ports: [],
+  ts: 0,
+  agentType: 'claude',
+  ...over,
+});
+
+const agentRow = (over: Partial<AgentState>, grouped = false) =>
+  ({ kind: 'agent', state: agentState(over), grouped }) as const;
 
 const fake = (n: number): LayoutLines => ({
   lines: Array.from({ length: n }, (_, i) => `line${i}`),
@@ -24,6 +45,26 @@ describe('stateIcon', () => {
   test('non-busy states ignore the pulse phase entirely', () => {
     expect(stateIcon(AgentStatus.PERMIT, true)).toBe(stateIcon(AgentStatus.PERMIT, false));
     expect(stateIcon(AgentStatus.IDLE, true)).toBe(stateIcon(AgentStatus.IDLE, false));
+  });
+});
+
+describe('agentRowLabel', () => {
+  test('names the row after the agent session when one is published', () => {
+    expect(agentRowLabel(agentRow({ agentName: 'Refactor auth module' }))).toBe('api · Refactor auth module');
+    expect(agentRowLabel(agentRow({ claudeName: 'Fix auth bug' }))).toBe('api · Fix auth bug');
+    // The hook-provided name outranks the pane-title name.
+    expect(agentRowLabel(agentRow({ agentName: 'Refactor auth module', claudeName: 'Fix auth bug' }))).toBe(
+      'api · Refactor auth module',
+    );
+  });
+
+  test('falls back to the window label when the agent publishes no name', () => {
+    expect(agentRowLabel(agentRow({}))).toBe('api · editor');
+  });
+
+  test('grouped rows drop the session prefix', () => {
+    expect(agentRowLabel(agentRow({ agentName: 'Refactor auth module' }, true))).toBe('Refactor auth module');
+    expect(agentRowLabel(agentRow({}, true))).toBe('editor');
   });
 });
 

--- a/src/tui/layouts/shared.ts
+++ b/src/tui/layouts/shared.ts
@@ -1,8 +1,10 @@
-import { C } from '../../terminal/colors.ts';
+import { C, serializeThemeColor, stateThemeColor } from '../../terminal/colors.ts';
 import {
   AgentStatus,
   STATUS_DISPLAY,
+  agentSessionName,
   formatAgeDelta,
+  needsAttention,
   sessionDisplay,
   windowLabel,
   type AgentState,
@@ -22,16 +24,30 @@ export interface LayoutLines {
   states: (AgentState | null)[];
 }
 
-// Row label shared by both layouts. Grouped rows sit under a session header,
-// so repeating the session per row is noise — the window label alone names
-// them. Ungrouped rows carry the session inline. Window-presence logic keys on
-// the real session (windowLabel compares against it); only the shown string
-// swaps to the rename via sessionDisplay.
+// Row label shared by both layouts. The agent's own session name (pi session
+// name, codex thread name, claude pane-title name) names the row when one is
+// available — several agents can share a window, so the window label can't
+// tell them apart; the window label is the fallback. Grouped rows sit under a
+// session header, so repeating the session per row is noise. Ungrouped rows
+// carry the session inline. Window-presence logic keys on the real session
+// (windowLabel compares against it); only the shown string swaps to the
+// rename via sessionDisplay.
 export function agentRowLabel(row: Extract<DashboardRow, { kind: 'agent' }>): string {
-  const label = windowLabel(row.state);
+  const label = agentSessionName(row.state) ?? windowLabel(row.state);
   if (row.grouped) return label;
   const session = sessionDisplay(row.state);
   return label === row.state.session ? session : `${session} · ${label}`;
+}
+
+// Style prefix for the row's primary label: bold + a dedicated accent hue (the
+// 'question' mauve doubles as the identity lane), switching to the row's state
+// color when the row needs you (permit/question/done) so attention rows light
+// up. Serializers return '' when colors are disabled, degrading to plain text.
+export function agentNameStyle(state: AgentState): string {
+  const fg = needsAttention(state.status)
+    ? getStateColor(state.status)
+    : serializeThemeColor(stateThemeColor('question'));
+  return `${C.bold}${fg}`;
 }
 
 export function getStateColor(status: AgentStatus): string {

--- a/src/tui/layouts/table.ts
+++ b/src/tui/layouts/table.ts
@@ -2,7 +2,15 @@ import { C } from '../../terminal/colors.ts';
 import { padAnsi, truncateAnsi, truncateWidth, visibleLength } from '../../terminal/ansi.ts';
 import { STATUS_DISPLAY, type AgentState } from '../../state/types.ts';
 import type { DashboardRow, TuiApp } from '../app.ts';
-import { agentRowLabel, formatAge, getAgeColor, getStateColor, stateIcon, type LayoutLines } from './shared.ts';
+import {
+  agentNameStyle,
+  agentRowLabel,
+  formatAge,
+  getAgeColor,
+  getStateColor,
+  stateIcon,
+  type LayoutLines,
+} from './shared.ts';
 
 export interface ColumnWidths {
   name: number;
@@ -57,15 +65,15 @@ function formatAgentRow(
 
   const sel = selected ? `${stColor}▌${C.reset}` : ' ';
 
-  const nameColor = selected ? C.bold : hovered ? C.underline : '';
+  // The session name is the row's identity — bold + accent hue, switching to
+  // the state color when the row needs you (agentNameStyle). Selection shows
+  // on the ▌ bar; hover adds the underline.
+  const nameColor = `${agentNameStyle(state)}${hovered ? C.underline : ''}`;
   const name = padAnsi(truncateWidth(nameCell(row), widths.name), widths.name);
 
-  let detail = '';
-  if (state.claudeName) {
-    detail = state.claudeName;
-  } else {
-    detail = (state.project ?? '').replace(/^~\/Developer\//, '');
-  }
+  // The agent's session name moved up to the name cell (agentRowLabel), so
+  // the detail column stays on the project path full-time.
+  const detail = (state.project ?? '').replace(/^~\/Developer\//, '');
 
   const branch = state.branch ?? '';
   const branchColor = branch && branch !== 'main' && branch !== 'master' ? C.purple : C.gray;
@@ -77,8 +85,7 @@ function formatAgentRow(
 
   const portStr = state.ports.length > 0 ? ` ${C.cyan}⌁${state.ports[0]}${C.reset}` : '';
 
-  const detailColor = state.claudeName ? C.dim : C.gray;
-  const line = `${sel} ${stateIcon(state.status, pulse)} ${nameColor}${name}${C.reset}${detailColor}${padAnsi(truncateWidth(detail, widths.detail), widths.detail)}${C.reset}${branchPart} ${ageColor}${age.padEnd(4)}${C.reset}${portStr}`;
+  const line = `${sel} ${stateIcon(state.status, pulse)} ${nameColor}${name}${C.reset}${C.gray}${padAnsi(truncateWidth(detail, widths.detail), widths.detail)}${C.reset}${branchPart} ${ageColor}${age.padEnd(4)}${C.reset}${portStr}`;
 
   return truncateAnsi(line, cols);
 }

--- a/src/tui/preview.ts
+++ b/src/tui/preview.ts
@@ -1,6 +1,6 @@
 import { C } from '../terminal/colors.ts';
 import { truncateAnsi } from '../terminal/ansi.ts';
-import { AgentStatus, STATUS_DISPLAY, whereLabel, type AgentState } from '../state/types.ts';
+import { AgentStatus, STATUS_DISPLAY, agentSessionName, whereLabel, type AgentState } from '../state/types.ts';
 import { capturePane } from '../tmux/sessions.ts';
 import { chip } from './layouts/shared.ts';
 
@@ -53,8 +53,9 @@ export function renderPreview(
   const display = STATUS_DISPLAY[state.status];
 
   const modeTag = passthrough ? ` ${C.cyan}● LIVE${C.reset}` : '';
-  const claudeInfo = state.claudeName ? ` · ${state.claudeName}` : '';
-  const title = `${display.icon} ${whereLabel(state)} · ${display.label.toUpperCase()}${claudeInfo}${modeTag}`;
+  const agentName = agentSessionName(state);
+  const nameInfo = agentName ? ` · ${agentName}` : '';
+  const title = `${display.icon} ${whereLabel(state)} · ${display.label.toUpperCase()}${nameInfo}${modeTag}`;
   const toolInfo = state.tool ? ` · ${state.tool}` : '';
   const portInfo = state.ports.length > 0 ? ` · ⌁${state.ports.join(',')}` : '';
   lines.push(truncateAnsi(`${C.bold}${title}${C.reset}${C.gray}${toolInfo}${portInfo}${C.reset}`, width));


### PR DESCRIPTION
## Why

Several agents often share one tmux window (multiple panes), and every row showed the same window name — the one label that can't tell them apart. Agents already know their own session names; fleet now uses them.

## What changes

The status file schema gains an optional `name` field, and every label surface uses the same precedence: **user rename → agent session name → claude pane-title name → window/session fallback** (identical to today when no name exists).

Per-agent name channels:

- **pi** — two channels, either suffices: the fleet-pi extension writes `pi.getSessionName()` into the status file (including on `session_start`, so reload/resume surfaces the name immediately, and rewriting on `session_info_changed`), and read-side extraction from pi's built-in terminal title (`π - <name> - <dir>`, plus the common session-name package's `{summary}` / `{summary} — {dir}` formats). The title channel needs **nothing loaded into pi** and works retroactively for already-running sessions.
- **codex** — the hook joins the payload's `session_id` against `~/.codex/session_index.jsonl`'s `thread_name`. `lib.sh` preserves a previously written name across nameless writes so a transient lookup miss can't erase it.
- **claude** — unchanged: the existing `✳` pane-title extraction.
- **opencode** — no hook integration exists, so no name channel; falls back as before.

Surfaces: TUI table + cards name cell, tmux statusline chips (capped at 30 chars — generated names run long), kill confirm, preview header, `/` search, `fleet list` / `status --json` labels.

Bonus: the session name is now visually pronounced — **bold + accent hue** (the palette's `question` entry, so it tracks themes), switching to the row's **state color when it needs you** (permit/question/done). Selection stays on the ▌ bar, hover underlines, `NO_COLOR` degrades to plain text.

## Testing

- 934 unit + 33 e2e tests pass; typecheck/lint/format clean.
- Verified live: codex hook against the real `session_index.jsonl` (name written + preserved); a scratch pi session (`session_start` write, `/name` propagation, `status --json` label); title extraction across all running pi sessions with zero extension changes; name styling rendered in both layouts via detached tmux captures.
