### PR TITLE
feat: color statusline chip labels by agent state

### DIFF
--- a/src/cli/status.test.ts
+++ b/src/cli/status.test.ts
@@ -161,7 +161,7 @@ describe('formatStatusLine', () => {
     expect(permitIdx).toBeLessThan(questionIdx);
   });
 
-  test('formats each entry with icon, bold window name, and age', () => {
+  test('formats each entry with icon, state-colored bold name, and age', () => {
     const now = Math.floor(Date.now() / 1000);
     const states = [
       makeState({ status: AgentStatus.PERMIT, session: 'mysession', window: 'task-window', ts: now - 10 }),
@@ -170,18 +170,31 @@ describe('formatStatusLine', () => {
     // Icon for PERMIT is ⚠ in the terminal's yellow (theme-aware named color)
     expect(result).toContain('#[fg=yellow]');
     expect(result).toContain('⚠');
-    expect(result).toContain('#[bold]task-window#[nobold]');
+    // The label wears the same state color — every chip is an attention state.
+    expect(result).toContain('#[fg=yellow,bold]task-window#[nobold,fg=default]');
     expect(result).toContain('10s');
+  });
+
+  test('label color tracks the state: permit yellow, question magenta, done green', () => {
+    const states = [
+      makeState({ status: AgentStatus.PERMIT, window: 'perm-win', paneId: '%1' }),
+      makeState({ status: AgentStatus.QUESTION, window: 'ques-win', paneId: '%2' }),
+      makeState({ status: AgentStatus.DONE, window: 'done-win', paneId: '%3' }),
+    ];
+    const result = formatStatusLine(states);
+    expect(result).toContain('#[fg=yellow,bold]perm-win');
+    expect(result).toContain('#[fg=magenta,bold]ques-win');
+    expect(result).toContain('#[fg=green,bold]done-win');
   });
 
   test('falls back to the session name when the window is empty', () => {
     const states = [makeState({ status: AgentStatus.PERMIT, session: 'dotfiles', window: '' })];
-    expect(formatStatusLine(states)).toContain('#[bold]dotfiles#[nobold]');
+    expect(formatStatusLine(states)).toContain('#[fg=yellow,bold]dotfiles#[nobold,fg=default]');
   });
 
   test('falls back to the session name when the window equals the session', () => {
     const states = [makeState({ status: AgentStatus.PERMIT, session: 'dotfiles', window: 'dotfiles' })];
-    expect(formatStatusLine(states)).toContain('#[bold]dotfiles#[nobold]');
+    expect(formatStatusLine(states)).toContain('#[fg=yellow,bold]dotfiles#[nobold,fg=default]');
   });
 
   test('two same-session agents in different windows render distinguishable chips', () => {
@@ -190,8 +203,8 @@ describe('formatStatusLine', () => {
       makeState({ status: AgentStatus.DONE, session: 'cli', window: 'beta', paneId: '%2' }),
     ];
     const result = formatStatusLine(states);
-    expect(result).toContain('#[bold]alpha#[nobold]');
-    expect(result).toContain('#[bold]beta#[nobold]');
+    expect(result).toContain('#[fg=green,bold]alpha#[nobold,fg=default]');
+    expect(result).toContain('#[fg=green,bold]beta#[nobold,fg=default]');
   });
 
   test('wraps each entry in a clickable range with the pane id', () => {

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -61,8 +61,13 @@ export function formatStatusLine(states: AgentState[]): string {
     const name = agentSessionName(s) ?? windowLabel(s);
     const clipped = [...name].length > 30 ? [...name].slice(0, 29).join('') + '…' : name;
     const label = clipped.replace(/#/g, '##');
+    // The label wears the state color, same as the icon: every chip here is an
+    // attention state by design (quiet agents are filtered out above), so the
+    // TUI's neutral name accent never applies on this surface. Named tmux
+    // colors keep the terminal-palette adaptability the statusline chose over
+    // theme hexes (see STATUS_DISPLAY).
     entries.push(
-      `#[range=user|${s.paneId}]#[fg=${display.color}]${display.icon} #[bold]${label}#[nobold] ${formatAge(s.ts)}#[norange]`,
+      `#[range=user|${s.paneId}]#[fg=${display.color}]${display.icon} #[fg=${display.color},bold]${label}#[nobold,fg=default] ${formatAge(s.ts)}#[norange]`,
     );
   }
 


### PR DESCRIPTION
## Why

Follow-up to #78: the dashboard row names got bold + accent/state coloring, but the tmux statusline chips still rendered plain bold labels.

## What changes

Each chip's label now wears the chip's state color (permit yellow, question magenta, ready green), bold as before — the whole chip glows in its state color. The TUI's neutral mauve name accent deliberately does NOT appear here: the statusline filters to attention states only, so a neutral treatment would never show.

Still named tmux colors (not theme hexes), honoring this surface's existing choice to resolve against the terminal's own palette so it stays readable on any theme.

## Testing

- Unit tests updated + a new per-state color test (permit/question/done).
- Verified live with a fabricated status file against a real pane: chip renders `#[fg=green,bold]<name>#[nobold,fg=default]`.
