### PR TITLE
feat: show project dirname in card meta line

### DIFF
--- a/src/tui/layouts/cards.ts
+++ b/src/tui/layouts/cards.ts
@@ -52,7 +52,8 @@ export function buildCardLines(app: TuiApp, cols: number): LayoutLines {
     );
     states.push(st);
 
-    const meta = [st.branch, st.agentType].filter(Boolean).join(' · ');
+    const project = st.project?.split('/').pop();
+    const meta = [project, st.branch, st.agentType].filter(Boolean).join(' · ');
     lines.push(truncateAnsi(`${bar}   ${C.gray}${truncateWidth(meta, Math.max(1, cols - 4))}${C.reset}`, cols));
     states.push(st);
 


### PR DESCRIPTION
The sidebar card meta line now leads with the project directory basename:

`fleet · main · pi` instead of `main · pi`

Makes it possible to tell apart agents with the same branch/agent type running in different projects.